### PR TITLE
A very simple extension to Navigation2D so it plays better with gaps

### DIFF
--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -318,7 +318,6 @@ lineNavigation = N 1 doLineNavigation
 centerNavigation :: Navigation2D
 centerNavigation = N 2 doCenterNavigation
 
-
 -- | Hybrid navigation. This attempts Line navigation, then falls back on Center
 -- navigation if it does not find any suitable target windows. This is useful since
 -- Line navigation tends to fail on gaps, but provides more intuitive motions

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -674,7 +674,7 @@ doScreenNavigation conf dir act cur wsrects
 -- these lists for all visible workspaces.)
 doLineNavigation :: Eq a => Direction2D -> Rect a -> [Rect a] -> Maybe a
 doLineNavigation dir (cur, rect) winrects
-  | null winrects' = Nothing -- doCenterNavigation dir (cur, rect) winrects
+  | null winrects' = Nothing
   | otherwise      = Just . fst $ L.foldl1' closer winrects'
   where
     -- The current window's center

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -664,7 +664,7 @@ doScreenNavigation conf dir act cur wsrects
 -- these lists for all visible workspaces.)
 doLineNavigation :: Eq a => Direction2D -> Rect a -> [Rect a] -> Maybe a
 doLineNavigation dir (cur, rect) winrects
-  | null winrects' = Nothing
+  | null winrects' = doCenterNavigation dir (cur, rect) winrects -- MY MODIFICATION HERE
   | otherwise      = Just . fst $ L.foldl1' closer winrects'
   where
     -- The current window's center

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -771,9 +771,11 @@ doCenterNavigation dir (cur, rect) winrects
 -- | Implements Hybrid navigation. This attempts Line navigation first,
 -- then falls back on Center navigation if it finds no suitable target window.
 doHybridNavigation :: Eq a => Direction2D -> Rect a -> [Rect a] -> Maybe a
-doHybridNavigation dir (cur, rect) winrects
-  | (doLineNavigation dir (cur, rect) winrects == Nothing) = doCenterNavigation dir (cur, rect) winrects
-  | otherwise = doLineNavigation dir (cur, rect) winrects
+doHybridNavigation = applyToBoth pickSomething doLineNavigation doCenterNavigation
+    where
+        applyToBoth f g h a b c = f (g a b c) (h a b c)
+        pickSomething Nothing b = b
+        pickSomething a _ = a
 
 -- | Swaps the current window with the window given as argument
 swap :: Window -> WindowSet -> WindowSet

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -322,7 +322,7 @@ centerNavigation = N 2 doCenterNavigation
 -- | Hybrid navigation. This attempts Line navigation, then falls back on Center
 -- navigation if it does not find any suitable target windows. This is useful since
 -- Line navigation tends to fail on gaps, but provides more intuitive motions
--- when it succeeds, provided there are no floating windows.
+-- when it succeeds—provided there are no floating windows.
 hybridNavigation :: Navigation2D
 hybridNavigation = N 2 doHybridNavigation
 

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -770,11 +770,9 @@ doCenterNavigation dir (cur, rect) winrects
 -- | Implements Hybrid navigation. This attempts Line navigation first,
 -- then falls back on Center navigation if it finds no suitable target window.
 doHybridNavigation :: Eq a => Direction2D -> Rect a -> [Rect a] -> Maybe a
-doHybridNavigation = applyToBoth pickSomething doLineNavigation doCenterNavigation
+doHybridNavigation = applyToBoth (<|>) doLineNavigation doCenterNavigation
     where
         applyToBoth f g h a b c = f (g a b c) (h a b c)
-        pickSomething Nothing b = b
-        pickSomething a _ = a
 
 -- | Swaps the current window with the window given as argument
 swap :: Window -> WindowSet -> WindowSet


### PR DESCRIPTION
The documentation in the diffs pretty much covers it, but to summarise, I simply combined the two navigation methods that were already implemented into a 'best of both worlds' version. Line navigation fails to produce the expected motions when the line it's using falls on gaps, so in these cases you want to fall back on the more robust Center navigation, and that's exactly what Hybrid navigation does.

This is my first contribution to xmonad and also my first pull request, so please do provide constructive criticism if I've done something stupid or failed to follow some style guideline.

Edit: An example of a layout where gaps break Line navigation, in case it wasn't clear what the problem was. The layout below is achieved with SplitGrid tiling mode.
![2016-08-27-041550_1920x1080_scrot](https://cloud.githubusercontent.com/assets/17093042/18012344/291426fe-6c0d-11e6-99cb-fa40fde3392c.png)

Here, if focus is on one of the six windows in the bottom right, then line navigation can take you left, but you won't be able to go right afterwards. Similarly, you can go up, but not back down. If Center navigation is used, then you can move down and left as needed, but you cannot go up from all four windows that are directly below the top window, you can only do so from the two most central windows.

With Hybrid navigation all these motions are possible, with priority to the more intuitive motions derived from Line navigation.

My ![xmonad config file](https://github.com/LSLeary/config-slash/blob/master/xmonad.hs) is available here on github if it's of use or relevance.

Further edit: It may be worth noting that the Navigation2D type has a 'generality' parameter, which in this case I chose somewhat arbitrarily to be 2, the same as centerNavigation. On further thought, maybe it should be 3, since it will sometimes move when Center navigation won't. That said, I can't see anywhere the parameter is actually used, except for in making Navigation2D an instance of the Eq and Ord typeclasses.

Further further edit:
The only piece of meaningful code introduced is the function below.

```haskell
doHybridNavigation dir (cur, rect) winrects
  | (doLineNavigation dir (cur, rect) winrects == Nothing) = doCenterNavigation dir (cur, rect) winrects
  | otherwise = doLineNavigation dir (cur, rect) winrects
```

At the time it was just written to work, and the thought of making it a bit cleaner has only occurred to me just now. Rewriting it, I find the following vastly more aesthetically pleasing. It's untested since I'm currently on the wrong machine, but I'll test it and push the commit ~~within a day or two~~. **Done.**

```haskell
doHybridNavigation = applyToBoth pickSomething doLineNavigation doCenterNavigation
    where
        applyToBoth f g h a b c = f (g a b c) (h a b c)
        pickSomething Nothing b = b
        pickSomething a _ = a
```