### PR TITLE
X.U.EZConfig: include Latin1 keys

### DIFF
--- a/XMonad/Util/EZConfig.hs
+++ b/XMonad/Util/EZConfig.hs
@@ -427,7 +427,11 @@ parseKey = parseRegular +++ parseSpecial
 -- | Parse a regular key name (represented by itself).
 parseRegular :: ReadP KeySym
 parseRegular = choice [ char s >> return k
-                      | (s,k) <- zip ['!'..'~'] [xK_exclam..xK_asciitilde]
+                      | (s,k) <- zip ['!'             .. '~'          ] -- ASCII
+                                     [xK_exclam       .. xK_asciitilde]
+
+                              ++ zip ['\xa0'          .. '\xff'       ] -- Latin1
+                                     [xK_nobreakspace .. xK_ydiaeresis]
                       ]
 
 -- | Parse a special key name (one enclosed in angle brackets).


### PR DESCRIPTION
### Description

Includes ability to parse Latin1 keys in EZConfig.  This will better accommodate users with non-US keyboards who might have some keys corresponding to such characters.  (There might be users with other keys not included in Latin1 --- we can certainly consider extending this further in the future.)

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
