### PR TITLE
Only modify the last word during tab completion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -337,6 +337,11 @@
 
     - Added `filterOutWs` for workspace filtering.
 
+  * `XMonad.Prompt
+
+    - Accommodate completion of multiple words even when `alwaysHighlight` is
+      enabled.
+
 ## 0.16
 
 ### Breaking Changes


### PR DESCRIPTION
Fixes #164.

It's not clear to me why these functions take in XPState as a param only
to then produce some XP () values. It seems like they could just as well
call `get`.

### Description

When tab-completing in alwaysHighlight mode, rather than setting the entire command string, just delete the last word and insert the completion in its place.
Since the entire command is no longer set simply to a completion, dispatch on the last word of the command instead.
Motivated by https://github.com/xmonad/xmonad-contrib/issues/164.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
