### PR TITLE
Respect number of master windows in Magnify layout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@
     - Added the ability to test if a window has a tag from
       `XMonad.Actions.TagWindows`
 
+  * `XMonad.Layout.Magnifier`
+
+    - Handle `IncMasterN` messages.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Handle `IncMasterN` in the `Magnify` layout. Because `Magnify` has a concept of not magnifying the master window, I believe it makes sense to treat windows moved into the master pane as masters themselves (w.r.t. not being magnified). This works nicely when magnifying `FixedColumn` layouts.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
