### PR TITLE
X.P.Window: add window selector for the prompt and BringToMaster action

### DIFF
--- a/XMonad/Prompt/Window.hs
+++ b/XMonad/Prompt/Window.hs
@@ -18,10 +18,16 @@ module XMonad.Prompt.Window
     (
     -- * Usage
     -- $usage
+    WindowPrompt(..),
+    windowPrompt,
+    allWindows,
+    wsWindows,
+    XWindowMap,
+
+    -- * Deprecated
     windowPromptGoto,
     windowPromptBring,
     windowPromptBringCopy,
-    WindowPrompt,
     ) where
 
 import qualified Data.Map as M
@@ -31,11 +37,13 @@ import XMonad
 import XMonad.Prompt
 import XMonad.Actions.CopyWindow
 import XMonad.Actions.WindowBringer
+import XMonad.Util.NamedWindows
 
 -- $usage
--- WindowPrompt brings windows to you and you to windows.
--- That is to say, it pops up a prompt with window names, in case you forgot
--- where you left your XChat.
+-- WindowPrompt brings windows to you and you to windows. That is to
+-- say, it pops up a prompt with window names, in case you forgot
+-- where you left your XChat. It also offers helpers to build the
+-- subset of windows which is used for the prompt completion.
 --
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
 --
@@ -44,13 +52,14 @@ import XMonad.Actions.WindowBringer
 --
 -- and in the keys definition:
 --
--- > , ((modm .|. shiftMask, xK_g     ), windowPromptGoto  def)
--- > , ((modm .|. shiftMask, xK_b     ), windowPromptBring def)
+-- > , ((modm .|. shiftMask, xK_g     ), windowPrompt def Goto wsWindows)
+-- > , ((modm .|. shiftMask, xK_b     ), windowPrompt def Bring allWindows)
 --
 -- The autoComplete option is a handy complement here:
 --
--- > , ((modm .|. shiftMask, xK_g     ), windowPromptGoto
--- >                                            def { autoComplete = Just 500000 } )
+-- > , ((modm .|. shiftMask, xK_g     ), windowPrompt
+-- >                                        def { autoComplete = Just 500000 }
+-- >                                        Goto allWindows)
 --
 -- The \'500000\' is the number of microseconds to pause before sending you to
 -- your new window. This is useful so that you don't accidentally send some
@@ -59,27 +68,49 @@ import XMonad.Actions.WindowBringer
 -- For detailed instruction on editing the key binding see
 -- "XMonad.Doc.Extending#Editing_key_bindings".
 
-data WindowPrompt = Goto | Bring | BringCopy
+-- Describe actions that can applied  on the selected window
+data WindowPrompt = Goto | Bring | BringCopy | BringToMaster
 instance XPrompt WindowPrompt where
     showXPrompt Goto      = "Go to window: "
     showXPrompt Bring     = "Bring window: "
+    showXPrompt BringToMaster
+                          = "Bring window to master: "
     showXPrompt BringCopy = "Bring a copy: "
     commandToComplete _ c = c
     nextCompletion      _ = getNextCompletion
 
+-- | Deprecated. Use windowPrompt instead.
 windowPromptGoto, windowPromptBring, windowPromptBringCopy :: XPConfig -> X ()
-windowPromptGoto  = doPrompt Goto
-windowPromptBring = doPrompt Bring
-windowPromptBringCopy = doPrompt BringCopy
+windowPromptGoto c = windowPrompt c Goto windowMap
+windowPromptBring c = windowPrompt c Bring windowMap
+windowPromptBringCopy c = windowPrompt c BringCopy windowMap
 
--- | Pops open a prompt with window titles. Choose one, and you will be
--- taken to the corresponding workspace.
-doPrompt :: WindowPrompt -> XPConfig -> X ()
-doPrompt t c = do
+-- | A helper to get the map of all windows.
+allWindows :: XWindowMap
+allWindows = windowMap
+
+-- | A helper to get the map of windows of the current workspace.
+wsWindows :: XWindowMap
+wsWindows = withWindowSet (return . W.index) >>= windowMap
+    where
+      windowMap = fmap M.fromList . mapM pair
+      pair w = do name <- fmap show $ getName w
+                  return (name, w)
+
+-- | A Map where keys are pretty printable window names and values are
+-- Xmonad windows identifier.
+type XWindowMap = X (M.Map String Window)
+
+-- | Pops open a prompt with window titles belonging to
+-- windowMap. Choose one, and an action is applied on the
+-- selected window, according to WindowPrompt.
+windowPrompt :: XPConfig -> WindowPrompt -> XWindowMap -> X ()
+windowPrompt c t windowMap = do
   a <- case t of
          Goto  -> fmap gotoAction  windowMap
          Bring -> fmap bringAction windowMap
          BringCopy -> fmap bringCopyAction windowMap
+         BringToMaster -> fmap bringToMaster windowMap
   wm <- windowMap
   mkXPrompt t c (compList wm) a
 
@@ -88,9 +119,9 @@ doPrompt t c = do
       gotoAction       = winAction W.focusWindow
       bringAction      = winAction bringWindow
       bringCopyAction  = winAction bringCopyWindow
+      bringToMaster    = winAction (\w s -> W.shiftMaster . W.focusWindow w $ bringWindow w s)
 
       compList m s = return . filter (searchPredicate c s) . map fst . M.toList $ m
-
 
 -- | Brings a copy of the specified window into the current workspace.
 bringCopyWindow :: Window -> WindowSet -> WindowSet


### PR DESCRIPTION
- The set of windows proposed by the prompt can be parametrized. Two
  helper functions are currently defined. One for selecting all
  available windows and another one for selecting all windows of the
  current workspace.

- Add BringToMaster action which brings the selected window to the
  current workspace and set it as master.

- windowPromptGoto, windowPromptBring, windowPromptBringCopy are
  marked as deprecated since they can be realized by the more generic
  windowPrompt function.  For instance, "windowPromptGoto prompt" can
  be easily replaced by "windowPrompt prompt Goto allWindows".