### PR TITLE
Fix #120 - Make Actions.WindowGo.raiseNextMaybe span over all workspaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,11 @@
       The project itself was already being deleted, this just deletes
       the workspace created for it as well.
 
+  * `XMonad.Actions.WindowGo`
+
+    - Fix `raiseNextMaybe` cycling between 2 workspaces only.
+
+
 ## 0.12 (December 14, 2015)
 
 ### Breaking Changes

--- a/XMonad/Actions/WindowGo.hs
+++ b/XMonad/Actions/WindowGo.hs
@@ -67,9 +67,9 @@ appropriate one, or cover your bases by using instead something like:
 For detailed instructions on editing your key bindings, see
 "XMonad.Doc.Extending#Editing_key_bindings". -}
 
+-- | Get the list of workspaces sorted by their tag
 workspacesSorted :: Ord i => W.StackSet i l a s sd -> [W.Workspace i l a]
-workspacesSorted s = L.sortBy (\u t -> W.tag u `compare` W.tag t) $
-                       W.workspaces s
+workspacesSorted s = L.sortBy (\u t -> W.tag u `compare` W.tag t) $ W.workspaces s
 
 -- | Get a list of all windows in the 'StackSet' with an absolute ordering of workspaces
 allWindowsSorted :: Ord i => Eq a => W.StackSet i l a s sd -> [a]


### PR DESCRIPTION
As discussed in #120, this patch introduces workspaceSorted and allWindowsSorted to provide an ordering of windows which does not change when changing the current workspace. 