### PR TITLE
X.H.EwmhDesktops: optionally advertise fullscreen support in _NET_SUPPORTED

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,42 @@
 # Change Log / Release Notes
 
+## unknown
+
+### Breaking Changes
+
+### New Modules
+
+  * `XMonad.Layout.TallMastersCombo`
+
+    A layout combinator that support Shrink, Expand, and IncMasterN just as
+    the 'Tall' layout, and also support operations of two master windows:
+    a main master, which is the original master window;
+    a sub master, the first window of the second pane.
+    This combinator can be nested, and has a good support for using
+    'XMonad.Layout.Tabbed' as a sublayout.
+
+  * `XMonad.Actions.PerWindowKeys`
+
+    Create actions that run on a `Query Bool`, usually associated with
+    conditions on a window, basis. Useful for creating bindings that are
+    excluded or exclusive for some windows.
+
+### Bug Fixes and Minor Changes
+
+  * `XMonad.Prompt.Window`
+
+    Added 'allApplications' function which maps application executable
+    names to it's underlying window.
+
+  * `XMonad.Prompt.WindowBringer`
+
+    Added 'windowApMap' function which maps application executable
+    names to it's underlying window.
+
+  * `XMonad.Actions.Search`
+
+    The `hoogle` function now uses the new URL `hoogle.haskell.org`.
+
 ## 0.16
 
 ### Breaking Changes
@@ -24,14 +61,6 @@
 
 ### New Modules
 
-  * `XMonad.Layout.TallMastersCombo`
-    A layout combinator that support Shrink, Expand, and IncMasterN just as
-    the 'Tall' layout, and also support operations of two master windows:
-    a main master, which is the original master window;
-    a sub master, the first window of the second pane.
-    This combinator can be nested, and has a good support for using
-    'XMonad.Layout.Tabbed' as a sublayout.
-
   * `XMonad.Layout.TwoPanePersistent`
 
     A layout that is like TwoPane but keeps track of the slave window that is
@@ -46,12 +75,6 @@
     idea of named scratchpads such that you can define "families of scratchpads"
     that are exclusive on the same screen. It also allows to remove this
     constraint of being mutually exclusive with another scratchpad.
-
-  * `XMonad.Actions.PerWindowKeys`
-
-    Create actions that run on a `Query Bool`, usually associated with
-    conditions on a window, basis. Useful for creating bindings that are
-    excluded or exclusive for some windows.
 
 ### Bug Fixes and Minor Changes
 
@@ -84,16 +107,6 @@
 
     Made password prompts traverse symlinks when gathering password names for
     autocomplete.
-
-* `XMonad.Prompt.Window`
-
-    Added 'allApplications' function which maps application executable
-    names to it's underlying window.
-
-* `XMonad.Prompt.WindowBringer`
-
-    Added 'windowApMap' function which maps application executable
-    names to it's underlying window.
 
   * `XMonad.Actions.DynamicProjects`
 
@@ -136,10 +149,6 @@
   * `XMonad.Prompt.FuzzyMatch`
 
     Make fuzzy sort show shorter strings first.
-
-  * `XMonad.Actions.Search`
-
-    The `hoogle` function now uses the new URL `hoogle.haskell.org`.
 
 ## 0.15
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@
 
 ### Breaking Changes
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    It is no longer recommended to use `fullscreenEventHook` directly.
+    Instead, use `ewmhFullscreen` which additionally advertises fullscreen
+    support in `_NET_SUPPORTED` and fixes fullscreening of applications that
+    explicitly check it, e.g. mupdf-gl, sxiv, …
+
 ### New Modules
 
   * `XMonad.Layout.TallMastersCombo`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
     support in `_NET_SUPPORTED` and fixes fullscreening of applications that
     explicitly check it, e.g. mupdf-gl, sxiv, …
 
+    `XMonad.Layout.Fullscreen.fullscreenSupport` now advertises it as well,
+    and no configuration changes are required in this case.
+
 ### New Modules
 
   * `XMonad.Layout.TallMastersCombo`

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -231,8 +231,7 @@ fullscreenEventHook (ClientMessageEvent _ _ _ dpy win typ (action:dats)) = do
       remove = 0
       add = 1
       toggle = 2
-      ptype = 4 -- The atom property type for changeProperty
-      chWstate f = io $ changeProperty32 dpy win wmstate ptype propModeReplace (f wstate)
+      chWstate f = io $ changeProperty32 dpy win wmstate aTOM propModeReplace (f wstate)
 
   when (typ == wmstate && fi fullsc `elem` dats) $ do
     when (action == add || (action == toggle && not isFull)) $ do
@@ -249,16 +248,14 @@ fullscreenEventHook _ = return $ All True
 setNumberOfDesktops :: (Integral a) => a -> X ()
 setNumberOfDesktops n = withDisplay $ \dpy -> do
     a <- getAtom "_NET_NUMBER_OF_DESKTOPS"
-    c <- getAtom "CARDINAL"
     r <- asks theRoot
