### PR TITLE
Refactor all X.L.LayoutBuilderP functionality into X.L.LayoutBuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,13 @@
     EWMH taskbars and pagers. Useful for `NamedScratchpad` windows, since
     you will usually be taken to the `NSP` workspace by them.
 
+### Minor Changes
+
+  * `XMonad.Layout.LayoutBuilder`
+
+    Merge all functionality from `XMonad.Layout.LayoutBuilderP` into
+    `XMonad.Layout.LayoutBuilder`.
+
 ## 0.12 (December 14, 2015)
 
 ### Breaking Changes

--- a/XMonad/Layout/LayoutBuilderP.hs
+++ b/XMonad/Layout/LayoutBuilderP.hs
@@ -9,12 +9,11 @@
 -- Stability   :  unstable
 -- Portability :  unportable
 --
--- A layout combinator that sends windows matching given predicate to one rectangle
--- and the rest to another.
+-- DEPRECATED.  Use 'XMonad.Layout.LayoutBuilder' instead.
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Layout.LayoutBuilderP (
+module XMonad.Layout.LayoutBuilderP {-# DEPRECATED "Use XMonad.Layout.LayoutBuilder instead" #-} (
   LayoutP (..),
   layoutP, layoutAll,
   B.relBox, B.absBox,
@@ -59,6 +58,7 @@ data LayoutP p l1 l2 a =
 
 -- | Use the specified layout in the described area windows that match given predicate and send the rest of the windows to the next layout in the chain.
 --   It is possible to supply an alternative area that will then be used instead, if there are no windows to send to the next layout.
+{-# DEPRECATED layoutP "Use XMonad.Layout.LayoutBuilder.layoutP instead." #-}
 layoutP :: (Read a, Eq a, LayoutClass l1 a, LayoutClass l2 a, LayoutClass l3 a, Predicate p a) =>
        p
     -> B.SubBox                       -- ^ The box to place the windows in
@@ -69,6 +69,7 @@ layoutP :: (Read a, Eq a, LayoutClass l1 a, LayoutClass l2 a, LayoutClass l3 a, 
 layoutP prop box mbox sub next = LayoutP Nothing Nothing prop box mbox sub (Just next)
 
 -- | Use the specified layout in the described area for all remaining windows.
+{-# DEPRECATED layoutAll "Use XMonad.Layout.LayoutBuilder.layoutAll instead." #-}
 layoutAll :: forall l1 p a. (Read a, Eq a, LayoutClass l1 a, Predicate p a) =>
        B.SubBox             -- ^ The box to place the windows in
     -> l1 a               -- ^ The layout to use in the specified area
@@ -207,4 +208,3 @@ differentiate' (Just f) w
 instance Predicate Property Window where
   alwaysTrue _ = Const True
   checkPredicate = hasProperty
-


### PR DESCRIPTION
X.L.LayoutBuilderP is nearly identical to X.L.LayoutBuilder.  Originally
I wanted to add the ability to dynamically resize the layout boxes so it
make a lot of sense to join these two modules together so I wouldn't
have to do it in both.  Even though I never got around to that I still
think it's a good idea to merge these two modules into one.

I believe I was able to merge these without creating any
backward-compatibility issues.  I've been sitting on these changes since
2015 and they work for me without having to change older parts of my
config (relating to X.L.LayoutBuilder).

If anyone wants to work on dynamically resizing layout boxes the issue I
created for it is #36.