### PR TITLE
Use minimize in scratchpads

### DIFF
--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -157,6 +157,6 @@ someNamedScratchpadAction f confs n
 -- | Manage hook to use with named scratchpads
 namedScratchpadManageHook :: NamedScratchpads -- ^ Named scratchpads configuration
                           -> ManageHook
-namedScratchpadManageHook = composeAll . fmap (\c -> query c --> (hook c >> doF copyToAll))
+namedScratchpadManageHook = composeAll . fmap (\c -> query c --> (hook c <+> doF copyToAll))
 
 -- vim:ts=4:shiftwidth=4:softtabstop=4:expandtab:foldlevel=20:

--- a/XMonad/Util/Scratchpad.hs
+++ b/XMonad/Util/Scratchpad.hs
@@ -20,7 +20,6 @@ module XMonad.Util.Scratchpad (
   ,scratchpadSpawnActionCustom
   ,scratchpadManageHookDefault
   ,scratchpadManageHook
-  ,scratchpadFilterOutWorkspace
   ) where
 
 import XMonad
@@ -108,13 +107,5 @@ scratchpadManageHook :: W.RationalRect -- ^ User-specified screen rectangle.
 scratchpadManageHook rect = namedScratchpadManageHook [NS "" "" scratchpadQuery (customFloating rect)]
 
 
--- | Transforms a workspace list containing the SP workspace into one that
--- doesn't contain it. Intended for use with logHooks.
-scratchpadFilterOutWorkspace :: [WindowSpace] -> [WindowSpace]
-scratchpadFilterOutWorkspace = namedScratchpadFilterOutWorkspace
-
-
 scratchpadDefaultRect :: W.RationalRect
 scratchpadDefaultRect = W.RationalRect 0.25 0.375 0.5 0.25
-
-


### PR DESCRIPTION
### Description

Use X.A.Minimize instead of NSP workspace for managing scratchpads. Rationale is described in #90.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
