### PR TITLE
add new module X.U.ExclusiveScratchpads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,13 @@
 
 ### New Modules
 
+  * `XMonad.Util.MutexScratchpads`
+
+    Named scratchpads that can be mutually exclusive: This new module extends the
+    idea of named scratchpads such that you can define "families of scratchpads"
+    that are mutually exclusive on the same screen. It also allows to remove this
+    constraint of being mutually exclusive with another scratchpad when.
+
   * `XMonad.Hooks.Focus`
 
     A new module extending ManageHook EDSL to work on focused windows and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,11 +34,11 @@
 
 ### New Modules
 
-  * `XMonad.Util.MutexScratchpads`
+  * `XMonad.Util.ExclusiveScratchpads`
 
     Named scratchpads that can be mutually exclusive: This new module extends the
     idea of named scratchpads such that you can define "families of scratchpads"
-    that are mutually exclusive on the same screen. It also allows to remove this
+    that are exclusive on the same screen. It also allows to remove this
     constraint of being mutually exclusive with another scratchpad when.
 
   * `XMonad.Hooks.Focus`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
     Named scratchpads that can be mutually exclusive: This new module extends the
     idea of named scratchpads such that you can define "families of scratchpads"
     that are exclusive on the same screen. It also allows to remove this
-    constraint of being mutually exclusive with another scratchpad when.
+    constraint of being mutually exclusive with another scratchpad.
 
   * `XMonad.Hooks.Focus`
 

--- a/XMonad/Util/ExclusiveScratchpads.hs
+++ b/XMonad/Util/ExclusiveScratchpads.hs
@@ -1,7 +1,7 @@
 
 -----------------------------------------------------------------------------
 -- |
--- Module      :  XMonad.Util.MutexScratchpads
+-- Module      :  XMonad.Util.ExclusiveScratchpads
 -- Copyright   :  Bruce Forte (2017)
 -- License     :  BSD-style (see LICENSE)
 --
