### PR TITLE
Fix Gnome config modm+shift+Q logout command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,11 @@
       changed and you want to re-sort windows into the appropriate
       sub-layout.
 
+  * `XMonad.Config.Gnome`
+
+    - Update logout key combination (modm+shift+Q) to work with modern
+      versions of GNOME
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes

--- a/XMonad/Config/Gnome.hs
+++ b/XMonad/Config/Gnome.hs
@@ -47,7 +47,7 @@ gnomeConfig = desktopConfig
 
 gnomeKeys (XConfig {modMask = modm}) = M.fromList $
     [ ((modm, xK_p), gnomeRun)
-    , ((modm .|. shiftMask, xK_q), spawn "gnome-session-save --kill") ]
+    , ((modm .|. shiftMask, xK_q), spawn "gnome-session-quit --logout") ]
 
 -- | Launch the "Run Application" dialog.  gnome-panel must be running for this
 -- to work.


### PR DESCRIPTION
### Description

The modm+shift+Q key combination in `XMonad.Config.Gnome` is supposed to open the logout dialog, but it tries to run a command that doesn't work with modern GNOME versions.

The `--kill` option was deprecated in [2.23.x (year 2008)](https://github.com/GNOME/gnome-session/blob/c91d138b33a96cf9ccc36893899db9abb8f272bb/NEWS#L1843)

`gnome-session-save` was renamed to `gnome-session-quit` in [2.91.x (year 2011)](https://github.com/GNOME/gnome-session/blob/c91d138b33a96cf9ccc36893899db9abb8f272bb/NEWS#L988)

I didn't test this change with xmonad-testing, but have used the fix in my config for a while with Ubuntu 17.04 (GNOME 3.22.0).

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
