### PR TITLE
XMonad/Layout/Groups/Helpers.hs: drop broken ImpredicativeTypes extension (fixes #123)

### DIFF
--- a/XMonad/Layout/Groups/Helpers.hs
+++ b/XMonad/Layout/Groups/Helpers.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-{-# LANGUAGE MultiParamTypeClasses, Rank2Types, ImpredicativeTypes #-}
+{-# LANGUAGE MultiParamTypeClasses, Rank2Types #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -178,7 +178,7 @@ focusFloatDown = focusHelper id id
 -- ** Groups-specific actions
 
 wrap :: G.ModifySpec -> X ()
-wrap = sendMessage . G.Modify
+wrap x = sendMessage (G.Modify x)
 
 -- | Swap the focused group with the previous one
 swapGroupUp :: X ()


### PR DESCRIPTION
ImpredicativeTypes is practically unsupported extension
on it's way to be removed from GHC:
    https://mail.haskell.org/pipermail/ghc-devs/2016-September/012826.html

GHC-8.0.2-rc1 already fails to build xmonad-contrib as:

  XMonad/Layout/Groups/Helpers.hs:181:22: error:
    • Couldn't match type ‘G.WithID l0 Window
                           -> XMonad.Util.Stack.Zipper (G.Group l0 Window)
                           -> XMonad.Util.Stack.Zipper (G.Group l0 Window)’
                     with ‘G.ModifySpec’
      Expected type: (G.WithID l0 Window
                      -> XMonad.Util.Stack.Zipper (G.Group l0 Window)
                      -> XMonad.Util.Stack.Zipper (G.Group l0 Window))
                     -> G.GroupsMessage
        Actual type: G.ModifySpec -> G.GroupsMessage
    • In the second argument of ‘(.)’, namely ‘G.Modify’
      In the expression: sendMessage . G.Modify
      In an equation for ‘wrap’: wrap = sendMessage . G.Modify

The workaround is simple: add explicit types to applications
or open-code direct application (this change).

Bug: https://github.com/xmonad/xmonad-contrib/issues/123
Signed-off-by: Sergei Trofimovich <siarheit@google.com>