### PR TITLE
export BinarySpacePartition type

### DIFF
--- a/XMonad/Layout/BinarySpacePartition.hs
+++ b/XMonad/Layout/BinarySpacePartition.hs
@@ -20,6 +20,7 @@ module XMonad.Layout.BinarySpacePartition (
   -- * Usage
   -- $usage
     emptyBSP
+  , BinarySpacePartition
   , Rotate(..)
   , Swap(..)
   , ResizeDirectional(..)


### PR DESCRIPTION
### Description

I've exported the `BinarySpacePartition` type as it's really hard to write type signatures without it!

I haven't updated the `CHANGES.md` file as it's non-obvious where to put changes for unreleased code. But I'm happy to amend them if needed.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