-    io $ changeProperty32 dpy r a c propModeReplace [fromIntegral n]
+    io $ changeProperty32 dpy r a cARDINAL propModeReplace [fromIntegral n]
 
 setCurrentDesktop :: (Integral a) => a -> X ()
 setCurrentDesktop i = withDisplay $ \dpy -> do
     a <- getAtom "_NET_CURRENT_DESKTOP"
-    c <- getAtom "CARDINAL"
     r <- asks theRoot
-    io $ changeProperty32 dpy r a c propModeReplace [fromIntegral i]
+    io $ changeProperty32 dpy r a cARDINAL propModeReplace [fromIntegral i]
 
 setDesktopNames :: [String] -> X ()
 setDesktopNames names = withDisplay $ \dpy -> do
@@ -273,23 +270,20 @@ setClientList :: [Window] -> X ()
 setClientList wins = withDisplay $ \dpy -> do
     -- (What order do we really need? Something about age and stacking)
     r <- asks theRoot
-    c <- getAtom "WINDOW"
     a <- getAtom "_NET_CLIENT_LIST"
-    io $ changeProperty32 dpy r a c propModeReplace (fmap fromIntegral wins)
+    io $ changeProperty32 dpy r a wINDOW propModeReplace (fmap fromIntegral wins)
     a' <- getAtom "_NET_CLIENT_LIST_STACKING"
-    io $ changeProperty32 dpy r a' c propModeReplace (fmap fromIntegral wins)
+    io $ changeProperty32 dpy r a' wINDOW propModeReplace (fmap fromIntegral wins)
 
 setWindowDesktop :: (Integral a) => Window -> a -> X ()
 setWindowDesktop win i = withDisplay $ \dpy -> do
     a <- getAtom "_NET_WM_DESKTOP"
-    c <- getAtom "CARDINAL"
-    io $ changeProperty32 dpy win a c propModeReplace [fromIntegral i]
+    io $ changeProperty32 dpy win a cARDINAL propModeReplace [fromIntegral i]
 
 setSupported :: X ()
 setSupported = withDisplay $ \dpy -> do
     r <- asks theRoot
     a <- getAtom "_NET_SUPPORTED"
-    c <- getAtom "ATOM"
     supp <- mapM getAtom ["_NET_WM_STATE_HIDDEN"
                          ,"_NET_NUMBER_OF_DESKTOPS"
                          ,"_NET_CLIENT_LIST"
@@ -300,7 +294,7 @@ setSupported = withDisplay $ \dpy -> do
                          ,"_NET_WM_DESKTOP"
                          ,"_NET_WM_STRUT"
                          ]
-    io $ changeProperty32 dpy r a c propModeReplace (fmap fromIntegral supp)
+    io $ changeProperty32 dpy r a aTOM propModeReplace (fmap fromIntegral supp)
 
     setWMName "xmonad"
 
@@ -308,5 +302,4 @@ setActiveWindow :: Window -> X ()
 setActiveWindow w = withDisplay $ \dpy -> do
     r <- asks theRoot
     a <- getAtom "_NET_ACTIVE_WINDOW"
-    c <- getAtom "WINDOW"
-    io $ changeProperty32 dpy r a c propModeReplace [fromIntegral w]
+    io $ changeProperty32 dpy r a wINDOW propModeReplace [fromIntegral w]

--- a/XMonad/Hooks/FadeInactive.hs
+++ b/XMonad/Hooks/FadeInactive.hs
@@ -65,8 +65,7 @@ rationalToOpacity perc
 setOpacity :: Window -> Rational -> X ()
 setOpacity w t = withDisplay $ \dpy -> do
     a <- getAtom "_NET_WM_WINDOW_OPACITY"
-    c <- getAtom "CARDINAL"
-    io $ changeProperty32 dpy w a c propModeReplace [rationalToOpacity t]
+    io $ changeProperty32 dpy w a cARDINAL propModeReplace [rationalToOpacity t]
 
 -- | Fades a window out by setting the opacity
 fadeOut :: Rational -> Window -> X ()

--- a/XMonad/Hooks/SetWMName.hs
+++ b/XMonad/Hooks/SetWMName.hs
@@ -61,12 +61,12 @@ setWMName name = do
     dpy <- asks display
     io $ do
         -- _NET_SUPPORTING_WM_CHECK atom of root and support windows refers to the support window
-        mapM_ (\w -> changeProperty32 dpy w atom_NET_SUPPORTING_WM_CHECK wINDOW 0 [fromIntegral supportWindow]) [root, supportWindow]
+        mapM_ (\w -> changeProperty32 dpy w atom_NET_SUPPORTING_WM_CHECK wINDOW propModeReplace [fromIntegral supportWindow]) [root, supportWindow]
         -- set WM_NAME in supportWindow (now only accepts latin1 names to eliminate dependency on utf8 encoder)
