### PR TITLE
Better description of 'font' field of 'XPC' record

### DIFF
--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -126,7 +126,10 @@ data XPState =
         }
 
 data XPConfig =
-    XPC { font              :: String     -- ^ Font; use the prefix @"xft:"@ for TrueType fonts
+    XPC { font              :: String     -- ^ Font. For TrueType fonts, use something like
+                                          -- @"xft:Hack:pixelsize=1"@. Alternatively, use X Logical Font
+                                          -- Description, i.e. something like
+                                          -- @"-*-dejavu sans mono-medium-r-normal--*-80-*-*-*-*-iso10646-1"@.
         , bgColor           :: String     -- ^ Background color
         , fgColor           :: String     -- ^ Font color
         , fgHLight          :: String     -- ^ Font color of a highlighted completion entry


### PR DESCRIPTION
Describe how to use the 'font' field of 'XPC' record by adding two different examples.

### Description

Include a description for your changes, including the motivation
behind them.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
