### PR TITLE
Add XMonad.Util.SessionStart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,14 @@
     Also provides the `repeatableAction` helper function which can be used to
     build actions that can be repeated while a modifier key is held down.
 
+  * `XMonad.Utils.SessionStart`
+
+    A new module that allows to query if this is the first time xmonad is
+    started of the session, or a xmonad restart.
+
+    Currently needs manual setting of the session start flag. This could be
+    automated when this moves to the core repository.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Layout.LayoutHints`

--- a/XMonad/Util/SessionStart.hs
+++ b/XMonad/Util/SessionStart.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Util.SessionStart
+-- Copyright   :  (c) Markus Ongyerth 2017
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  markus@ongy.net
+-- Stability   :  unstable
+-- Portability :  not portable
+--
+-- A module for detectiong session startup.  Useful to start
+-- status bars, compositors and session initialization.
+-- This is a more general approach than spawnOnce and allows spawnOn etc.
+-----------------------------------------------------------------------------
+
+module XMonad.Util.SessionStart
+    ( doOnce
+    , isSessionStart
+    , setSessionStarted
+    )
+where
+
+import Control.Monad (when)
+import Control.Applicative ((<$>))
+
+import XMonad
+import qualified XMonad.Util.ExtensibleState as XS
+
+-- ---------------------------------------------------------------------
+-- $usage
+--
+-- Add 'setSessionStarted' at the end of the 'startupHook' to set the
+-- flag.
+--
+-- To do something only when the session is started up, use 
+-- 'isSessionStart' to query or wrap it in 'doOnce' to only do it when
+-- the flag isn't set.
+-- ---------------------------------------------------------------------
+
+data SessionStart = SessionStart { unSessionStart :: Bool }
+    deriving (Read, Show, Typeable)
+
+instance ExtensionClass SessionStart where
+    initialValue = SessionStart True
+    extensionType = PersistentExtension
+
+-- | Use this to only do a part of your hook on session start
+doOnce :: X () -> X ()
+doOnce act = do
+    startup <- isSessionStart
+    when startup act
+
+-- | Query if the current startup is the session start
+isSessionStart :: X Bool
+isSessionStart = unSessionStart <$> XS.get
+
+-- This should become a noop/be deprecated when merged into master, and
+-- the flag should be set when the state file is loaded.
+-- | This currently has to be added to the end of the startup hook to
+-- set the flag.
+setSessionStarted :: X ()
+setSessionStarted = XS.put $ SessionStart False

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -327,6 +327,7 @@ library
                         XMonad.Util.Run
                         XMonad.Util.Scratchpad
                         XMonad.Util.SpawnNamedPipe
+                        XMonad.Util.SessionStart
                         XMonad.Util.SpawnOnce
                         XMonad.Util.Stack
                         XMonad.Util.StringProp


### PR DESCRIPTION
### Description

I added a `XMonad.Util.SessoinStart` module to include a way to check if we are currently starting the session, or restarting xmonad in the startupHook.
This is a more general approach than `spawnOnce` which e.g. allows to use `spawnOn`.

Currently this requires to manually set a flag in the ExtensibleState (at the end of startupHook). If this is moved to the core repository at some point, this can be done automatically when the state file is read.

### Checklist

  - [✓] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [✓] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [✓] I updated the `CHANGES.md` file
