### PR TITLE
README.md: Update links and add contributing info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ You need the ghc compiler and xmonad window manager installed in
 order to use these extensions.
 
 For installation and configuration instructions, please see the
-[xmonad website] [xmonad], the documents included with the
-[xmonad source distribution] [xmonad-git], and the
-[online haddock documentation] [xmonad-docs].
+[xmonad website][xmonad], the documents included with the
+[xmonad source distribution][xmonad-git], and the
+[online haddock documentation][xmonad-docs].
 
 ## Getting or Updating XMonadContrib
 
@@ -17,7 +17,7 @@ For installation and configuration instructions, please see the
   * Git version: <https://github.com/xmonad/xmonad-contrib>
 
 (To use git xmonad-contrib you must also use the
-[git version of xmonad] [xmonad-git].)
+[git version of xmonad][xmonad-git].)
 
 ## Contributing
 
@@ -28,15 +28,15 @@ example, to use the Grid layout, one would import:
 
     XMonad.Layout.Grid
 
-For further details, see the [documentation] [developing] for the
-`XMonad.Doc.Developing` module and the [xmonad website] [xmonad].
+For further details, see the [documentation][developing] for the
+`XMonad.Doc.Developing` module, XMonad's [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)  and the [xmonad website][xmonad].
 
 ## License
 
 Code submitted to the contrib repo is licensed under the same license as
 xmonad itself, with copyright held by the authors.
-
+ 
 [xmonad]: http://xmonad.org
 [xmonad-git]: https://github.com/xmonad/xmonad
-[xmonad-docs]: http://www.xmonad.org/xmonad-docs
-[developing]: http://xmonad.org/xmonad-docs/xmonad-contrib/XMonad-Doc-Developing.html
+[xmonad-docs]: http://hackage.haskell.org/package/xmonad
+[developing]: http://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Doc-Developing.html


### PR DESCRIPTION
### Description

The links are updated to point to Hackage rather than xmonad.org since not all redirects work correctly. For example the link to developing documentation went to the main XMonad's Hackage page instead of XMonad.Docs.Extending on Hackage.

Secondly, the links are changed such that their [id]-tag isn't showing.

Lastly, a link to XMonad's contributing.md has been added.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
