### PR TITLE
Fixed bottom-yielding definition of toggleGroupFull

### DIFF
--- a/XMonad/Layout/Groups/Wmii.hs
+++ b/XMonad/Layout/Groups/Wmii.hs
@@ -114,7 +114,7 @@ zoomGroupReset = zoomColumnReset
 -- | Toggle whether the currently focused group should be maximized
 -- whenever it has focus.
 toggleGroupFull :: X ()
-toggleGroupFull = toggleGroupFull
+toggleGroupFull = toggleColumnFull
 
 -- | Rotate the layouts in the focused group.
 groupToNextLayout :: X ()


### PR DESCRIPTION
The current value of `toggleGroupFull` is ⊥, since it's defined as `toggleGroupFull = toggleGroupFull`.

Presumably, this is a typo for `toggleColumnFull` from `XMonad.Layout.Groups.Examples`.