@@ -13,29 +13,28 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Util.MutexScratchpads (
+module XMonad.Util.ExclusiveScratchpads (
   -- * Usage
   -- $usage
-  mkMutexSps,
-  mutexSpsManageHook,
+  mkXScratchpads,
+  xScratchpadsManageHook,
   -- * Keyboard related
   scratchpadAction,
   hideAll,
-  resetMutexSp,
+  resetExclusiveSp,
   -- * Mouse related
-  setNomutex,
-  resizeNomutex,
-  floatMoveNomutex,
+  setNoexclusive,
+  resizeNoexclusive,
+  floatMoveNoexclusive,
   -- * Types
-  MutexScratchpad(..),
-  MutexScratchpads,
+  ExclusiveScratchpad(..),
+  ExclusiveScratchpads,
   -- * Hooks
   nonFloating,
   defaultFloating,
   customFloating
   ) where
 
-import Control.Applicative ((<$>))
 import Control.Monad (filterM,unless,void,(<=<))
 import Data.Monoid (appEndo)
 import XMonad hiding (hide)
@@ -48,27 +47,27 @@ import qualified XMonad.StackSet as W
 -- $usage
 -- To use this module, put the following in your @~\/.xmonad\/xmonad.hs@:
 --
--- > import XMonad.Utils.MutexScratchpads
+-- > import XMonad.Utils.ExclusiveScratchpads
 -- > import XMonad.ManageHook
 -- > import qualified XMonad.StackSet as W
 --
--- Add mutually exclusive scratchpads, for example:
+-- Add exclusive scratchpads, for example:
 --
--- > mutexSps = mkMutexSps [ ("htop",   "urxvt -e htop", title =? "htop")
--- >                       , ("xclock", "xclock", appName =? "xclock")
--- >                       ] $ customFloating $ W.RationalRect (1/4) (1/4) (1/2) (1/2)
+-- > exclusiveSps = mkXScratchpads [ ("htop",   "urxvt -e htop", title =? "htop")
+-- >                               , ("xclock", "xclock", appName =? "xclock")
+-- >                               ] $ customFloating $ W.RationalRect (1/4) (1/4) (1/2) (1/2)
 --
--- The scratchpads don\'t have to be mutually exclusive, you can create them like this (see 'MutexScratchpad'):
+-- The scratchpads don\'t have to be exclusive, you can create them like this (see 'ExclusiveScratchpad'):
 --
--- > regularSps   = [ MNS "term" "urxvt -name scratchpad" (appName =? "scratchpad") defaultFloating [] ]
+-- > regularSps   = [ EXS "term" "urxvt -name scratchpad" (appName =? "scratchpad") defaultFloating [] ]
 --
 -- Create a list that contains all your scratchpads like this:
 --
--- > scratchpads = mutexSps ++ regularSps
+-- > scratchpads = exclusiveSps ++ regularSps
 --
 -- Add the hooks to your managehook, eg. (see "XMonad.Doc.Extending#Editing_the_manage_hook"):
 --
--- > manageHook = myManageHook <+> mutexSpsManageHook scratchpads
+-- > manageHook = myManageHook <+> xScratchpadsManageHook scratchpads
 --
 -- And finally add some keybindings (see "XMonad.Doc.Extending#Editing_key_bindings"):
 --
@@ -82,67 +81,67 @@ import qualified XMonad.StackSet as W
 -- scratchpad then @htop@ gets hidden.
 --
 -- If you move a scratchpad it still gets hidden when you fetch a scratchpad of
--- the same family, to change that behaviour and make windows not mutually exclusive
+-- the same family, to change that behaviour and make windows not exclusive
 -- anymore when they get resized or moved add these mouse bindings
 -- (see "XMonad.Doc.Extending#Editing_mouse_bindings"):
 --
--- >     , ((mod4Mask, button1), floatMoveNomutex scratchpads)
--- >     , ((mod4Mask, button3), resizeNomutex scratchpads)
+-- >     , ((mod4Mask, button1), floatMoveNoexclusive scratchpads)
+-- >     , ((mod4Mask, button3), resizeNoexclusive scratchpads)
 --
 -- To reset a moved scratchpad to the original position that you set with its hook,
--- call @resetMutexSp@ when it is in focus. For example if you want to extend
+-- call @resetExclusiveSp@ when it is in focus. For example if you want to extend
 -- Mod-Return to reset the placement when a scratchpad is in focus but keep the
 -- default behaviour for tiled windows, set these key bindings:
 --
--- > , ((modMask, xK_Return), windows W.swapMaster >> resetMutexSp scratchpads)
+-- > , ((modMask, xK_Return), windows W.swapMaster >> resetExclusiveSp scratchpads)
 --
 -- If you are annoyed by the @NSP@ workspace in your statusbar and are using
 -- @dynamicLogWithPP@ add this to your PP:
 --
 -- > , ppHidden        = \x -> if x == "NSP" then "" else x
 --
--- __Note:__ This is just an example, in general you can add more than two mutually
+-- __Note:__ This is just an example, in general you can add more than two
 -- exclusive scratchpads and multiple families of such.
 
 
--- | MutexScratchpad record specifies its properties
-data MutexScratchpad = MNS { name   :: String      -- ^ Name of the scratchpad
-                           , cmd    :: String      -- ^ Command to spawn the scratchpad
-                           , query  :: Query Bool  -- ^ Query to match the scratchpad
-                           , hook   :: ManageHook  -- ^ Hook to specify the placement policy
-                           , rivals :: [String]    -- ^ Names of rivalling scratchpads
+-- | ExclusiveScratchpad record specifies its properties
+data ExclusiveScratchpad = EXS { name   :: String   -- ^ Name of the scratchpad
+                           , cmd    :: String       -- ^ Command to spawn the scratchpad
+                           , query  :: Query Bool   -- ^ Query to match the scratchpad
+                           , hook   :: ManageHook   -- ^ Hook to specify the placement policy
+                           , exclusive :: [String]  -- ^ Names of exclusive scratchpads
                            }
 
-type MutexScratchpads = [MutexScratchpad]
+type ExclusiveScratchpads = [ExclusiveScratchpad]
 
 -- | Name of the hidden workspace
 nsp :: String
 nsp = "NSP"
 
--- | Create 'MutexScratchpads' from @[(name,cmd,query)]@ with a common @hook@
-mkMutexSps :: [(String,String,Query Bool)]  -- ^ List of @(name,cmd,query)@ of the
-                                            --   mutually exclusive scratchpads
-           -> ManageHook                    -- ^ The common @hook@ that they use
-           -> MutexScratchpads
-mkMutexSps sps h = foldl accumulate [] sps
+-- | Create 'ExclusiveScratchpads' from @[(name,cmd,query)]@ with a common @hook@
+mkXScratchpads :: [(String,String,Query Bool)]  -- ^ List of @(name,cmd,query)@ of the
+                                                --   exclusive scratchpads
+               -> ManageHook                    -- ^ The common @hook@ that they use
+               -> ExclusiveScratchpads
+mkXScratchpads sps h = foldl accumulate [] sps
   where
-    accumulate a (n,c,q) = MNS n c q h (filter (n/=) names) : a
+    accumulate a (n,c,q) = EXS n c q h (filter (n/=) names) : a
     names = map (\(n,_,_) -> n) sps
 
--- | Create 'ManageHook' from 'MutexScratchpads'
-mutexSpsManageHook :: MutexScratchpads  -- ^ List of mutually exclusive scratchpads from
-                                        --   which a 'ManageHook' should be generated
-                   -> ManageHook
-mutexSpsManageHook = composeAll . fmap (\sp -> query sp --> hook sp)
+-- | Create 'ManageHook' from 'ExclusiveScratchpads'
+xScratchpadsManageHook :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads from
+                                                --   which a 'ManageHook' should be generated
+                       -> ManageHook
+xScratchpadsManageHook = composeAll . fmap (\sp -> query sp --> hook sp)
 
--- | Pop up/hide the scratchpad by name and possibly hide its rivals
-scratchpadAction :: MutexScratchpads  -- ^ List of mutually exclusive scratchpads
-                 -> String            -- ^ Name of the scratchpad to toggle
+-- | Pop up/hide the scratchpad by name and possibly hide its exclusive
+scratchpadAction :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
+                 -> String                -- ^ Name of the scratchpad to toggle
                  -> X ()
-scratchpadAction sps n = popOrHide sps n >> whenX (isMutex sps n) (hideOthers sps n)
+scratchpadAction sps n = popOrHide sps n >> whenX (isExclusive sps n) (hideOthers sps n)
 
 -- | Toggles the scratchpad, if 'nsp' is not present create it on a spawn
-popOrHide :: MutexScratchpads -> String -> X ()
+popOrHide :: ExclusiveScratchpads -> String -> X ()
 popOrHide sps n = do
   let sp = filter ((n==).name) sps
       q  = joinQueries $ map query sp
@@ -163,19 +162,19 @@ popOrHide sps n = do
 hide :: Window -> WindowSet -> WindowSet
 hide = W.shiftWin nsp
 
--- | Hide all 'MutexScratchpads' on the current screen
-hideAll :: MutexScratchpads  -- ^ List of mutually exclusive scratchpads
+-- | Hide all 'ExclusiveScratchpads' on the current screen
+hideAll :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
         -> X ()
 hideAll sps = void $ mapWithCurrentScreen q hide
   where q = joinQueries $ map query sps
 
 -- | Hide the scratchpad of the same family by name if it's on the focused workspace
-hideOthers :: MutexScratchpads -> String -> X ()
+hideOthers :: ExclusiveScratchpads -> String -> X ()
 hideOthers sps n =
-  let others = concatMap rivals $ filter ((n==).name) sps
+  let others = concatMap exclusive $ filter ((n==).name) sps
       otherQueries = map query $ filter ((`elem` others).name) sps
       joinedQuery = joinQueries otherQueries
-      qry = joinedQuery <&&> isMutexQuery in
+      qry = joinedQuery <&&> isExclusiveQuery in
 
   void $ mapWithCurrentScreen qry hide
 
@@ -187,25 +186,25 @@ mapWithCurrentScreen q f = withWindowSet $ \s -> do
 
   return $ ws /= []
 
--- | Check if scratchpad is mutually exclusive
-isMutex :: MutexScratchpads -> String -> X Bool
-isMutex sps n = withWindowSet $ \s -> do
-  let q = isMutexQuery <&&> joinQueries (map query $ filter ((n==).name) sps)
+-- | Check if scratchpad is exclusive
+isExclusive :: ExclusiveScratchpads -> String -> X Bool
+isExclusive sps n = withWindowSet $ \s -> do
+  let q = isExclusiveQuery <&&> joinQueries (map query $ filter ((n==).name) sps)
 
   ws <- filterM (runQuery q) $ W.allWindows s
   return $ ws /= []
 
 -- | Check if given window is a scratchpad
-isScratchpad :: MutexScratchpads -> Window -> X Bool
+isScratchpad :: ExclusiveScratchpads -> Window -> X Bool
 isScratchpad sps w = withWindowSet $ \s -> do
   let q = joinQueries $ map query sps
 
   ws <- filterM (runQuery q) $ W.allWindows s
   return $ elem w ws
 
--- | Query that matches if the window is mutually exclusive
-isMutexQuery :: Query Bool
-isMutexQuery = (notElem "CS_NOMUTEX" . words) <$> stringProperty "_XMONAD_TAGS"
+-- | Query that matches if the window is exclusive
+isExclusiveQuery :: Query Bool
+isExclusiveQuery = (notElem "CS_NOEXCLUSIVE" . words) <$> stringProperty "_XMONAD_TAGS"
 
 -- | Build a disjunction from a list of clauses
 joinQueries :: [Query Bool] -> Query Bool
@@ -220,10 +219,10 @@ unlessX :: X Bool -> X () -> X ()
 unlessX = whenX . fmap not
 
 -- | If the focused window is a scratchpad, the scratchpad gets reset to the original
--- placement specified with the hook and becomes mutually exclusive again
-resetMutexSp :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
-             -> X ()
-resetMutexSp sps = withFocused $ \w -> whenX (isScratchpad sps w) $ do
+-- placement specified with the hook and becomes exclusive again
+resetExclusiveSp :: ExclusiveScratchpads -- ^ List of exclusive scratchpads
+                 -> X ()
+resetExclusiveSp sps = withFocused $ \w -> whenX (isScratchpad sps w) $ do
   let msp = filterM (flip runQuery w . query) sps
 
   unlessX (null <$> msp) $ do
@@ -232,29 +231,29 @@ resetMutexSp sps = withFocused $ \w -> whenX (isScratchpad sps w) $ do
 
     (windows . appEndo <=< runQuery mh) w
     hideOthers sps n
-    delTag "CS_NOMUTEX" w
+    delTag "CS_NOEXCLUSIVE" w
 
--- | Make a window not mutually exclusive anymore
-setNomutex :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
-           -> Window           -- ^ Window which should be made not mutually
-                               --   exclusive anymore
-           -> X ()
-setNomutex sps w = whenX (isScratchpad sps w) $ addTag "CS_NOMUTEX" w
+-- | Make a window not exclusive anymore
+setNoexclusive :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
+               -> Window                -- ^ Window which should be made not
+                                        --   exclusive anymore
+               -> X ()
+setNoexclusive sps w = whenX (isScratchpad sps w) $ addTag "CS_NOEXCLUSIVE" w
 
--- | Float and drag the window, make it not mutually exclusive anymore
-floatMoveNomutex :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
-                 -> Window           -- ^ Window which should be moved
-                 -> X ()
-floatMoveNomutex sps w = setNomutex sps w
+-- | Float and drag the window, make it not exclusive anymore
+floatMoveNoexclusive :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
+                     -> Window                -- ^ Window which should be moved
+                     -> X ()
+floatMoveNoexclusive sps w = setNoexclusive sps w
   >> focus w
   >> mouseMoveWindow w
   >> windows W.shiftMaster
 
--- | Resize window, make it not mutually exclusive anymore
-resizeNomutex :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
-              -> Window           -- ^ Window which should be resized
-              -> X ()
-resizeNomutex sps w = setNomutex sps w
+-- | Resize window, make it not exclusive anymore
+resizeNoexclusive :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
+                  -> Window                    -- ^ Window which should be resized
+                  -> X ()
+resizeNoexclusive sps w = setNoexclusive sps w
   >> focus w
   >> mouseResizeWindow w
   >> windows W.shiftMaster

--- a/XMonad/Util/ExclusiveScratchpads.hs
+++ b/XMonad/Util/ExclusiveScratchpads.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -36,37 +37,42 @@ module XMonad.Util.ExclusiveScratchpads (
   ) where
 
 import Control.Applicative ((<$>))
-import Control.Monad (filterM,unless,void,(<=<))
+import Control.Monad ((<=<),filterM,liftM2)
 import Data.Monoid (appEndo)
-import XMonad hiding (hide)
-import XMonad.Actions.DynamicWorkspaces (addHiddenWorkspace)
+import XMonad
+import XMonad.Actions.Minimize
 import XMonad.Actions.TagWindows (addTag,delTag)
-import XMonad.Hooks.ManageHelpers (doRectFloat)
+import XMonad.Hooks.ManageHelpers (doRectFloat,isInProperty)
 
 import qualified XMonad.StackSet as W
 
 -- $usage
+--
+-- For this module to work properly, you need to use "XMonad.Layout.BoringWindows" and
+-- "XMonad.Layout.Minimize", please refer to the documentation of these modules for more
+-- information on how to configure them.
+--
 -- To use this module, put the following in your @~\/.xmonad\/xmonad.hs@:
 --
 -- > import XMonad.Utils.ExclusiveScratchpads
--- > import XMonad.ManageHook
+-- > import XMonad.ManageHook (title,appName)
 -- > import qualified XMonad.StackSet as W
 --
 -- Add exclusive scratchpads, for example:
 --
--- > exclusiveSps = mkXScratchpads [ ("htop",   "urxvt -e htop", title =? "htop")
+-- > exclusiveSps = mkXScratchpads [ ("htop",   "urxvt -name htop -e htop", title =? "htop")
 -- >                               , ("xclock", "xclock", appName =? "xclock")
 -- >                               ] $ customFloating $ W.RationalRect (1/4) (1/4) (1/2) (1/2)
 --
 -- The scratchpads don\'t have to be exclusive, you can create them like this (see 'ExclusiveScratchpad'):
 --
--- > regularSps   = [ EXS "term" "urxvt -name scratchpad" (appName =? "scratchpad") defaultFloating [] ]
+-- > regularSps   = [ XSP "term" "urxvt -name scratchpad" (appName =? "scratchpad") defaultFloating [] ]
 --
 -- Create a list that contains all your scratchpads like this:
 --
 -- > scratchpads = exclusiveSps ++ regularSps
 --
--- Add the hooks to your managehook, eg. (see "XMonad.Doc.Extending#Editing_the_manage_hook"):
+-- Add the hooks to your managehook (see "XMonad.Doc.Extending#Editing_the_manage_hook"), eg.:
 --
 -- > manageHook = myManageHook <+> xScratchpadsManageHook scratchpads
 --
@@ -96,38 +102,29 @@ import qualified XMonad.StackSet as W
 --
 -- > , ((modMask, xK_Return), windows W.swapMaster >> resetExclusiveSp scratchpads)
 --
--- If you are annoyed by the @NSP@ workspace in your statusbar and are using
--- @dynamicLogWithPP@ add this to your PP:
---
--- > , ppHidden        = \x -> if x == "NSP" then "" else x
---
 -- __Note:__ This is just an example, in general you can add more than two
 -- exclusive scratchpads and multiple families of such.
 
-
--- | ExclusiveScratchpad record specifies its properties
-data ExclusiveScratchpad = EXS { name   :: String   -- ^ Name of the scratchpad
-                           , cmd    :: String       -- ^ Command to spawn the scratchpad
-                           , query  :: Query Bool   -- ^ Query to match the scratchpad
-                           , hook   :: ManageHook   -- ^ Hook to specify the placement policy
-                           , exclusive :: [String]  -- ^ Names of exclusive scratchpads
-                           }
+data ExclusiveScratchpad = XSP { name   :: String       -- ^ Name of the scratchpad
+                               , cmd    :: String       -- ^ Command to spawn the scratchpad
+                               , query  :: Query Bool   -- ^ Query to match the scratchpad
+                               , hook   :: ManageHook   -- ^ Hook to specify the placement policy
+                               , exclusive :: [String]  -- ^ Names of exclusive scratchpads
+                               }
 
 type ExclusiveScratchpads = [ExclusiveScratchpad]
 
--- | Name of the hidden workspace
-nsp :: String
-nsp = "NSP"
+-- -----------------------------------------------------------------------------------
 
 -- | Create 'ExclusiveScratchpads' from @[(name,cmd,query)]@ with a common @hook@
 mkXScratchpads :: [(String,String,Query Bool)]  -- ^ List of @(name,cmd,query)@ of the
                                                 --   exclusive scratchpads
                -> ManageHook                    -- ^ The common @hook@ that they use
                -> ExclusiveScratchpads
-mkXScratchpads sps h = foldl accumulate [] sps
+mkXScratchpads xs h = foldl accumulate [] xs
   where
-    accumulate a (n,c,q) = EXS n c q h (filter (n/=) names) : a
-    names = map (\(n,_,_) -> n) sps
+    accumulate a (n,c,q) = XSP n c q h (filter (n/=) names) : a
+    names = map (\(n,_,_) -> n) xs
 
 -- | Create 'ManageHook' from 'ExclusiveScratchpads'
 xScratchpadsManageHook :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads from
@@ -139,125 +136,117 @@ xScratchpadsManageHook = composeAll . fmap (\sp -> query sp --> hook sp)
 scratchpadAction :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
                  -> String                -- ^ Name of the scratchpad to toggle
                  -> X ()
-scratchpadAction sps n = popOrHide sps n >> whenX (isExclusive sps n) (hideOthers sps n)
+scratchpadAction xs n =
+  let ys = filter ((n==).name) xs in
 
--- | Toggles the scratchpad, if 'nsp' is not present create it on a spawn
-popOrHide :: ExclusiveScratchpads -> String -> X ()
-popOrHide sps n = do
-  let sp = filter ((n==).name) sps
-      q  = joinQueries $ map query sp
+  case ys of []     -> return ()
+             (sp:_) -> let q = query sp in withWindowSet $ \s -> do
+                       ws <- filterM (runQuery q) $ W.allWindows s
 
-  unlessX (mapWithCurrentScreen q hide) $ withWindowSet $ \s -> do
-    ws <- filterM (runQuery q) $ W.allWindows s
-    case ws of [] -> unless (null sp)
-                       $ spawnSp s $ cmd $ head sp  -- sp /= [], so `head` is fine
-               _  -> mapW (fetchWindow s) ws
+                       case ws of []    -> do spawn (cmd sp)
+                                              hideOthers xs n
+                                              windows W.shiftMaster
+
+                                  (w:_) -> do toggleWindow w
+                                              whenX (runQuery isExclusive w) (hideOthers xs n)
   where
-    spawnSp s c = do
-      unless (any ((nsp==).W.tag) $ W.workspaces s) (addHiddenWorkspace nsp)
-      spawn c
+    toggleWindow w = liftM2 (&&) (runQuery isMaximized w) (onCurrentScreen w) >>= \case
+      True  -> whenX (onCurrentScreen w) (minimizeWindow w)
+      False -> do windows (flip W.shiftWin w =<< W.currentTag)
+                  maximizeWindowAndFocus w
+                  windows W.shiftMaster
 
-    fetchWindow s = (W.shiftMaster .) . (W.shiftWin $ W.currentTag s)
-
--- | Move the window to the hidden workspace
-hide :: Window -> WindowSet -> WindowSet
-hide = W.shiftWin nsp
+    onCurrentScreen w = withWindowSet (return . elem w . currentWindows)
 
 -- | Hide all 'ExclusiveScratchpads' on the current screen
 hideAll :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
         -> X ()
-hideAll sps = void $ mapWithCurrentScreen q hide
-  where q = joinQueries $ map query sps
-
--- | Hide the scratchpad of the same family by name if it's on the focused workspace
-hideOthers :: ExclusiveScratchpads -> String -> X ()
-hideOthers sps n =
-  let others = concatMap exclusive $ filter ((n==).name) sps
-      otherQueries = map query $ filter ((`elem` others).name) sps
-      joinedQuery = joinQueries otherQueries
-      qry = joinedQuery <&&> isExclusiveQuery in
-
-  void $ mapWithCurrentScreen qry hide
-
--- | Conditionally map a function on all windows of the current screen
-mapWithCurrentScreen :: Query Bool -> (Window -> WindowSet -> WindowSet) -> X Bool
-mapWithCurrentScreen q f = withWindowSet $ \s -> do
-  ws <- filterM (runQuery q) $ W.integrate' $ W.stack $ W.workspace $ W.current s
-  mapW f ws
-
-  return $ ws /= []
-
--- | Check if scratchpad is exclusive
-isExclusive :: ExclusiveScratchpads -> String -> X Bool
-isExclusive sps n = withWindowSet $ \s -> do
-  let q = isExclusiveQuery <&&> joinQueries (map query $ filter ((n==).name) sps)
-
-  ws <- filterM (runQuery q) $ W.allWindows s
-  return $ ws /= []
-
--- | Check if given window is a scratchpad
-isScratchpad :: ExclusiveScratchpads -> Window -> X Bool
-isScratchpad sps w = withWindowSet $ \s -> do
-  let q = joinQueries $ map query sps
-
-  ws <- filterM (runQuery q) $ W.allWindows s
-  return $ elem w ws
-
--- | Query that matches if the window is exclusive
-isExclusiveQuery :: Query Bool
-isExclusiveQuery = (notElem "CS_NOEXCLUSIVE" . words) <$> stringProperty "_XMONAD_TAGS"
-
--- | Build a disjunction from a list of clauses
-joinQueries :: [Query Bool] -> Query Bool
-joinQueries = foldl (<||>) (liftX $ return False)
-
--- | Useful for "mapping a function over a list of windows"
-mapW :: (a -> WindowSet -> WindowSet) -> [a] -> X ()
-mapW f ws = windows $ foldl (.) id (map f ws)
-
--- | Counterpart to whenX
-unlessX :: X Bool -> X () -> X ()
-unlessX = whenX . fmap not
+hideAll xs = mapWithCurrentScreen q minimizeWindow
+  where q = joinQueries (map query xs) <&&> isExclusive <&&> isMaximized
 
 -- | If the focused window is a scratchpad, the scratchpad gets reset to the original
 -- placement specified with the hook and becomes exclusive again
 resetExclusiveSp :: ExclusiveScratchpads -- ^ List of exclusive scratchpads
                  -> X ()
-resetExclusiveSp sps = withFocused $ \w -> whenX (isScratchpad sps w) $ do
-  let msp = filterM (flip runQuery w . query) sps
+resetExclusiveSp xs = withFocused $ \w -> whenX (isScratchpad xs w) $ do
+  let ys = filterM (flip runQuery w . query) xs
 
-  unlessX (null <$> msp) $ do
-    mh <- (head . map hook) <$> msp  -- msp /= [], so `head` is fine
-    n  <- (head . map name) <$> msp  -- same
+  unlessX (null <$> ys) $ do
+    mh <- (head . map hook) <$> ys  -- ys /= [], so `head` is fine
+    n  <- (head . map name) <$> ys  -- same
 
     (windows . appEndo <=< runQuery mh) w
-    hideOthers sps n
-    delTag "CS_NOEXCLUSIVE" w
+    hideOthers xs n
+    delTag "_XSP_NOEXCLUSIVE" w
+
+  where unlessX = whenX . fmap not
+
+-- -----------------------------------------------------------------------------------
+
+-- | Hide the scratchpad of the same family by name if it's on the focused workspace
+hideOthers :: ExclusiveScratchpads -> String -> X ()
+hideOthers xs n =
+  let ys = concatMap exclusive $ filter ((n==).name) xs
+      qs = map query $ filter ((`elem` ys).name) xs
+      q  = joinQueries qs <&&> isExclusive <&&> isMaximized in
+
+  mapWithCurrentScreen q minimizeWindow
+
+-- | Conditionally map a function on all windows of the current screen
+mapWithCurrentScreen :: Query Bool -> (Window -> X ()) -> X ()
+mapWithCurrentScreen q f = withWindowSet $ \s -> do
+  ws <- filterM (runQuery q) $ currentWindows s
+  mapM_ f ws
+
+-- | Extract all windows on the current screen from a StackSet
+currentWindows :: W.StackSet i l a sid sd -> [a]
+currentWindows = W.integrate' . W.stack . W.workspace . W.current
+
+-- | Check if given window is a scratchpad
+isScratchpad :: ExclusiveScratchpads -> Window -> X Bool
+isScratchpad xs w = withWindowSet $ \s -> do
+  let q = joinQueries $ map query xs
+
+  ws <- filterM (runQuery q) $ W.allWindows s
+  return $ elem w ws
+
+-- | Build a disjunction from a list of clauses
+joinQueries :: [Query Bool] -> Query Bool
+joinQueries = foldl (<||>) (liftX $ return False)
+
+-- | Useful queries
+isExclusive, isMaximized :: Query Bool
+isExclusive = (notElem "_XSP_NOEXCLUSIVE" . words) <$> stringProperty "_XMONAD_TAGS"
+isMaximized = not <$> isInProperty "_NET_WM_STATE" "_NET_WM_STATE_HIDDEN"
+
+-- -----------------------------------------------------------------------------------
 
 -- | Make a window not exclusive anymore
 setNoexclusive :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
                -> Window                -- ^ Window which should be made not
                                         --   exclusive anymore
                -> X ()
-setNoexclusive sps w = whenX (isScratchpad sps w) $ addTag "CS_NOEXCLUSIVE" w
+setNoexclusive xs w = whenX (isScratchpad xs w) $ addTag "_XSP_NOEXCLUSIVE" w
 
 -- | Float and drag the window, make it not exclusive anymore
 floatMoveNoexclusive :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
                      -> Window                -- ^ Window which should be moved
                      -> X ()
-floatMoveNoexclusive sps w = setNoexclusive sps w
+floatMoveNoexclusive xs w = setNoexclusive xs w
   >> focus w
   >> mouseMoveWindow w
   >> windows W.shiftMaster
 
 -- | Resize window, make it not exclusive anymore
 resizeNoexclusive :: ExclusiveScratchpads  -- ^ List of exclusive scratchpads
-                  -> Window                    -- ^ Window which should be resized
+                  -> Window                -- ^ Window which should be resized
                   -> X ()
-resizeNoexclusive sps w = setNoexclusive sps w
+resizeNoexclusive xs w = setNoexclusive xs w
   >> focus w
   >> mouseResizeWindow w
   >> windows W.shiftMaster
+
+-- -----------------------------------------------------------------------------------
 
 -- | Manage hook that makes the window non-floating
 nonFloating :: ManageHook

--- a/XMonad/Util/ExclusiveScratchpads.hs
+++ b/XMonad/Util/ExclusiveScratchpads.hs
@@ -35,6 +35,7 @@ module XMonad.Util.ExclusiveScratchpads (
   customFloating
   ) where
 
+import Control.Applicative ((<$>))
 import Control.Monad (filterM,unless,void,(<=<))
 import Data.Monoid (appEndo)
 import XMonad hiding (hide)

--- a/XMonad/Util/MutexScratchpads.hs
+++ b/XMonad/Util/MutexScratchpads.hs
@@ -1,0 +1,273 @@
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Util.MutexScratchpads
+-- Copyright   :  Bruce Forte (2017)
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Bruce Forte
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Named scratchpads that can be mutually exclusive.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Util.MutexScratchpads (
+  -- * Usage
+  -- $usage
+  mkMutexSps,
+  mutexSpsManageHook,
+  -- * Keyboard related
+  scratchpadAction,
+  hideAll,
+  resetMutexSp,
+  -- * Mouse related
+  setNomutex,
+  resizeNomutex,
+  floatMoveNomutex,
+  -- * Types
+  MutexScratchpad(..),
+  MutexScratchpads,
+  -- * Hooks
+  nonFloating,
+  defaultFloating,
+  customFloating
+  ) where
+
+import Control.Monad (filterM,unless,void,(<=<))
+import Data.Monoid (appEndo)
+import XMonad hiding (hide)
+import XMonad.Actions.DynamicWorkspaces (addHiddenWorkspace)
+import XMonad.Actions.TagWindows (addTag,delTag)
+import XMonad.Hooks.ManageHelpers (doRectFloat)
+
+import qualified XMonad.StackSet as W
+
+-- $usage
+-- To use this module, put the following in your @~\/.xmonad\/xmonad.hs@:
+--
+-- > import XMonad.Utils.MutexScratchpads
+-- > import XMonad.ManageHook
+-- > import qualified XMonad.StackSet as W
+--
+-- Add mutually exclusive scratchpads, for example:
+--
+-- > mutexSps = mkMutexSps [ ("htop",   "urxvt -e htop", title =? "htop")
+-- >                       , ("xclock", "xclock", appName =? "xclock")
+-- >                       ] $ customFloating $ W.RationalRect (1/4) (1/4) (1/2) (1/2)
+--
+-- The scratchpads don\'t have to be mutually exclusive, you can create them like this (see 'MutexScratchpad'):
+--
+-- > regularSps   = [ MNS "term" "urxvt -name scratchpad" (appName =? "scratchpad") defaultFloating [] ]
+--
+-- Create a list that contains all your scratchpads like this:
+--
+-- > scratchpads = mutexSps ++ regularSps
+--
+-- Add the hooks to your managehook, eg. (see "XMonad.Doc.Extending#Editing_the_manage_hook"):
+--
+-- > manageHook = myManageHook <+> mutexSpsManageHook scratchpads
+--
+-- And finally add some keybindings (see "XMonad.Doc.Extending#Editing_key_bindings"):
+--
+-- > , ((modMask, xK_h), scratchpadAction scratchpads "htop")
+-- > , ((modMask, xK_c), scratchpadAction scratchpads "xclock")
+-- > , ((modMask, xK_t), scratchpadAction scratchpads "term")
+-- > , ((modMask, xK_h), hideAll scratchpads)
+--
+-- Now you can get your scratchpads by pressing the corresponding keys, if you
+-- have the @htop@ scratchpad on your current screen and you fetch the @xclock@
+-- scratchpad then @htop@ gets hidden.
+--
+-- If you move a scratchpad it still gets hidden when you fetch a scratchpad of
+-- the same family, to change that behaviour and make windows not mutually exclusive
+-- anymore when they get resized or moved add these mouse bindings
+-- (see "XMonad.Doc.Extending#Editing_mouse_bindings"):
+--
+-- >     , ((mod4Mask, button1), floatMoveNomutex scratchpads)
+-- >     , ((mod4Mask, button3), resizeNomutex scratchpads)
+--
+-- To reset a moved scratchpad to the original position that you set with its hook,
+-- call @resetMutexSp@ when it is in focus. For example if you want to extend
+-- Mod-Return to reset the placement when a scratchpad is in focus but keep the
+-- default behaviour for tiled windows, set these key bindings:
+--
+-- > , ((modMask, xK_Return), windows W.swapMaster >> resetMutexSp scratchpads)
+--
+-- If you are annoyed by the @NSP@ workspace in your statusbar and are using
+-- @dynamicLogWithPP@ add this to your PP:
+--
+-- > , ppHidden        = \x -> if x == "NSP" then "" else x
+--
+-- __Note:__ This is just an example, in general you can add more than two mutually
+-- exclusive scratchpads and multiple families of such.
+
+
+-- | MutexScratchpad record specifies its properties
+data MutexScratchpad = MNS { name   :: String      -- ^ Name of the scratchpad
+                           , cmd    :: String      -- ^ Command to spawn the scratchpad
+                           , query  :: Query Bool  -- ^ Query to match the scratchpad
+                           , hook   :: ManageHook  -- ^ Hook to specify the placement policy
+                           , rivals :: [String]    -- ^ Names of rivalling scratchpads
+                           }
+
+type MutexScratchpads = [MutexScratchpad]
+
+-- | Name of the hidden workspace
+nsp :: String
+nsp = "NSP"
+
+-- | Create 'MutexScratchpads' from @[(name,cmd,query)]@ with a common @hook@
+mkMutexSps :: [(String,String,Query Bool)]  -- ^ List of @(name,cmd,query)@ of the
+                                            --   mutually exclusive scratchpads
+           -> ManageHook                    -- ^ The common @hook@ that they use
+           -> MutexScratchpads
+mkMutexSps sps h = foldl accumulate [] sps
+  where
+    accumulate a (n,c,q) = MNS n c q h (filter (n/=) names) : a
+    names = map (\(n,_,_) -> n) sps
+
+-- | Create 'ManageHook' from 'MutexScratchpads'
+mutexSpsManageHook :: MutexScratchpads  -- ^ List of mutually exclusive scratchpads from
+                                        --   which a 'ManageHook' should be generated
+                   -> ManageHook
+mutexSpsManageHook = composeAll . fmap (\sp -> query sp --> hook sp)
+
+-- | Pop up/hide the scratchpad by name and possibly hide its rivals
+scratchpadAction :: MutexScratchpads  -- ^ List of mutually exclusive scratchpads
+                 -> String            -- ^ Name of the scratchpad to toggle
+                 -> X ()
+scratchpadAction sps n = popOrHide sps n >> whenX (isMutex sps n) (hideOthers sps n)
+
+-- | Toggles the scratchpad, if 'nsp' is not present create it on a spawn
+popOrHide :: MutexScratchpads -> String -> X ()
+popOrHide sps n = do
+  let sp = filter ((n==).name) sps
+      q  = joinQueries $ map query sp
+
+  unlessX (mapWithCurrentScreen q hide) $ withWindowSet $ \s -> do
+    ws <- filterM (runQuery q) $ W.allWindows s
+    case ws of [] -> unless (null sp)
+                       $ spawnSp s $ cmd $ head sp  -- sp /= [], so `head` is fine
+               _  -> mapW (fetchWindow s) ws
+  where
+    spawnSp s c = do
+      unless (any ((nsp==).W.tag) $ W.workspaces s) (addHiddenWorkspace nsp)
+      spawn c
+
+    fetchWindow s = (W.shiftMaster .) . (W.shiftWin $ W.currentTag s)
+
+-- | Move the window to the hidden workspace
+hide :: Window -> WindowSet -> WindowSet
+hide = W.shiftWin nsp
+
+-- | Hide all 'MutexScratchpads' on the current screen
+hideAll :: MutexScratchpads  -- ^ List of mutually exclusive scratchpads
+        -> X ()
+hideAll sps = void $ mapWithCurrentScreen q hide
+  where q = joinQueries $ map query sps
+
+-- | Hide the scratchpad of the same family by name if it's on the focused workspace
+hideOthers :: MutexScratchpads -> String -> X ()
+hideOthers sps n =
+  let others = concatMap rivals $ filter ((n==).name) sps
+      otherQueries = map query $ filter ((`elem` others).name) sps
+      joinedQuery = joinQueries otherQueries
+      qry = joinedQuery <&&> isMutexQuery in
+
+  void $ mapWithCurrentScreen qry hide
+
+-- | Conditionally map a function on all windows of the current screen
+mapWithCurrentScreen :: Query Bool -> (Window -> WindowSet -> WindowSet) -> X Bool
+mapWithCurrentScreen q f = withWindowSet $ \s -> do
+  ws <- filterM (runQuery q) $ W.integrate' $ W.stack $ W.workspace $ W.current s
+  mapW f ws
+
+  return $ ws /= []
+
+-- | Check if scratchpad is mutually exclusive
+isMutex :: MutexScratchpads -> String -> X Bool
+isMutex sps n = withWindowSet $ \s -> do
+  let q = isMutexQuery <&&> joinQueries (map query $ filter ((n==).name) sps)
+
+  ws <- filterM (runQuery q) $ W.allWindows s
+  return $ ws /= []
+
+-- | Check if given window is a scratchpad
+isScratchpad :: MutexScratchpads -> Window -> X Bool
+isScratchpad sps w = withWindowSet $ \s -> do
+  let q = joinQueries $ map query sps
+
+  ws <- filterM (runQuery q) $ W.allWindows s
+  return $ elem w ws
+
+-- | Query that matches if the window is mutually exclusive
+isMutexQuery :: Query Bool
+isMutexQuery = (notElem "CS_NOMUTEX" . words) <$> stringProperty "_XMONAD_TAGS"
+
+-- | Build a disjunction from a list of clauses
+joinQueries :: [Query Bool] -> Query Bool
+joinQueries = foldl (<||>) (liftX $ return False)
+
+-- | Useful for "mapping a function over a list of windows"
+mapW :: (a -> WindowSet -> WindowSet) -> [a] -> X ()
+mapW f ws = windows $ foldl (.) id (map f ws)
+
+-- | Counterpart to whenX
+unlessX :: X Bool -> X () -> X ()
+unlessX = whenX . fmap not
+
+-- | If the focused window is a scratchpad, the scratchpad gets reset to the original
+-- placement specified with the hook and becomes mutually exclusive again
+resetMutexSp :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
+             -> X ()
+resetMutexSp sps = withFocused $ \w -> whenX (isScratchpad sps w) $ do
+  let msp = filterM (flip runQuery w . query) sps
+
+  unlessX (null <$> msp) $ do
+    mh <- (head . map hook) <$> msp  -- msp /= [], so `head` is fine
+    n  <- (head . map name) <$> msp  -- same
+
+    (windows . appEndo <=< runQuery mh) w
+    hideOthers sps n
+    delTag "CS_NOMUTEX" w
+
+-- | Make a window not mutually exclusive anymore
+setNomutex :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
+           -> Window           -- ^ Window which should be made not mutually
+                               --   exclusive anymore
+           -> X ()
+setNomutex sps w = whenX (isScratchpad sps w) $ addTag "CS_NOMUTEX" w
+
+-- | Float and drag the window, make it not mutually exclusive anymore
+floatMoveNomutex :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
+                 -> Window           -- ^ Window which should be moved
+                 -> X ()
+floatMoveNomutex sps w = setNomutex sps w
+  >> focus w
+  >> mouseMoveWindow w
+  >> windows W.shiftMaster
+
+-- | Resize window, make it not mutually exclusive anymore
+resizeNomutex :: MutexScratchpads -- ^ List of mutually exclusive scratchpads
+              -> Window           -- ^ Window which should be resized
+              -> X ()
+resizeNomutex sps w = setNomutex sps w
+  >> focus w
+  >> mouseResizeWindow w
+  >> windows W.shiftMaster
+
+-- | Manage hook that makes the window non-floating
+nonFloating :: ManageHook
+nonFloating = idHook
+
+-- | Manage hook that makes the window floating with the default placement
+defaultFloating :: ManageHook
+defaultFloating = doFloat
+
+-- | Manage hook that makes the window floating with custom placement
+customFloating :: W.RationalRect  -- ^ @RationalRect x y w h@ that specifies relative position,
+                                  --   height and width (see "XMonad.StackSet#RationalRect")
+               -> ManageHook
+customFloating = doRectFloat

--- a/XMonad/Util/MutexScratchpads.hs
+++ b/XMonad/Util/MutexScratchpads.hs
@@ -35,6 +35,7 @@ module XMonad.Util.MutexScratchpads (
   customFloating
   ) where
 
+import Control.Applicative ((<$>))
 import Control.Monad (filterM,unless,void,(<=<))
 import Data.Monoid (appEndo)
 import XMonad hiding (hide)

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -309,6 +309,7 @@ library
                         XMonad.Util.Dmenu
                         XMonad.Util.Dzen
                         XMonad.Util.EZConfig
+                        XMonad.Util.ExclusiveScratchpads
                         XMonad.Util.ExtensibleState
                         XMonad.Util.Font
                         XMonad.Util.Image
@@ -316,7 +317,6 @@ library
                         XMonad.Util.Loggers
                         XMonad.Util.Loggers.NamedScratchpad
                         XMonad.Util.Minimize
-                        XMonad.Util.MutexScratchpads
                         XMonad.Util.NamedActions
                         XMonad.Util.NamedScratchpad
                         XMonad.Util.NamedWindows

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -316,6 +316,7 @@ library
                         XMonad.Util.Loggers
                         XMonad.Util.Loggers.NamedScratchpad
                         XMonad.Util.Minimize
+                        XMonad.Util.MutexScratchpads
                         XMonad.Util.NamedActions
                         XMonad.Util.NamedScratchpad
                         XMonad.Util.NamedWindows


### PR DESCRIPTION
### Description

This is a new module that extends the idea of NamedScratchpads: For example, a lot of the time I just need a scratchpad for doing a quick calculation (eg. a `ghci` shell) after that I might use another scratchpad (eg. `octave` shell), with this module the workspace doesn't get polluted since I can group related scratchpads that share the same position on the workspace.

I use it a lot and thought it might be worth being shared, note that I'm not sure if this meets all your standards as this is my first (real) contribution. I tested the module for about a week now with my current setup and it works the way it is supposed to, I also I tested it with `xmonad-testing`, so I think it should do fine.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
