### PR TITLE
Resubmit #128 (X.H.Focus)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,16 @@
     `XMonad.Layout.Fullscreen.fullscreenSupport` now advertises it as well,
     and no configuration changes are required in this case.
 
+
+  * `XMonad.Hooks.EwmhDesktops`
+
+    `ewmh` function will use `logHook` for handling activated window. And now
+    by default window activation will do nothing.
+
+    You can use regular `ManageHook` combinators for changing window
+    activation behavior and then add resulting `ManageHook` using
+    `activateLogHook` to your `logHook`.
+
   * `XMonad.Prompt.Directory`
 
     The `Dir` constructor now takes an additional `ComplCaseSensitivity`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,8 @@
 
     You can use regular `ManageHook` combinators for changing window
     activation behavior and then add resulting `ManageHook` using
-    `activateLogHook` to your `logHook`.
+    `activateLogHook` to your `logHook`. Also, module `X.H.Focus` provides
+    additional combinators.
 
   * `XMonad.Prompt.Directory`
 
@@ -108,6 +109,10 @@
 
     Provides a modifier that semi-permanently (requires manual intervention)
     disables borders for windows from the layout it modifies.
+
+  * `XMonad.Hooks.Focus`
+
+    Extends ManageHook EDSL to work on focused windows and current workspace.
 
 ### Bug Fixes and Minor Changes
 

--- a/XMonad/Config/Desktop.hs
+++ b/XMonad/Config/Desktop.hs
@@ -58,6 +58,7 @@ import XMonad
 import XMonad.Hooks.ManageDocks
 import XMonad.Hooks.EwmhDesktops
 import XMonad.Util.Cursor
+import qualified XMonad.StackSet as W
 
 import qualified Data.Map as M
 
@@ -167,10 +168,16 @@ import qualified Data.Map as M
 desktopConfig = docks $ ewmh def
     { startupHook     = setDefaultCursor xC_left_ptr <+> startupHook def
     , layoutHook      = desktopLayoutModifiers $ layoutHook def
+    , logHook         = desktopLogHook <+> logHook def
     , keys            = desktopKeys <+> keys def }
 
 desktopKeys (XConfig {modMask = modm}) = M.fromList $
     [ ((modm, xK_b), sendMessage ToggleStruts) ]
 
 desktopLayoutModifiers layout = avoidStruts layout
+
+-- | 'logHook' preserving old 'ewmh' behavior to switch workspace and focus to
+-- activated window.
+desktopLogHook :: X ()
+desktopLogHook      = activateLogHook (reader W.focusWindow >>= doF)
 

