### PR TITLE
X.H.DynamicLog: make xmobarStrip actually strip xmobar tags

### DIFF
--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -398,7 +398,11 @@ xmobarColor fg bg = wrap t "</fc>"
 -- | Strip xmobar markup, specifically the <fc>, <icon> and <action> tags and
 -- the matching tags like </fc>.
 xmobarStrip :: String -> String
-xmobarStrip = xmobarStripTags ["fc","icon","action"] where
+xmobarStrip = converge (xmobarStripTags ["fc","icon","action"]) where
+
+converge :: (Eq a) => (a -> a) -> a -> a
+converge f a = let xs = iterate f a
+    in fst $ head $ dropWhile (uncurry (/=)) $ zip xs $ tail xs
 
 xmobarStripTags :: [String] -- ^ tags
         -> String -> String -- ^ with all <tag>...</tag> removed


### PR DESCRIPTION
This is a port of a personal patch I've been meaning to contribute. I haven't tried to compile it outside of my xmonad.hs but it should work.

Consider the old implementation:
> \> xmobarStrip "\<\<fc=#f00>fc=#f00>foo\</\</fc>fc>"
"\<fc=#f00>foo\</fc>"

While the result should be "foo", nothing more.

I don't know dzen markup but dzenStrip might suffer from the same problem.