### PR TITLE
X.H.EwmhDesktops: Add remap argument to the custom log hook

### DIFF
--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -68,12 +68,12 @@ ewmhDesktopsStartup = setSupported
 -- Notifies pagers and window lists, such as those in the gnome-panel
 -- of the current state of workspaces and windows.
 ewmhDesktopsLogHook :: X ()
-ewmhDesktopsLogHook = ewmhDesktopsLogHookCustom id
+ewmhDesktopsLogHook = ewmhDesktopsLogHookCustom id id
 -- |
 -- Generalized version of ewmhDesktopsLogHook that allows an arbitrary
 -- user-specified function to transform the workspace list (post-sorting)
-ewmhDesktopsLogHookCustom :: ([WindowSpace] -> [WindowSpace]) -> X ()
-ewmhDesktopsLogHookCustom f = withWindowSet $ \s -> do
+ewmhDesktopsLogHookCustom :: ([WindowSpace] -> [WindowSpace]) -> (String -> String) -> X ()
+ewmhDesktopsLogHookCustom f workspaceNamesRemap = withWindowSet $ \s -> do
     sort' <- getSortByIndex
     let ws = f $ sort' $ W.workspaces s
 
@@ -81,7 +81,7 @@ ewmhDesktopsLogHookCustom f = withWindowSet $ \s -> do
     setNumberOfDesktops (length ws)
 
     -- Names thereof
-    setDesktopNames (map W.tag ws)
+    setDesktopNames $ map (workspaceNamesRemap . W.tag) ws
 
     -- all windows, with focused windows last
     let wins =  nub . concatMap (maybe [] (\(W.Stack x l r)-> reverse l ++ r ++ [x]) . W.stack) $ ws


### PR DESCRIPTION
One might wonder why the additional argument to `ewmhDesktopsLogHookCustom` that
is added in this pull request is necessary -- it seems that the existing
argument, that allows arbitrary transformations of the workspaces should be
enough to rename the existing workspaces with something like the following:

``` haskell
ewmhWorkspaceNamesLogHook = do
  WorkspaceNames namesMap <- XS.get
  ewmhDesktopsLogHookCustom $ map (addWorkspaceNamesToTag namesMap)

addWorkspaceNamesToTag namesMap ws@W.Workspace { W.tag = currentTag } =
   let currentName = M.findWithDefault "" (W.tag ws) namesMap in
        ws { W.tag = printf "%s: %s" currentTag currentName }
```

(If you wish to reproduce this error, you may wish to use a simpler function to
change the workspace tag; one that simply appends some character to the end of
the workspace name would do.)

The issue is that when this transformation is applied, the ewmh hooks do not
properly set the current active workspace. The reason for this is that the way
that the way that the current workspace is determined uses the current window
set which has the untransformed versions of the current workspaces
([relevant line is here](https://github.com/xmonad/xmonad-contrib/blob/ae7fd21e29766cda99ca2bece6f25fb8b4e029b2/XMonad/Hooks/EwmhDesktops.hs#L91)).

I suspect that there is a more elegant way to handle this issue (perhaps by
using a version of the s (the WindowSet) that has the remapped WindowSpaces? Any
way, I just wanted to put this out there to see what other peoples thoughts
about this are.
