### PR TITLE
X.A.WorkspaceNames: Export WorkspaceNames type

### DIFF
--- a/XMonad/Actions/WorkspaceNames.hs
+++ b/XMonad/Actions/WorkspaceNames.hs
@@ -21,6 +21,7 @@ module XMonad.Actions.WorkspaceNames (
     -- * Usage
     -- $usage
 
+    WorkspaceNames(..),
     -- * Workspace naming
     renameWorkspace,
     workspaceNamesPP,


### PR DESCRIPTION
The getWorkspaceNames names that is exported by this module adds the tag with a colon as a prefix.

With WorkspaceNames type itself users can access the actual names that are assigned to each workspace.