### PR TITLE
Add multiple key support for completion key

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -66,6 +66,7 @@ Rickard Gustafsson <acura@allyourbase.se>
 Robert Marlow <bobstopper@bobturf.org>
 Robert Marlow <bobstopper@bobturf.org> <robreim@bobturf.org>
 Rohan Jain <crodjer@gmail.com>
+Sibi Prabakaran <sibi@psibi.in> <psibi2000@gmail.com>
 Sean Escriva <sean.escriva@gmail.com>
 Sean McEligot <seanmce33@gmail.com>
 Spencer Janssen <spencerjanssen@gmail.com> <sjanssen@cse.unl.edu>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log / Release Notes
 
+## 0.13
+
+### Breaking Changes
+
+  * The type of `completionKey` (of `XPConfig` record) has been
+    changed from `KeySym` to `(KeyMask, KeySym)`. The default value
+    for this is still binded to `Tab` key.
+
 ## 0.12 (December 14, 2015)
 
 ### Breaking Changes


### PR DESCRIPTION
This patch enables support for key binding like Ctrl + i which was not
previously possible. Technically, this changes the type of completionKey
from KeySym to (KeyMask, KeySym). Note that programs like dmenu support
Ctrl + i by default.