### PR TITLE
Add `XMonad.Actions.KeyChord`

### DIFF
--- a/XMonad/Actions/KeyChord.hs
+++ b/XMonad/Actions/KeyChord.hs
@@ -1,0 +1,85 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Actions.KeyChord
+-- Copyright   :  (c) Pedro Rodriguez Tavarez <pedro@pjrt.co>
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  Pedro Rodriguez Tavarez <pedro@pjrt.co>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- A module that allows the user to create keychords similar to vi using
+-- 'submap' from "XMonad.Actions.Submap".
+--
+-- What 'keychords' does can be manually (and painfully) replicated using plain
+-- 'submap'. This module aims to make the process simpler.
+--
+-------------------------------------------------------------------------------
+module XMonad.Actions.KeyChord
+( -- Usage
+  -- $usage
+  keychords
+) where
+
+import Data.PathTree (fromPaths, LCRSTree(Empty, Leaf, Node))
+import XMonad
+import XMonad.Actions.Submap (submap)
+import Data.Map (fromList)
+
+-------------------------------------------------------------------------------
+
+{- $usage
+  In your `~/.xmonad/xmonad.hs`, import this module
+
+  @import XMonad.Actions.KeyChord@
+
+  This allows you to do the following:
+
+  @
+  , ((modm, xK_semicolon), keychords
+      [ ([(0, xK_i), (0, xK_k)], action1)
+      , ([(0, xK_i), (0, xK_w)], action2)
+      , ([(0, xK_j), (0, xK_j)], action3)
+      , ([(0, xK_s), (0, xK_a), (shiftMask, xK_t)], action4)
+      ])
+  @
+
+  Now, to run @action1@, press /modm-; i k/.
+
+  Restrictions:
+
+  * If two chords conflict (ie: are the same), the last one will be the active
+    one
+  * If a chord is a subset of another (eg: k -> t -> y and k -> t), the shorter
+    one will be picked
+
+-}
+
+-- | Given a list of tuples of key strokes and an action, collect all the
+-- keystrokes and map them to the action using 'submap' from
+-- "XMonad.Actions.Submap".
+keychords :: [([(KeyMask, KeySym)], X ())] -> X ()
+keychords kCombos =
+  let trees = fromPaths $ tupLast <$> kCombos
+  in sm . buildChord $ fmap toEither trees
+  where
+    tupLast :: ([n], a) -> [NEither n a]
+    tupLast (ps, a) =
+      map (NEither . Left) (init ps) ++ [NEither $ Right (last ps, a)]
+
+    buildChord Empty = []
+    buildChord (Leaf (Right (n, a)) s) = (n, a) : buildChord s
+    buildChord (Node (Left n) c s) = (n, sm $ buildChord c) : buildChord s
+    buildChord Leaf {} = error "buildChord: incorrectly built tree. A leaf with a Left"
+    buildChord Node {} = error "buildChord: incorrectly built tree. A node with a Right"
+
+    sm = submap . fromList
+
+-- | A version of Either where only 'n' has to match in order to count as
+-- "equal". Used in 'keychords' to produce the chord paths using the @LCRSTree@.
+newtype NEither n a = NEither { toEither :: Either n (n, a) }
+
+instance Eq n => Eq (NEither n a) where
+  (NEither (Left n1)) == (NEither (Left n2)) = n1 == n2
+  (NEither (Right (n1, _))) == (NEither (Right (n2, _))) = n1 == n2
+  _ == _ = False

--- a/XMonad/Actions/KeyChord.hs
+++ b/XMonad/Actions/KeyChord.hs
@@ -60,7 +60,7 @@ import Data.Map (fromList)
 -- "XMonad.Actions.Submap".
 keychords :: [([(KeyMask, KeySym)], X ())] -> X ()
 keychords kCombos =
-  let trees = fromPaths $ tupLast <$> kCombos
+  let trees = fromPaths $ map tupLast kCombos
   in sm . buildChord $ fmap toEither trees
   where
     tupLast :: ([n], a) -> [NEither n a]

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -68,7 +68,7 @@ library
                    X11>=1.6.1 && < 1.7,
                    xmonad>=0.12   && < 0.13,
                    utf8-string,
-                   PathTree
+                   PathTree>=0.1.1
 
     if flag(use_xft)
         build-depends: X11-xft >= 0.2

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -67,7 +67,8 @@ library
                    unix,
                    X11>=1.6.1 && < 1.7,
                    xmonad>=0.12   && < 0.13,
-                   utf8-string
+                   utf8-string,
+                   PathTree
 
     if flag(use_xft)
         build-depends: X11-xft >= 0.2
@@ -122,6 +123,7 @@ library
                         XMonad.Actions.Plane
                         XMonad.Actions.Promote
                         XMonad.Actions.RandomBackground
+                        XMonad.Actions.KeyChord
                         XMonad.Actions.KeyRemap
                         XMonad.Actions.RotSlaves
                         XMonad.Actions.Search


### PR DESCRIPTION
`KeyChord` is a module to building keychords using `submap` from`XMonad.Actions.Submap`. However, this module exports a simplerinterface for creating long keychords. Here, a "keychord" is a series of keystrokes, similar to what you would get in vi/vim.

Addd a new dependency: `PathTree` https://hackage.haskell.org/package/PathTree

`PathTree` is also created and maintained by me.