### PR TITLE
X.A.WindowGo: Add arg for custom focus fn to raiseNextMaybe

### DIFF
--- a/XMonad/Actions/WindowGo.hs
+++ b/XMonad/Actions/WindowGo.hs
@@ -138,9 +138,7 @@ raiseNext = raiseNextMaybe $ return ()
      'raiseNextMaybe' is an alternative version that allows cycling
      through the matching windows. If the focused window matches the
      query the next matching window is raised. If no matches are found
-     the function f is executed.
--}
-
+     the function f is executed. -}
 raiseNextMaybe :: X () -> Query Bool -> X ()
 raiseNextMaybe = raiseNextMaybeCustomFocus W.focusWindow
 
@@ -175,7 +173,8 @@ raiseAndDo :: X () -> Query Bool -> (Window -> X ()) -> X ()
 raiseAndDo f qry after = ifWindow qry (afterRaise `mappend` raiseHook) f
     where afterRaise = ask >>= (>> idHook) . liftX . after
 
-{- | If a window matching the second argument is found, the window is focused and the third argument is called;
+{- | If a window matching the second argument is found, the window is focused and
+     the third argument is called;
      otherwise, the first argument is called. -}
 runOrRaiseAndDo :: String -> Query Bool -> (Window -> X ()) -> X ()
 runOrRaiseAndDo = raiseAndDo . safeSpawnProg
@@ -190,7 +189,6 @@ raiseMaster raisef thatUserQuery = raiseAndDo raisef thatUserQuery (\_ -> window
 {- |  If the window is found the window is focused and set to master
       otherwise, action is run.
 
-      > runOrRaiseMaster "firefox" (className =? "Firefox"))
-  -}
+      > runOrRaiseMaster "firefox" (className =? "Firefox")) -}
 runOrRaiseMaster :: String -> Query Bool -> X ()
 runOrRaiseMaster run query = runOrRaiseAndDo run query (\_ -> windows W.swapMaster)

--- a/XMonad/Actions/WindowGo.hs
+++ b/XMonad/Actions/WindowGo.hs
@@ -144,6 +144,10 @@ raiseNext = raiseNextMaybe $ return ()
 raiseNextMaybe :: X () -> Query Bool -> X ()
 raiseNextMaybe = raiseNextMaybeCustomFocus W.focusWindow
 
+{- | See 'raiseMaybe' and 'raiseNextMaybe'.
+     In addition to all of the options offered by 'raiseNextMaybe'
+     'raiseNextMaybeCustomFocus' allows the user to supply the function that
+     should be used to shift the focus to any window that is found. -}
 raiseNextMaybeCustomFocus :: (Window -> WindowSet -> WindowSet) -> X() -> Query Bool -> X()
 raiseNextMaybeCustomFocus focusFn f qry = flip (ifWindows qry) f $ \ws -> do
   foc <- withWindowSet $ return . W.peek

--- a/XMonad/Actions/WindowGo.hs
+++ b/XMonad/Actions/WindowGo.hs
@@ -144,7 +144,7 @@ raiseNext = raiseNextMaybe $ return ()
 raiseNextMaybe :: X () -> Query Bool -> X ()
 raiseNextMaybe = raiseNextMaybeCustomFocus W.focusWindow
 
-raiseNextMaybeCustomFocus :: (Window -> (WindowSet -> WindowSet)) -> X() -> Query Bool -> X()
+raiseNextMaybeCustomFocus :: (Window -> WindowSet -> WindowSet) -> X() -> Query Bool -> X()
 raiseNextMaybeCustomFocus focusFn f qry = flip (ifWindows qry) f $ \ws -> do
   foc <- withWindowSet $ return . W.peek
   case foc of


### PR DESCRIPTION
Motivation: I prefer to use a greedier focus function that switches the workspace on the current screen to the focused window.

``` haskell
greedyFocusWindow w ws = W.focusWindow w $ W.greedyView
                         (fromMaybe (W.currentTag ws) $ W.findTag w ws) ws
```

This pull request exposes a version of raiseNextMaybe to which a custom focus function, such as the one that I prefer, can be provided.
