### PR TITLE
Use existing connection in X.H.DynamicBars

### DIFF
--- a/XMonad/Hooks/DynamicBars.hs
+++ b/XMonad/Hooks/DynamicBars.hs
@@ -77,10 +77,9 @@ type DynamicStatusBarCleanup = IO ()
 
 dynStatusBarStartup :: DynamicStatusBar -> DynamicStatusBarCleanup -> X ()
 dynStatusBarStartup sb cleanup = do
-  liftIO $ do
-      dpy <- openDisplay ""
-      xrrSelectInput dpy (defaultRootWindow dpy) rrScreenChangeNotifyMask
-      closeDisplay dpy
+  dpy <- asks display
+  root <- asks theRoot
+  io $ xrrSelectInput dpy root rrScreenChangeNotifyMask
   updateStatusBars sb cleanup
 
 dynStatusBarEventHook :: DynamicStatusBar -> DynamicStatusBarCleanup -> Event -> X All


### PR DESCRIPTION
This is just the patch from https://code.google.com/p/xmonad/issues/detail?id=538, updated so it applies to the latest version of the file.

This fixes that issue for me using both the minimal `xmonad.hs` from the bug report and using my real configuration.