-        changeProperty8 dpy supportWindow atom_NET_WM_NAME atom_UTF8_STRING 0 (latin1StringToCCharList name)
+        changeProperty8 dpy supportWindow atom_NET_WM_NAME atom_UTF8_STRING propModeReplace (latin1StringToCCharList name)
         -- declare which _NET protocols are supported (append to the list if it exists)
         supportedList <- join . maybeToList <$> getWindowProperty32 dpy atom_NET_SUPPORTED_ATOM root
-        changeProperty32 dpy root atom_NET_SUPPORTED_ATOM aTOM 0 (nub $ fromIntegral atom_NET_SUPPORTING_WM_CHECK : fromIntegral atom_NET_WM_NAME : supportedList)
+        changeProperty32 dpy root atom_NET_SUPPORTED_ATOM aTOM propModeReplace (nub $ fromIntegral atom_NET_SUPPORTING_WM_CHECK : fromIntegral atom_NET_WM_NAME : supportedList)
   where
     netSupportingWMCheckAtom :: X Atom
     netSupportingWMCheckAtom = getAtom "_NET_SUPPORTING_WM_CHECK"

--- a/XMonad/Hooks/UrgencyHook.hs
+++ b/XMonad/Hooks/UrgencyHook.hs
@@ -321,8 +321,7 @@ changeNetWMState :: Display -> Window -> ([CLong] -> [CLong]) -> X ()
 changeNetWMState dpy w f = do
    wmstate <- getAtom "_NET_WM_STATE"
    wstate  <- fromMaybe [] <$> getProp32 wmstate w
-   let ptype = 4 -- atom property type for changeProperty
-   io $ changeProperty32 dpy w wmstate ptype propModeReplace (f wstate)
+   io $ changeProperty32 dpy w wmstate aTOM propModeReplace (f wstate)
    return ()
 
 -- | Add an atom to the _NET_WM_STATE property.

--- a/XMonad/Layout/Fullscreen.hs
+++ b/XMonad/Layout/Fullscreen.hs
@@ -203,8 +203,7 @@ fullscreenEventHook (ClientMessageEvent _ _ _ dpy win typ (action:dats)) = do
       remove = 0
       add = 1
       toggle = 2
-      ptype = 4
-      chWState f = io $ changeProperty32 dpy win wmstate ptype propModeReplace (f wstate)
+      chWState f = io $ changeProperty32 dpy win wmstate aTOM propModeReplace (f wstate)
   when (typ == wmstate && fi fullsc `elem` dats) $ do
     when (action == add || (action == toggle && not isFull)) $ do
       chWState (fi fullsc:)

--- a/XMonad/Layout/Fullscreen.hs
+++ b/XMonad/Layout/Fullscreen.hs
@@ -32,6 +32,7 @@ module XMonad.Layout.Fullscreen
 
 import           XMonad
 import           XMonad.Layout.LayoutModifier
+import           XMonad.Hooks.EwmhDesktops      (fullscreenStartup)
 import           XMonad.Hooks.ManageHelpers     (isFullscreen)
 import           XMonad.Util.WindowProperties
 import qualified XMonad.Util.Rectangle          as R
@@ -77,7 +78,8 @@ fullscreenSupport :: LayoutClass l Window =>
 fullscreenSupport c = c {
     layoutHook = fullscreenFull $ layoutHook c,
     handleEventHook = handleEventHook c <+> fullscreenEventHook,
-    manageHook = manageHook c <+> fullscreenManageHook
+    manageHook = manageHook c <+> fullscreenManageHook,
+    startupHook = startupHook c <+> fullscreenStartup
   }
 
 -- | Messages that control the fullscreen state of the window.

--- a/XMonad/Util/RemoteWindows.hs
+++ b/XMonad/Util/RemoteWindows.hs
@@ -63,9 +63,8 @@ setRemoteProp :: Window -> String -> X ()
 setRemoteProp w host = do
     d <- asks display
     p <- getAtom "XMONAD_REMOTE"
-    t <- getAtom "CARDINAL"
     v <- hasProperty (Machine host) w
-    io $ changeProperty32 d w p t propModeReplace
+    io $ changeProperty32 d w p cARDINAL propModeReplace
                           [fromIntegral . fromEnum $ not v]
 
 -- | Given a window, tell if it is a local or a remote process. Normally,


### PR DESCRIPTION
Provide a way to advertise _NET_WM_STATE_FULLSCREEN in _NET_SUPPORTED.
I had this hardcoded for a while but read the mpv manpage recently:

```
Specifically, yes will force use of NetWM fullscreen support, even
if not advertised by the WM. This can be useful for WMs that are
broken on purpose, like XMonad. (XMonad supposedly doesn't advertise
fullscreen support, because Flash uses it. Apparently, applications
which want to use fullscreen anyway are supposed to either ignore
the NetWM support hints, or provide a workaround. Shame on XMonad
for deliberately breaking X protocols (as if X isn't bad enough
already).
```

I'm not sure Flash is still a good reason these days to not advertise
fullscreen support yet still handle it and look like idiots while doing so.
(And if anyone thinks it is a good reason, their unchanged xmonad config
will continue behaving that way.)
