### PR TITLE
Fix CHANGES.md after b9d8f6c .

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,12 +42,6 @@
     EWMH taskbars and pagers. Useful for `NamedScratchpad` windows, since
     you will usually be taken to the `NSP` workspace by them.
 
-  * `XMonad.Actions.Submap`
-
-    Establish pointer grab to avoid freezing X, when button press occurs after
-    submap key press.  And terminate submap at button press in the same way,
-    as we do for wrong key press.
-
 ### Minor Changes
 
   * `XMonad.Layout.LayoutBuilder`
@@ -70,6 +64,12 @@
   * `XMonad.Actions.UpdatePointer`
 
     - Fix bug when cursor gets stuck in one of the corners.
+
+  * `XMonad.Actions.Submap`
+
+    Establish pointer grab to avoid freezing X, when button press occurs after
+    submap key press.  And terminate submap at button press in the same way,
+    as we do for wrong key press.
 
 
 ## 0.12 (December 14, 2015)


### PR DESCRIPTION
Fix CHANGES.md after "X.A.Submap: establish pointer grab to avoid freezing X."