### PR TITLE
Make UnicodeData.txt path configurable, remove unsafePerformIO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@
      sending messages to `Minimized` layout. `XMonad.Hooks.RestoreMinimized` has
      been completely deprecated, and its functions have no effect.
 
+  * `XMonad.Prompt.Unicode`
+
+    - `unicodePrompt :: String -> XPConfig -> X ()` now additionally takes a
+      filepath to the `UnicodeData.txt` file containing unicode data.
+
 ### New Modules
 
   * `XMonad.Hooks.Focus`
@@ -144,6 +149,16 @@
   * `XMonad.Config.Gnome`
 
     - Update logout key combination (modm+shift+Q) to work with modern
+
+  * `XMonad.Prompt.Unicode`
+
+    - Persist unicode data cache across XMonad instances due to
+      `ExtensibleState` now used instead of `unsafePerformIO`.
+    - `typeUnicodePrompt :: String -> XPConfig -> X ()` provided to insert the
+      Unicode character via `xdotool` instead of copying it to the paste buffer.
+    - `mkUnicodePrompt :: String -> [String] -> String -> XPConfig -> X ()`
+      acts as a generic function to pass the selected Unicode character to any
+      program.
 
 ## 0.13 (February 10, 2017)
 

--- a/XMonad/Prompt/Unicode.hs
+++ b/XMonad/Prompt/Unicode.hs
@@ -1,6 +1,7 @@
 {- |
 Module      :  XMonad.Prompt.Unicode
 Copyright   :  (c) 2016 Joachim Breitner
+                   2017 Nick Hu
 License     :  BSD-style (see LICENSE)
 
 Maintainer  :  <mail@joachim-breitner.de>
@@ -9,14 +10,18 @@ Stability   :  stable
 A prompt for searching unicode characters by name and inserting them into
 the clipboard.
 
-Requires the file @\/usr\/share\/unicode\/UnicodeData.txt@ (shipped in the package
-@unicode-data@ on Debian) and the @xsel@ tool.
+The provided @unicodePrompt@ and @typeUnicodePrompt@ use @xsel@ and @xdotool@
+respectively.
 -}
+
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module XMonad.Prompt.Unicode (
  -- * Usage
  -- $usage
- unicodePrompt
+ unicodePrompt,
+ typeUnicodePrompt,
+ mkUnicodePrompt
  ) where
 
 import qualified Data.ByteString.Char8 as BS
@@ -33,8 +38,22 @@ import Data.List
 import Text.Printf
 
 import XMonad
+import qualified XMonad.Util.ExtensibleState as XS
 import XMonad.Util.Run
 import XMonad.Prompt
+
+data Unicode = Unicode
+instance XPrompt Unicode where
+  showXPrompt Unicode = "Unicode: "
+  commandToComplete Unicode s = s
+  nextCompletion Unicode = getNextCompletion
+
+newtype UnicodeData = UnicodeData { getUnicodeData :: [(Char, BS.ByteString)] }
+  deriving (Typeable, Read, Show)
+
+instance ExtensionClass UnicodeData where
+  initialValue = UnicodeData []
+  extensionType = StateExtension
 
 {- $usage
 
@@ -46,54 +65,61 @@ You can use this module by importing it, along with
 
 and adding an appropriate keybinding, for example:
 
->  , ((modm .|. controlMask, xK_u), unicodePrompt def)
+>  , ((modm .|. controlMask, xK_u), unicodePrompt "/path/to/unicode-data" def)
 
+More flexibility is given by the @mkUnicodePrompt@ function, which takes a
+command and a list of arguments to pass as its first two arguments. See
+@unicodePrompt@ for details.
 -}
 
