### PR TITLE
Adjust debugWindow to the addition of wa_colormap.

### DIFF
--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -41,7 +41,7 @@ debugWindow w =  do
   case w' of
     Nothing                                   ->
       return $ "(deleted window " ++ wx ++ ")"
-    Just (WindowAttributes x y wid ht bw cm m o) -> do
+    Just (WindowAttributes x y wid ht bw cm mi m o) -> do
       c' <- withDisplay $ \d ->
             io (getWindowProperty8 d wM_CLASS w)
       let c = case c' of

--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -41,7 +41,7 @@ debugWindow w =  do
   case w' of
     Nothing                                   ->
       return $ "(deleted window " ++ wx ++ ")"
-    Just (WindowAttributes x y wid ht bw m o) -> do
+    Just (WindowAttributes x y wid ht bw cm m o) -> do
       c' <- withDisplay $ \d ->
             io (getWindowProperty8 d wM_CLASS w)
       let c = case c' of


### PR DESCRIPTION
After adding wa_colormap to getWindowAttributes in Graphics.X11.Xlib.Extras
in https://github.com/asjo/X11/commit/29c8035648d5b17c09730193ae6aa002c3fc8f5c
this change is needed in xmonad-contrib.