### PR TITLE
Use `setWindowBorderWithFallback' to support windows with RGBA color maps

### DIFF
--- a/XMonad/Hooks/UrgencyHook.hs
+++ b/XMonad/Hooks/UrgencyHook.hs
@@ -339,7 +339,7 @@ getNetWMState :: Window -> X [CLong]
 getNetWMState w = do
     a_wmstate <- getAtom "_NET_WM_STATE"
     fromMaybe [] `fmap` getProp32 a_wmstate w
-   
+
 
 -- The Non-ICCCM Manifesto:
 -- Note: Some non-standard choices have been made in this implementation to
@@ -497,14 +497,14 @@ data BorderUrgencyHook = BorderUrgencyHook { urgencyBorderColor :: !String }
 
 instance UrgencyHook BorderUrgencyHook where
   urgencyHook BorderUrgencyHook { urgencyBorderColor = cs } w =
-    withDisplay $ \dpy -> io $ do
-      c' <- initColor dpy cs
+    withDisplay $ \dpy -> do
+      c' <- io (initColor dpy cs)
       case c' of
-        Just c -> setWindowBorder dpy w c
-        _      -> hPutStrLn stderr $ concat ["Warning: bad urgentBorderColor "
-                                            ,show cs
-                                            ," in BorderUrgencyHook"
-                                            ]
+        Just c -> setWindowBorderWithFallback dpy w cs c
+        _      -> io $ hPutStrLn stderr $ concat ["Warning: bad urgentBorderColor "
+                                                 ,show cs
+                                                 ," in BorderUrgencyHook"
+                                                 ]
 
 -- | Flashes when a window requests your attention and you can't see it.
 -- Defaults to a duration of five seconds, and no extra args to dzen.
@@ -543,4 +543,3 @@ filterUrgencyHook skips w = do
         Just tag -> when (tag `elem` skips)
                         $ adjustUrgents (delete w)
         _ -> return ()
-

--- a/XMonad/Layout/WindowNavigation.hs
+++ b/XMonad/Layout/WindowNavigation.hs
@@ -195,7 +195,9 @@ navigable :: Direction2D -> Point -> [(Window, Rectangle)] -> [(Window, Rectangl
 navigable d pt = sortby d . filter (inr d pt . snd)
 
 sc :: Pixel -> Window -> X ()
-sc c win = withDisplay $ \dpy -> io $ setWindowBorder dpy win c
+sc c win = withDisplay $ \dpy -> do
+    colorName <- io (pixelToString dpy c)
+    setWindowBorderWithFallback dpy win colorName c
 
 center :: Rectangle -> Point
 center (Rectangle x y w h) = P (fromIntegral x + fromIntegral w/2)  (fromIntegral y + fromIntegral h/2)

--- a/XMonad/Util/XUtils.hs
+++ b/XMonad/Util/XUtils.hs
@@ -28,6 +28,7 @@ module XMonad.Util.XUtils
     , paintAndWrite
     , paintTextAndIcons
     , stringToPixel
+    , pixelToString
     , fi
     ) where
 
@@ -208,4 +209,3 @@ mkWindow d s rw x y w h p o = do
            set_background_pixel  attributes p
            createWindow d rw x y w h 0 (defaultDepthOfScreen s)
                         inputOutput visual attrmask attributes
-


### PR DESCRIPTION
### Description

This brings xmonad-contrib inline with xmonad in this regard.  Should
also be fix for #138


Include a description for your changes, including the motivation
behind them.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
