### PR TITLE
Added functions to perform actions with the first minimized window.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,11 @@
       changed and you want to re-sort windows into the appropriate
       sub-layout.
 
+  * `XMonad.Actions.Minimize`
+
+    - Now has `withFirstMinimized` and `withFirstMinimized'` so you can perform
+      actions with both the last and first minimized windows easily.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes

--- a/XMonad/Actions/Minimize.hs
+++ b/XMonad/Actions/Minimize.hs
@@ -29,6 +29,8 @@ module XMonad.Actions.Minimize
   , maximizeWindowAndFocus
   , withLastMinimized
   , withLastMinimized'
+  , withFirstMinimized
+  , withFirstMinimized'
   , withMinimized
   ) where
 
@@ -85,7 +87,7 @@ modified f = XS.modified $
        in Minimized { rectMap = newRectMap
                     , minimizedStack = (newWindows L.\\ oldStack)
                                        ++
-                                       (newWindows `L.intersect` oldStack)
+                                       (oldStack `L.intersect` newWindows)
                     }
 
 
@@ -114,6 +116,16 @@ maximizeWindow = maximizeWindowAndChangeWSet $ const id
 -- | Maximize a window and then focus it
 maximizeWindowAndFocus :: Window -> X ()
 maximizeWindowAndFocus = maximizeWindowAndChangeWSet W.focusWindow
+
+-- | Perform an action with first minimized window on current workspace
+--   or do nothing if there is no minimized windows on current workspace
+withFirstMinimized :: (Window -> X ()) -> X ()
+withFirstMinimized action = withFirstMinimized' (flip whenJust action)
+
+-- | Like withFirstMinimized but the provided action is always invoked with a
+--   'Maybe Window', that will be nothing if there is no first minimized window.
+withFirstMinimized' :: (Maybe Window -> X ()) -> X ()
+withFirstMinimized' action = withMinimized (action . listToMaybe . reverse)
 
 -- | Perform an action with last minimized window on current workspace
 --   or do nothing if there is no minimized windows on current workspace


### PR DESCRIPTION
### Description

I wanted to access the minimizedStack as if it were a queue, something which, despite the name, isn't a restriction to the module. The minimizedStack is just a `[Window]` anyways. This might not be particularly useful to many people, but it is to me.

I've compiled and am using the module with no errors, but have yet to write a minimal configuration for it to test with xmonad-testing. Given the size of the commit, I don't think this is *really* necessary, but let me know that I'm wrong.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