--- a/XMonad/Config/Example.hs
+++ b/XMonad/Config/Example.hs
@@ -30,7 +30,8 @@ main = do
     { modMask    = mod4Mask -- Use the "Win" key for the mod key
     , manageHook = myManageHook <+> manageHook desktopConfig
     , layoutHook = desktopLayoutModifiers $ myLayouts
-    , logHook    = dynamicLogString def >>= xmonadPropLog
+    , logHook    = (dynamicLogString def >>= xmonadPropLog)
+                    <+> logHook desktopConfig
     }
 
     `additionalKeysP` -- Add some extra key bindings:

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable     #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module       : XMonad.Hooks.EwmhDesktops
@@ -19,6 +21,9 @@ module XMonad.Hooks.EwmhDesktops (
     ewmhDesktopsStartup,
     ewmhDesktopsLogHook,
     ewmhDesktopsLogHookCustom,
+    NetActivated (..),
+    activated,
+    activateLogHook,
     ewmhDesktopsEventHook,
     ewmhDesktopsEventHookCustom,
     ewmhFullscreen,
@@ -42,6 +47,7 @@ import qualified XMonad.Util.ExtensibleState as E
 import XMonad.Util.XUtils (fi)
 import XMonad.Util.WorkspaceCompare
 import XMonad.Util.WindowProperties (getProp32)
+import qualified XMonad.Util.ExtensibleState as XS
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
@@ -56,7 +62,34 @@ import XMonad.Util.WindowProperties (getProp32)
 -- > main = xmonad $ ewmh def
 --
 -- You may also be interested in 'docks' from "XMonad.Hooks.ManageDocks".
-
+--
+-- __/NOTE:/__ 'ewmh' function will call 'logHook' for handling activated
+-- window.
+--
+-- And now by default window activation will do nothing: neither switch
+-- workspace, nor focus. You can use regular 'ManageHook' combinators for
+-- changing window activation behavior and then add resulting 'ManageHook'
+-- using 'activateLogHook' to your 'logHook'. Also, you may be interested in
+-- "XMonad.Hooks.Focus", which provides additional predicates for using in
+-- 'ManageHook'.
+--
+-- To get back old 'ewmh' window activation behavior (switch workspace and
+-- focus to activated window) you may use:
+--
+-- > import XMonad
+-- >
+-- > import XMonad.Hooks.EwmhDesktops
+-- > import qualified XMonad.StackSet as W
+-- >
+-- > main :: IO ()
+-- > main = do
+-- >         let acMh :: ManageHook
+-- >             acMh = reader W.focusWindow >>= doF
+-- >             xcf = ewmh $ def
+-- >                    { modMask = mod4Mask
+-- >                    , logHook = activateLogHook acMh <+> logHook def
+-- >                    }
+-- >         xmonad xcf
 
 -- | Add EWMH functionality to the given config.  See above for an example.
 ewmh :: XConfig a -> XConfig a
@@ -180,6 +213,40 @@ ewmhDesktopsEventHook = ewmhDesktopsEventHookCustom id
 ewmhDesktopsEventHookCustom :: ([WindowSpace] -> [WindowSpace]) -> Event -> X All
 ewmhDesktopsEventHookCustom f e = handle f e >> return (All True)
 
+-- | Whether new window _NET_ACTIVE_WINDOW activated or not. I should keep
+-- this value in global state, because i use 'logHook' for handling activated
+-- windows and i need a way to tell 'logHook' what window is activated.
+newtype NetActivated    = NetActivated {netActivated :: Maybe Window}
+  deriving (Show, Typeable)
+instance ExtensionClass NetActivated where
+    initialValue        = NetActivated Nothing
+
+-- | Was new window @_NET_ACTIVE_WINDOW@ activated?
+activated :: Query Bool
+activated           = fmap (isJust . netActivated) (liftX XS.get)
+
+-- | Run supplied 'ManageHook' for activated windows /only/. If you want to
+-- run this 'ManageHook' for new windows too, add it to 'manageHook'.
+--
+-- __/NOTE:/__ 'activateLogHook' will work only _once_. I.e. if several
+-- 'activateLogHook'-s was used, only first one will actually run (because it
+-- resets 'NetActivated' at the end and others won't know, that window is
+-- activated).
+activateLogHook :: ManageHook -> X ()
+activateLogHook mh  = XS.get >>= maybe (return ()) go . netActivated
+  where
+    go :: Window -> X ()
+    go w            = do
+        f <- runQuery mh w
+        -- I should reset 'NetActivated' here, because:
+        --  * 'windows' calls 'logHook' and i shouldn't go here the second
+        --  time for one window.
+        --  * if i reset 'NetActivated' before running 'logHook' once,
+        --  then 'activated' predicate won't match.
+        -- Thus, here is the /only/ correct place.
+        XS.put NetActivated{netActivated = Nothing}
+        windows (appEndo f)
+
 handle :: ([WindowSpace] -> [WindowSpace]) -> Event -> X ()
 handle f (ClientMessageEvent {
                ev_window = w,
@@ -204,8 +271,10 @@ handle f (ClientMessageEvent {
                if 0 <= n && fi n < length ws then
                        windows $ W.shiftWin (W.tag (ws !! fi n)) w
                  else  trace $ "Bad _NET_DESKTOP with data[0]="++show n
-        else if mt == a_aw then
-               windows $ W.focusWindow w
+        else if mt == a_aw then do
+               lh <- asks (logHook . config)
+               XS.put (NetActivated (Just w))
+               lh
         else if mt == a_cw then
                killWindow w
         else if mt `elem` a_ignore then

--- a/XMonad/Hooks/Focus.hs
+++ b/XMonad/Hooks/Focus.hs
@@ -1,0 +1,581 @@
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE DeriveDataTypeable     #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module:      XMonad.Hooks.Focus
+-- Copyright:   sgf-dma, 2016
+-- Maintainer:  sgf.dma@gmail.com
+--
+
+module XMonad.Hooks.Focus
+    (
+      -- $main
+
+      -- * FocusQuery.
+      --
+      -- $focusquery
+      Focus (..)
+    , FocusLock (..)
+    , toggleLock
+    , focusLockOn
+    , focusLockOff
+    , FocusQuery
+    , runFocusQuery
+    , FocusHook
+
+      -- * Lifting into FocusQuery.
+      --
+      -- $lift
+    , liftQuery
+    , new
+    , focused
+    , focused'
+    , focusedOn
+    , focusedOn'
+    , focusedCur
+    , focusedCur'
+    , newOn
+    , newOnCur
+    , unlessFocusLock
+
+      -- * Commonly used actions for modifying focus.
+      --
+      -- $common
+    , keepFocus
+    , switchFocus
+    , keepWorkspace
+    , switchWorkspace
+
+      -- * Running FocusQuery.
+      --
+      -- $running
+    , manageFocus
+
+      -- * Example configurations.
+      --
+      -- $examples
+    , activateSwitchWs
+    , activateOnCurrentWs
+    , activateOnCurrentKeepFocus
+    )
+  where
+
+import Data.Maybe
+import Data.Monoid
+import qualified Data.Semigroup as S
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Reader
+import Control.Arrow hiding ((<+>))
+
+import XMonad
+import qualified XMonad.StackSet as W
+import qualified XMonad.Util.ExtensibleState as XS
+import XMonad.Hooks.ManageHelpers (currentWs)
+import XMonad.Hooks.EwmhDesktops (activated, NetActivated(..))
+
+
+-- $main
+--
+-- This module provides monad on top of Query monad providing additional
+-- information about new window:
+--
+--  - workspace, where new window will appear;
+--  - focused window on workspace, where new window will appear;
+--  - current workspace;
+--
+-- And a property in extensible state:
+--
+--  - is focus lock enabled? Focus lock instructs all library's 'FocusHook'
+--  functions to not move focus or switch workspace.
+--
+-- Lifting operations for standard 'ManageHook' EDSL combinators into
+-- 'FocusQuery' monad allowing to run these combinators on focused window and
+-- common actions for keeping focus and\/or workspace, switching focus and\/or
+-- workspace are also provided.
+--
+-- == Quick start.
+--
+-- I may use one of predefined configurations.
+--
+-- 1. Default window activation behavior is to switch to workspace with
+--    activated window and switch focus to it:
+--
+--      > import XMonad
+--      >
+--      > import XMonad.Hooks.EwmhDesktops
+--      > import XMonad.Hooks.Focus
+--      >
+--      > main :: IO ()
+--      > main = do
+--      >         let mh :: ManageHook
+--      >             mh = activateSwitchWs
+--      >             xcf = ewmh $ def
+--      >                     { modMask = mod4Mask
+--      >                     , logHook = activateLogHook mh <+> logHook def
+--      >                     }
+--      >         xmonad xcf
+--
+-- 2. Or i may move activated window to current workspace and switch focus to
+--    it:
+--
+--      >         let mh :: ManageHook
+--      >             mh = activateOnCurrentWs
+--
+-- 3. Or move activated window to current workspace, but keep focus unchanged:
+--
+--      >         let mh :: ManageHook
+--      >             mh = activateOnCurrentKeepFocus
+--
+-- 4. I may use regular 'ManageHook' combinators for filtering, which windows
+--    may activate. E.g. activate all windows, except firefox:
+--
+--      >         let mh :: ManageHook
+--      >             mh  = not <$> (className =? "Firefox" <||> className =? "Firefox-esr" <||> className =? "Iceweasel")
+--      >                     --> activateSwitchWs
+--
+-- 5. Or even use 'FocusHook' combinators. E.g. activate all windows, unless
+--    xterm is focused on /current/ workspace:
+--
+--      >         let mh :: ManageHook
+--      >             mh  = manageFocus (not <$> focusedCur (className =? "XTerm")
+--      >                     --> liftQuery activateSwitchWs)
+--
+--      or activate all windows, unless focused window on the workspace,
+--      /where activated window is/, is not a xterm:
+--
+--      >         let mh :: ManageHook
+--      >             mh  = manageFocus (not <$> focused (className =? "XTerm")
+--      >                     --> liftQuery activateSwitchWs)
+--
+-- == Defining FocusHook.
+--
+-- I may define my own 'FocusHook' like:
+--
+-- >    activateFocusHook :: FocusHook
+-- >    activateFocusHook = composeAll
+-- >            -- If 'gmrun' is focused on workspace, on which
+-- >            -- /activated window/ is, keep focus unchanged. But i
+-- >            -- may still switch workspace (thus, i use 'composeAll').
+-- >            -- See 'keepFocus' properties in the docs below.
+-- >            [ focused (className =? "Gmrun")
+-- >                            --> keepFocus
+-- >            -- Default behavior for activated windows: switch
+-- >            -- workspace and focus.
+-- >            , return True   --> switchWorkspace <+> switchFocus
+-- >            ]
+-- >
+-- >    newFocusHook :: FocusHook
+-- >    newFocusHook      = composeOne
+-- >            -- Always switch focus to 'gmrun'.
+-- >            [ new (className =? "Gmrun")        -?> switchFocus
+-- >            -- And always keep focus on 'gmrun'. Note, that
+-- >            -- another 'gmrun' will steal focus from already
+-- >            -- running one.
+-- >            , focused (className =? "Gmrun")    -?> keepFocus
+-- >            -- If firefox dialog prompt (e.g. master password
+-- >            -- prompt) is focused on current workspace and new
+-- >            -- window appears here too, keep focus unchanged
+-- >            -- (note, used predicates: @newOnCur <&&> focused@ is
+-- >            -- the same as @newOnCur <&&> focusedCur@, but is
+-- >            -- /not/ the same as just 'focusedCur' )
+-- >            , newOnCur <&&> focused
+-- >                ((className =? "Firefox" <||> className =? "Firefox-esr" <||> className =? "Iceweasel") <&&> isDialog)
+-- >                                                -?> keepFocus
+-- >            -- Default behavior for new windows: switch focus.
+-- >            , return True                       -?> switchFocus
+-- >            ]
+--
+-- And then use it:
+--
+-- >    import XMonad
+-- >    import XMonad.Util.EZConfig
+-- >
+-- >    import XMonad.Hooks.EwmhDesktops
+-- >    import XMonad.Hooks.ManageHelpers
+-- >    import XMonad.Hooks.Focus
+-- >
+-- >
+-- >    main :: IO ()
+-- >    main = do
+-- >            let newFh :: ManageHook
+-- >                newFh = manageFocus newFocusHook
+-- >                acFh :: X ()
+-- >                acFh = activateLogHook (manageFocus activateFocusHook)
+-- >                xcf = ewmh $ def
+-- >                             { manageHook   = newFh <+> manageHook def
+-- >                             , logHook      = acFh  <+> logHook def
+-- >                             , modMask      = mod4Mask
+-- >                             }
+-- >                        `additionalKeys` [((mod4Mask, xK_v), toggleLock)]
+-- >            xmonad xcf
+--
+-- Note:
+--
+--  - /mod4Mask+v/ key toggles focus lock (when enabled, neither focus nor
+--  workspace won't be switched).
+--  - I need 'XMonad.Hooks.EwmhDesktops' module for enabling window
+--  activation.
+--  - 'FocusHook' in 'manageHook' will be called /only/ for new windows.
+--  - 'FocusHook' in 'logHook' will be called /only/ for activated windows.
+--
+--  Alternatively, i may construct a single 'FocusHook' for both new and
+--  activated windows and then just add it to both 'manageHook' and 'logHook':
+--
+-- >            let fh :: ManageHook
+-- >                fh = manageFocus $ (composeOne
+-- >                        [ liftQuery activated -?> activateFocusHook
+-- >                        , Just <$> newFocusHook
+-- >                        ])
+-- >                xcf = ewmh $ def
+-- >                             { manageHook   = fh <+> manageHook def
+-- >                             , logHook      = activateLogHook fh <+> logHook def
+-- >                             , modMask      = mod4Mask
+-- >                             }
+-- >                        `additionalKeys` [((mod4Mask, xK_v), toggleLock)]
+--
+-- Note:
+--  - Predicate 'activated' will be 'True' for activated window.
+--  - The order, when constructing final 'FocusHook': 'FocusHook' without
+--  'activated' predicate will match to activated windows too, thus i should
+--  place it after one with 'activated' (so the latter will have a chance to
+--  handle activated window first).
+--
+-- And more technical notes:
+--
+--  - 'FocusHook' will run /many/ times, so it usually should not keep state
+--  or save results. Precisely, it may do anything, but it must be idempotent
+--  to operate properly.
+--  - 'FocusHook' will see new window at workspace, where functions on the
+--  /right/ from it in 'ManageHook' monoid place it.  In other words, in
+--  @(Endo WindowSet)@ monoid i may see changes only from functions applied
+--  /before/ (more to the right in function composition). Thus, it's better to
+--  add 'FocusHook' the last.
+--  - 'FocusHook' functions won't see window shift to another workspace made
+--  by function from 'FocusHook' itself: new window workspace is determined
+--  /before/ running 'FocusHook' and even if later one of 'FocusHook'
+--  functions moves window to another workspace, predicates ('focused',
+--  'newOn', etc) will still think new window is at workspace it was before.
+--  This can be worked around by splitting 'FocusHook' into several different
+--  values and evaluating each one separately, like:
+--
+--      > (FH2 -- manageFocus --> MH2) <+> (FH1 -- manageFocus --> MH1) <+> ..
+--
+--      E.g.
+--
+--      > manageFocus FH2 <+> manageFocus FH1 <+> ..
+--
+--      now @FH2@ will see window shift made by @FH1@.
+--
+--      Also, note, that if several 'activateLogHook'-s are sequenced, only
+--      /first/ one (leftmost) will run. Thus, to make above working,
+--      'mappend' all 'ManageHook'-s first, and then run by /single/
+--      'activateLogHook' (see next example).
+--
+-- Another interesting example is moving all activated windows to current
+-- workspace by default, and applying 'FocusHook' after:
+--
+-- >    import XMonad
+-- >    import XMonad.Util.EZConfig
+-- >
+-- >    import XMonad.Hooks.EwmhDesktops
+-- >    import XMonad.Hooks.ManageHelpers
+-- >    import XMonad.Hooks.Focus
+-- >
+-- >    main :: IO ()
+-- >    main = do
+-- >            let fh :: ManageHook
+-- >                fh = manageFocus $ (composeOne
+-- >                        [ liftQuery activated -?> (newOnCur --> keepFocus)
+-- >                        , Just <$> newFocusHook
+-- >                        ])
+-- >                xcf = ewmh $ def
+-- >                             { manageHook = fh <+> manageHook def
+-- >                             , logHook    = activateLogHook (fh <+> activateOnCurrentWs) <+> logHook def
+-- >                             , modMask    = mod4Mask
+-- >                             }
+-- >                        `additionalKeys` [((mod4Mask, xK_v), toggleLock)]
+-- >            xmonad xcf
+-- >
+-- >    newFocusHook :: FocusHook
+-- >    newFocusHook      = composeOne
+-- >            -- Always switch focus to 'gmrun'.
+-- >            [ new (className =? "Gmrun")        -?> switchFocus
+-- >            -- And always keep focus on 'gmrun'. Note, that
+-- >            -- another 'gmrun' will steal focus from already
+-- >            -- running one.
+-- >            , focused (className =? "Gmrun")    -?> keepFocus
+-- >            -- If firefox dialog prompt (e.g. master password
+-- >            -- prompt) is focused on current workspace and new
+-- >            -- window appears here too, keep focus unchanged
+-- >            -- (note, used predicates: @newOnCur <&&> focused@ is
+-- >            -- the same as @newOnCur <&&> focusedCur@, but is
+-- >            -- /not/ the same as just 'focusedCur' )
+-- >            , newOnCur <&&> focused
+-- >                ((className =? "Firefox" <||> className =? "Firefox-esr" <||> className =? "Iceweasel") <&&> isDialog)
+-- >                                                -?> keepFocus
+-- >            -- Default behavior for new windows: switch focus.
+-- >            , return True                       -?> switchFocus
+-- >            ]
+--
+-- Note here:
+--
+--  - i keep focus, when activated window appears on current workspace, in
+--  this example.
+--  - when @liftQuery activated -?> (newOnCur --> keepFocus)@ runs, activated
+--  window will be /already/ on current workspace, thus, if i do not want to
+--  move some activated windows, i should filter them out before applying
+--  @activateOnCurrentWs@ 'FocusHook'.
+--  - i 'mappend' all 'ManageHook'-s and run 'activateLogHook' only once.
+
+
+-- FocusQuery.
+-- $focusquery
+
+-- | Information about current workspace and focus.
+data Focus          = Focus
+                        { -- | Workspace, where new window appears.
+                          newWorkspace      :: WorkspaceId
+                          -- | Focused window on workspace, where new window
+                          -- appears.
+                        , focusedWindow     :: Maybe Window
+                          -- | Current workspace.
+                        , currentWorkspace  :: WorkspaceId
+                        }
+  deriving (Show)
+instance Default Focus where
+    def             = Focus
+                        { focusedWindow     = Nothing
+                        , newWorkspace      = ""
+                        , currentWorkspace  = ""
+                        }
+
+newtype FocusLock   = FocusLock {getFocusLock :: Bool}
+  deriving (Show, Typeable)
+instance ExtensionClass FocusLock where
+    initialValue    = FocusLock False
+
+-- | Toggle stored focus lock state.
+toggleLock :: X ()
+toggleLock          = XS.modify (\(FocusLock b) -> FocusLock (not b))
+
+-- | Lock focus.
+focusLockOn :: X ()
+focusLockOn         = XS.modify (const (FocusLock True))
+
+-- | Unlock focus.
+focusLockOff :: X ()
+focusLockOff        = XS.modify (const (FocusLock False))
+
+-- | Monad on top of 'Query' providing additional information about new
+-- window.
+newtype FocusQuery a = FocusQuery (ReaderT Focus Query a)
+instance Functor FocusQuery where
+    fmap f (FocusQuery x) = FocusQuery (fmap f x)
+instance Applicative FocusQuery where
+    pure x                              = FocusQuery (pure x)
+    (FocusQuery f) <*> (FocusQuery mx)  = FocusQuery (f <*> mx)
+instance Monad FocusQuery where
+    return x                = FocusQuery (return x)
+    (FocusQuery mx) >>= f   = FocusQuery $ mx >>= \x ->
+                              let FocusQuery y = f x in y
+instance MonadReader Focus FocusQuery where
+    ask                     = FocusQuery ask
+    local f (FocusQuery mx) = FocusQuery (local f mx)
+instance MonadIO FocusQuery where
+    liftIO mx       = FocusQuery (liftIO mx)
+instance S.Semigroup a => S.Semigroup (FocusQuery a) where
+    (<>)            = liftM2 (S.<>)
+instance Monoid a => Monoid (FocusQuery a) where
+    mempty          = return mempty
+    mappend         = (<>)
+
+runFocusQuery :: FocusQuery a -> Focus -> Query a
+runFocusQuery (FocusQuery m)    = runReaderT m
+
+type FocusHook      = FocusQuery (Endo WindowSet)
+
+
+-- Lifting into 'FocusQuery'.
+-- $lift
+
+-- | Lift 'Query' into 'FocusQuery' monad. The same as 'new'.
+liftQuery :: Query a -> FocusQuery a
+liftQuery           = FocusQuery . lift
+
+-- | Run 'Query' on new window.
+new :: Query a -> FocusQuery a
+new                 = liftQuery
+
+-- | Run 'Query' on focused window on workspace, where new window appears. If
+-- there is no focused window, return 'False'.
+focused :: Query Bool -> FocusQuery Bool
+focused m           = getAny <$> focused' (Any <$> m)
+-- | More general version of 'focused'.
+focused' :: Monoid a => Query a -> FocusQuery a
+focused' m          = do
+    mw <- asks focusedWindow
+    liftQuery (maybe mempty (flip local m . const) mw)
+
+-- | Run 'Query' on window focused at particular workspace. If there is no
+-- focused window, return 'False'.
+focusedOn :: WorkspaceId -> Query Bool -> FocusQuery Bool
+focusedOn i m       = getAny <$> focusedOn' i (Any <$> m)
+-- | More general version of 'focusedOn'.
+focusedOn' :: Monoid a => WorkspaceId -> Query a -> FocusQuery a
+focusedOn' i m      = liftQuery $ do
+    mw <- liftX $ withWindowSet (return . W.peek . W.view i)
+    maybe mempty (flip local m . const) mw
+
+-- | Run 'Query' on focused window on current workspace. If there is no
+-- focused window, return 'False'.  Note,
+--
+-- > focused <&&> newOnCur != focusedCur
+--
+-- The first will affect only new or activated window appearing on current
+-- workspace, while the last will affect any window: focus even for windows
+-- appearing on other workpsaces will depend on focus on /current/ workspace.
+focusedCur :: Query Bool -> FocusQuery Bool
+focusedCur m        = getAny <$> focusedCur' (Any <$> m)
+-- | More general version of 'focusedCur'.
+focusedCur' :: Monoid a => Query a -> FocusQuery a
+focusedCur' m       = asks currentWorkspace >>= \i -> focusedOn' i m
+
+-- | Does new window appear at particular workspace?
+newOn :: WorkspaceId -> FocusQuery Bool
+newOn i             = (i ==) <$> asks newWorkspace
+-- | Does new window appear at current workspace?
+newOnCur :: FocusQuery Bool
+newOnCur            = asks currentWorkspace >>= newOn
+
+-- | Execute 'Query', unless focus is locked.
+unlessFocusLock :: Monoid a => Query a -> Query a
+unlessFocusLock m   = do
+    FocusLock b <- liftX XS.get
+    when' (not b) m
+
+-- Commonly used actions for modifying focus.
+--
+-- $common
+-- Operations in each pair 'keepFocus' and 'switchFocus', 'keepWorkspace' and
+-- 'switchWorkspace' overwrite each other (the letftmost will determine what
+-- happened):
+--
+-- prop> keepFocus       <+> switchFocus     = keepFocus
+-- prop> switchFocus     <+> keepFocus       = switchFocus
+-- prop> keepWorkspace   <+> switchWorkspace = keepWorkspace
+-- prop> switchWorkspace <+> keepWorkspace   = switchWorkspace
+--
+-- and operations from different pairs are commutative:
+--
+-- prop> keepFocus   <+> switchWorkspace = switchWorkspace <+> keepFocus
+-- prop> switchFocus <+> switchWorkspace = switchWorkspace <+> switchFocus
+--
+-- etc.
+
+-- | Keep focus on workspace (may not be current), where new window appears.
+-- Workspace will not be switched. This operation is idempotent and
+-- effectively returns focus to window focused on that workspace before
+-- applying @(Endo WindowSet)@ function.
+keepFocus :: FocusHook
+keepFocus           = focused' $ ask >>= \w -> doF $ \ws ->
+                        W.view (W.currentTag ws) . W.focusWindow w $ ws
+
+-- | Switch focus to new window on workspace (may not be current), where new
+-- window appears. Workspace will not be switched. This operation is
+-- idempotent.
+switchFocus :: FocusHook
+switchFocus         = do
+    FocusLock b <- liftQuery . liftX $ XS.get
+    if b
+      -- When focus lock is enabled, call 'keepFocus' explicitly (still no
+      -- 'keepWorkspace') to overwrite default behavior.
+      then keepFocus
+      else new $ ask >>= \w -> doF $ \ws ->
+            W.view (W.currentTag ws) . W.focusWindow w $ ws
+
+-- | Keep current workspace. Focus will not be changed at either current or
+-- new window's  workspace. This operation is idempotent and effectively
+-- switches to workspace, which was current before applying @(Endo WindowSet)@
+-- function.
+keepWorkspace :: FocusHook
+keepWorkspace       = do
+    ws <- asks currentWorkspace
+    liftQuery . doF $ W.view ws
+
+-- | Switch workspace to one, where new window appears. Focus will not be
+-- changed at either current or new window's workspace. This operation is
+-- idempotent.
+switchWorkspace :: FocusHook
+switchWorkspace     = do
+    FocusLock b <- liftQuery . liftX $ XS.get
+    if b
+      -- When focus lock is enabled, call 'keepWorkspace' explicitly (still no
+      -- 'keepFocus') to overwrite default behavior.
+      then keepWorkspace
+      else do
+        ws <- asks newWorkspace
+        liftQuery . doF $ W.view ws
+
+-- Running FocusQuery.
+-- $running
+
+-- | I don't know at which workspace new window will appear until @(Endo
+-- WindowSet)@ function from 'windows' in "XMonad.Operations" actually run,
+-- but in @(Endo WindowSet)@ function i can't already execute monadic actions,
+-- because it's pure. So, i compute result for every workspace here and just
+-- use it later in @(Endo WindowSet)@ function.  Note, though, that this will
+-- execute monadic actions many times, and therefore assume, that result of
+-- 'FocusHook' does not depend on the number of times it was executed.
+manageFocus :: FocusHook -> ManageHook
+manageFocus m       = do
+    fws <- liftX . withWindowSet $ return
+      . map (W.tag &&& fmap W.focus . W.stack) . W.workspaces
+    ct  <- currentWs
+    let r = def {currentWorkspace = ct}
+    hs <- forM fws $ \(i, mw) -> do
+      f <- runFocusQuery m (r {focusedWindow = mw, newWorkspace = i})
+      return (i, f)
+    reader (selectHook hs) >>= doF
+  where
+    -- | Select and apply @(Endo WindowSet)@ function depending on which
+    -- workspace new window appeared now.
+    selectHook :: [(WorkspaceId, Endo WindowSet)] -> Window -> WindowSet -> WindowSet
+    selectHook cfs nw ws    = fromMaybe ws $ do
+        i <- W.findTag nw ws
+        f <- lookup i cfs
+        return (appEndo f ws)
+
+when' :: (Monad m, Monoid a) => Bool -> m a -> m a
+when' b mx
+  | b               = mx
+  | otherwise       = return mempty
+
+-- Exmaple configurations.
+-- $examples
+
+-- | Default EWMH window activation behavior: switch to workspace with
+-- activated window and switch focus to it.
+activateSwitchWs :: ManageHook
+activateSwitchWs    = manageFocus (liftQuery activated -->
+                        switchWorkspace <+> switchFocus)
+
+-- | Move activated window to current workspace.
+activateOnCurrent' :: ManageHook
+activateOnCurrent'  = activated --> currentWs >>= unlessFocusLock . doShift
+
+-- | Move activated window to current workspace and switch focus to it. Note,
+-- that i need to explicitly call 'switchFocus' here, because otherwise, when
+-- activated window is /already/ on current workspace, focus won't be
+-- switched.
+activateOnCurrentWs :: ManageHook
+activateOnCurrentWs = manageFocus (liftQuery activated <&&> newOnCur --> switchFocus)
+                        <+> activateOnCurrent'
+
+-- | Move activated window to current workspace, but keep focus unchanged.
+activateOnCurrentKeepFocus :: ManageHook
+activateOnCurrentKeepFocus  = manageFocus (liftQuery activated <&&> newOnCur --> keepFocus)
+                        <+> activateOnCurrent'
+

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -74,8 +74,8 @@ data Match a = Match Bool a
 -- | An alternative 'ManageHook' composer. Unlike 'composeAll' it stops as soon as
 -- a candidate returns a 'Just' value, effectively running only the first match
 -- (whereas 'composeAll' continues and executes all matching rules).
-composeOne :: [MaybeManageHook] -> ManageHook
-composeOne = foldr try idHook
+composeOne :: (Monoid a, Monad m) => [m (Maybe a)] -> m a
+composeOne = foldr try (return mempty)
     where
     try q z = do
         x <- q
@@ -86,17 +86,17 @@ composeOne = foldr try idHook
 infixr 0 -?>, -->>, -?>>
 
 -- | q \/=? x. if the result of q equals x, return False
-(/=?) :: Eq a => Query a -> a -> Query Bool
+(/=?) :: (Eq a, Functor m) => m a -> a -> m Bool
 q /=? x = fmap (/= x) q
 
 -- | q <==? x. if the result of q equals x, return True grouped with q
-(<==?) :: Eq a => Query a -> a -> Query (Match a)
+(<==?) :: (Eq a, Functor m) => m a -> a -> m (Match a)
 q <==? x = fmap (`eq` x) q
     where
     eq q' x' = Match (q' == x') q'
 
 -- | q <\/=? x. if the result of q notequals x, return True grouped with q
-(</=?) :: Eq a => Query a -> a -> Query (Match a)
+(</=?) :: (Eq a, Functor m) => m a -> a -> m (Match a)
 q </=? x = fmap (`neq` x) q
     where
     neq q' x' = Match (q' /= x') q'
@@ -104,19 +104,19 @@ q </=? x = fmap (`neq` x) q
 -- | A helper operator for use in 'composeOne'. It takes a condition and an action;
 -- if the condition fails, it returns 'Nothing' from the 'Query' so 'composeOne' will
 -- go on and try the next rule.
-(-?>) :: Query Bool -> ManageHook -> MaybeManageHook
+(-?>) :: (Functor m, Monad m) => m Bool -> m a -> m (Maybe a)
 p -?> f = do
     x <- p
     if x then fmap Just f else return Nothing
 
 -- | A helper operator for use in 'composeAll'. It takes a condition and a function taking a grouped datum to action.  If 'p' is true, it executes the resulting action.
-(-->>) :: Query (Match a) -> (a -> ManageHook) -> ManageHook
+(-->>) :: (Monoid b, Monad m) => m (Match a) -> (a -> m b) -> m b
 p -->> f = do
     Match b m <- p
-    if b then (f m) else mempty
+    if b then (f m) else return mempty
 
 -- | A helper operator for use in 'composeOne'.  It takes a condition and a function taking a groupdatum to action.  If 'p' is true, it executes the resulting action.  If it fails, it returns 'Nothing' from the 'Query' so 'composeOne' will go on and try the next rule.
-(-?>>) :: Query (Match a) -> (a -> ManageHook) -> MaybeManageHook
+(-?>>) :: (Functor m, Monad m) => m (Match a) -> (a -> m b) -> m (Maybe b)
 p -?>> f = do
     Match b m <- p
     if b then fmap  Just (f m) else return Nothing
@@ -180,7 +180,7 @@ transience' :: ManageHook
 transience' = maybeToDefinite transience
 
 -- | converts 'MaybeManageHook's to 'ManageHook's
-maybeToDefinite :: MaybeManageHook -> ManageHook
+maybeToDefinite :: (Monoid a, Functor m) => m (Maybe a) -> m a
 maybeToDefinite = fmap (fromMaybe mempty)
 
 

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -179,6 +179,7 @@ library
                         XMonad.Hooks.FadeInactive
                         XMonad.Hooks.FadeWindows
                         XMonad.Hooks.FloatNext
+                        XMonad.Hooks.Focus
                         XMonad.Hooks.ICCCMFocus
                         XMonad.Hooks.InsertPosition
                         XMonad.Hooks.ManageDebug


### PR DESCRIPTION
Resubmit #128 with changes requested in #162 .

@pjones , @geekosaur  Please, test and review.

@SirBoonami , @unclechu Please, try updated version. Now `logHook` (instead of `manageHook`) runs for activated window. Thus, if you use this module for managing focus _only_ for activated windows, you need to add `FocusHook` to your `logHook`. E.g.

    logHook = activateLogHook activateSwitchWs

If you use `FocusHook` for managing focus for _both_ new and activated windows, you need to add it to _both_. Either create two different `FocusHook`-s, e.g.:

    let newFh :: ManageHook
        newFh = manageFocus newFocusHook
        acFh :: X ()
        acFh = activateLogHook (manageFocus activateFocusHook)
        xcf = ewmh $ def
                     { manageHook   = newFh <+> manageHook def
                     , logHook      = acFh  <+> logHook def
                     }

or (as was before) use the single `FocusHook` with `activated` predicate, e.g.:

    let fh :: ManageHook
        fh = manageFocus $ (composeOne
                [ liftQuery activated -?> activateFocusHook
                , Just <$> newFocusHook
                ])
        xcf = ewmh $ def
                     { manageHook   = fh <+> manageHook def
                     , logHook      = activateLogHook fh <+> logHook def
                     }

See description for more examples and details.

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
