### PR TITLE
Use the new getXMonadCacheDir function from #62

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
   * New constructor `CenteredAt Rational Rational` added for
     `XMonad.Prompt.XPPosition`.
 
+  * `XMonad.Prompt` now stores its history file in the XMonad cache
+    directory in a file named `prompt-history`.
+
 ### New Modules
 
   * `XMonad.Layout.SortedLayout`

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -91,7 +91,6 @@ import           Data.List
 import qualified Data.Map                     as M
 import           Data.Maybe                   (fromMaybe)
 import           Data.Set                     (fromList, toList)
-import           System.Directory             (getAppUserDataDirectory)
 import           System.IO
 import           System.Posix.Files
 
@@ -1064,7 +1063,7 @@ emptyHistory :: History
 emptyHistory = M.empty
 
 getHistoryFile :: IO FilePath
-getHistoryFile = fmap (++ "/history") $ getAppUserDataDirectory "xmonad"
+getHistoryFile = fmap (++ "/prompt-history") getXMonadCacheDir
 
 readHistory :: IO History
 readHistory = readHist `E.catch` \(SomeException _) -> return emptyHistory
@@ -1170,7 +1169,7 @@ breakAtSpace s
 
 -- | 'historyCompletion' provides a canned completion function much like
 --   'getShellCompl'; you pass it to mkXPrompt, and it will make completions work
---   from the query history stored in ~\/.xmonad\/history.
+--   from the query history stored in the XMonad cache directory.
 historyCompletion :: ComplFunction
 historyCompletion = historyCompletionP (const True)
 


### PR DESCRIPTION
Prompt should have been using getXMonadDir this entire time but since
we now have getXMonadCacheDir use that instead.  This brings
xmonad-contrib inline with the changes in xmonad/xmonad#62.

This also fixes xmonad/xmonad-contrib#68