### PR TITLE
New function: `X.P.Window.windowMultiPrompt'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,25 @@
 # Change Log / Release Notes
 
+## 0.14 (No Release Date Announced)
+
+### Breaking Changes
+
+These are changes that users should review and prepare for before
+upgrading XMonad.
+
+### New Modules
+
+Exciting new modules added to xmonad-contrib.
+
+### Bug Fixes and Minor Changes
+
+These are changes to existing modules.
+
+  * `XMonad.Prompt.Window`
+
+    - New function: `windowMultiPrompt` for using `mkXPromptWithModes`
+      with window prompts.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Like 'windowPrompt', but uses the multiple modes feature of
@Prompt@ (via 'mkXPromptWithModes').

Given a list of actions along with the windows they should work
with, display the appropriate prompt with the ability to switch
between them using the @changeModeKey@.

For example, to have a prompt that first shows you all windows, but
allows you to narrow the list down to just the windows on the
current workspace:

> windowMultiPrompt config [(Goto, allWindows), (Goto, wsWindows)]

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