-unicodeDataFilename :: String
-unicodeDataFilename =  "/usr/share/unicode/UnicodeData.txt"
-
-entries :: [(Char, BS.ByteString)]
-entries = unsafePerformIO $ do
-    datE <- tryIOError $ BS.readFile unicodeDataFilename
-    case datE of
-        Left e -> do
-            hPutStrLn stderr $ "Could not read file \"" ++ unicodeDataFilename ++ "\""
-            hPutStrLn stderr $ show e
-            hPutStrLn stderr $ "Do you have unicode-data installed?"
-            return []
-        Right dat -> return $ sortBy (comparing (BS.length . snd)) $ parseUnicodeData dat
-{-# NOINLINE entries #-}
+populateEntries :: String -> X Bool
+populateEntries unicodeDataFilename = do
+  entries <- fmap getUnicodeData (XS.get :: X UnicodeData)
+  if null entries
+    then do
+      datE <- liftIO . tryIOError $ BS.readFile unicodeDataFilename
+      case datE of
+        Left e -> liftIO $ do
+          hPutStrLn stderr $ "Could not read file \"" ++ unicodeDataFilename ++ "\""
+          hPrint stderr e
+          hPutStrLn stderr "Do you have unicode-data installed?"
+          return False
+        Right dat -> do
+          XS.put . UnicodeData . sortBy (comparing (BS.length . snd)) $ parseUnicodeData dat
+          return True
+    else return True
 
 parseUnicodeData :: BS.ByteString -> [(Char, BS.ByteString)]
 parseUnicodeData = mapMaybe parseLine . BS.lines
-  where
-    parseLine l = do
-        field1 : field2 : _ <- return $ BS.split ';' l
-        [(c,"")] <- return $ readHex (BS.unpack field1)
-        return (chr c, field2)
+  where parseLine l = do
+          field1 : field2 : _ <- return $ BS.split ';' l
+          [(c,"")] <- return . readHex $ BS.unpack field1
+          return (chr c, field2)
 
-searchUnicode :: String -> [(Char, String)]
-searchUnicode s = map (second BS.unpack) $ filter go entries
-  where w = map BS.pack $  filter (all isAscii) $ filter ((> 1) . length) $ words $ map toUpper s
+searchUnicode :: [(Char, BS.ByteString)] -> String -> [(Char, String)]
+searchUnicode entries s = map (second BS.unpack) $ filter go entries
+  where w = map BS.pack . filter (all isAscii) . filter ((> 1) . length) . words $ map toUpper s
         go (c,d) = all (`BS.isInfixOf` d) w
 
--- | Prompt the user for a unicode character to be inserted into the paste buffer of the X server.
-unicodePrompt :: XPConfig -> X ()
-unicodePrompt config = mkXPrompt Unicode config unicodeCompl paste
+mkUnicodePrompt :: String -> [String] -> String -> XPConfig -> X ()
+mkUnicodePrompt prog args unicodeDataFilename config =
+  whenX (populateEntries unicodeDataFilename) $ do
+    entries <- fmap getUnicodeData (XS.get :: X UnicodeData)
+    mkXPrompt Unicode config (unicodeCompl entries) paste
   where
-    unicodeCompl [] = return []
-    unicodeCompl s = do
-        return $ map (\(c,d) -> printf "%s %s" [c] d) $ take 20 $ searchUnicode s
-
+    unicodeCompl _ [] = return []
+    unicodeCompl entries s = do
+      let m = searchUnicode entries s
+      return . map (\(c,d) -> printf "%s %s" [c] d) $ take 20 m
     paste [] = return ()
     paste (c:_) = do
-        runProcessWithInput "xsel" ["-i"] [c]
-        return ()
+      runProcessWithInput prog args [c]
+      return ()
 
-data Unicode = Unicode
-instance XPrompt Unicode where
-    showXPrompt Unicode = "Unicode: "
-    commandToComplete Unicode s = s
-    nextCompletion Unicode = getNextCompletion
+-- | Prompt the user for a Unicode character to be inserted into the paste buffer of the X server.
+unicodePrompt :: String -> XPConfig -> X ()
+unicodePrompt = mkUnicodePrompt "xsel" ["-i"]
 
+-- | Prompt the user for a Unicode character to be typed by @xdotool@.
+typeUnicodePrompt :: String -> XPConfig -> X ()
+typeUnicodePrompt = mkUnicodePrompt "xdotool" ["type", "--clearmodifiers", "--file", "-"]


### PR DESCRIPTION
### Description

I don't use Debian, and hardcoding the path doesn't seem great anyhow. Open to suggestions as to whether this is the best way to pass the file path around, or the argument order of `unicodePrompt`.

I also took out an `unsafePerformIO`, because it didn't seem necessary.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
