### PR TITLE
Determine which groups to Hide correctly

### DIFF
--- a/XMonad/Layout/Groups.hs
+++ b/XMonad/Layout/Groups.hs
@@ -274,7 +274,7 @@ instance (LayoutClass l Window, LayoutClass l2 (Group l Window))
                results <- forM areas $ \(g, r') -> runLayout ws { W.layout = gLayout g
                                                                 , W.stack = gZipper g } r'
 
-               let hidden = map gLayout (W.integrate $ groups l) \\ map (gLayout . fst) areas
+               let hidden = map gLayout (W.integrate $ groups _l) \\ map (gLayout . fst) areas
                hidden' <- mapM (flip handleMessage $ SomeMessage Hide) hidden
 
                let placements = concatMap fst results


### PR DESCRIPTION
This is a fix I have applied locally to make sure that when I use decorated layouts like tabbed in groups, XMonad does not leave bogus decoration windows lying around.

I think that the issue fixed is that the set of groups to send `Hide` to is determined by subtracting the extant groups from `l`, but `l` has already been put through `readapt` and so some groups may have been removed (if they are empty), so they don't get the Hide message.

The comparison should therefore be between `_l` and the new groups.

It seems to work for me.