### PR TITLE
Export XMonad.Actions.Workscreen (WorkscreenId)

### DIFF
--- a/XMonad/Actions/Workscreen.hs
+++ b/XMonad/Actions/Workscreen.hs
@@ -31,6 +31,7 @@ module XMonad.Actions.Workscreen (
   ,shiftToWorkscreen
   ,fromWorkspace
   ,expandWorkspace
+  ,WorkscreenId
   ) where
 
 import XMonad hiding (workspaces)


### PR DESCRIPTION
This is fixing for problem that
WorkscreenId was shown in XMonad.Actions.Workscreen document
(ex: viewWorkscreen),
but never shown WorkscreenId definition.

Is this the intension ?