### PR TITLE
Fix minor things

### DIFF
--- a/XMonad/Util/EZConfig.hs
+++ b/XMonad/Util/EZConfig.hs
@@ -80,7 +80,7 @@ import Text.ParserCombinators.ReadP
 -- Note that, unlike in xmonad 0.4 and previous, you can't use modMask to refer
 -- to the modMask you configured earlier. You must specify mod1Mask (or
 -- whichever), or add your own @myModMask = mod1Mask@ line.
-additionalKeys :: XConfig a -> [((ButtonMask, KeySym), X ())] -> XConfig a
+additionalKeys :: XConfig a -> [((KeyMask, KeySym), X ())] -> XConfig a
 additionalKeys conf keyList =
     conf { keys = \cnf -> M.union (M.fromList keyList) (keys conf cnf) }
 
@@ -103,7 +103,7 @@ additionalKeysP conf keyList =
 --
 -- > main = xmonad $ def { terminal = "urxvt" }
 -- >                 `removeKeys` [(mod1Mask .|. shiftMask, n) | n <- [xK_1 .. xK_9]]
-removeKeys :: XConfig a -> [(ButtonMask, KeySym)] -> XConfig a
+removeKeys :: XConfig a -> [(KeyMask, KeySym)] -> XConfig a
 removeKeys conf keyList =
     conf { keys = \cnf -> keys conf cnf `M.difference` M.fromList (zip keyList $ repeat ()) }
 

--- a/XMonad/Util/Run.hs
+++ b/XMonad/Util/Run.hs
@@ -94,7 +94,7 @@ runProcessWithInputAndWait cmd args input timeout = io $ do
 --
 -- to the top of your file) or use seconds in prefix form:
 --
--- > 5.5 seconds
+-- > seconds 5.5
 seconds :: Rational -> Int
 seconds = fromEnum . (* 1000000)
 


### PR DESCRIPTION
* Fix a minor error in the documentation of the function `seconds`
* Fix type declaration for two EZConfig functions used to configure keybindings. I think they should take a `KeyMask` instead of a `ButtonMask` (both are synonym for `Modifier` which is a `CUInt`).