### PR TITLE
Export XMonad.Prompt.insertString.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,10 @@
 
     Make type of ManageHook combinators more general.
 
+  * `XMonad.Prompt`
+
+    Export `insertString`.
+
   * `XMonad.Prompt.Window`
 
     - New function: `windowMultiPrompt` for using `mkXPromptWithModes`

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -35,7 +35,7 @@ module XMonad.Prompt
     , emacsLikeXPKeymap, emacsLikeXPKeymap'
     , quit
     , killBefore, killAfter, startOfLine, endOfLine
-    , pasteString, moveCursor
+    , insertString, pasteString, moveCursor
     , setInput, getInput
     , moveWord, moveWord', killWord, killWord', deleteString
     , moveHistory, setSuccess, setDone


### PR DESCRIPTION
### Description

Background: I am trying to add some shortcuts for XPrompt, for example,
when doing `Ctrl-V`, text in my clipboard will be pasted into prompt. The
best way to do this is to use the function `insertString`, but I surprisingly
find that it is not exported.

The current work around is to use `setInput`, but it loses track of the cursor position.
```haskell
myPromptKeymap = M.union defaultXPKeymap $ M.fromList
  [ ((controlMask, xK_v), setInput =<< liftIO getClipboard) 
  ]
```

As I have seen that `deleteString` is also exported, so I think there is no downside to
export this function. 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
