### PR TITLE
Generalised hybridNavigation to hybridOf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,10 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Actions.Navigation2D`
+
+    Generalised (and hence deprecated) hybridNavigation to hybridOf.
+
   * `XMonad.Layout.LayoutHints`
 
     Preserve the window order of the modified layout, except for the focused


### PR DESCRIPTION
### Description

Previously in #77 I wrote a very simple hybrid navigation strategy for Navigation2D, taking advantage of what was already written. It prioritised target windows found by lineNavigation over those found by centerNavigation, and due to relevant functions/constructors not being exposed by the module this wasn't able to be changed on the user end. This became a noticeable problem for me recently when I started using a layout with one window in a narrow vertical master pane and the rest of the screen in a grid, resulting in window configurations like the below:
![configuration](https://i.imgur.com/E6OuUPH.png)

In these cases lineNavigation—and hence hybridNavigation—move focus between the leftmost and rightmost windows, not able to reach the others. I don't use multiple screens so I can't confirm, but this may also be behind the comment @pjones left on a commit in the original PR. The behaviour should be expected so I don't consider it a bug as such, but changing the order of prioritisation to prefer centerNavigation would prevent the middle row getting skipped. Electing to generalise and allow either order (as well as hybrids with any future navigation strategies), I wrote and exposed hybridOf. It takes two exposed Navigation2D instances and returns a third that attempts the first, falling back on the second if it finds no target window.

hybridNavigation is hence redefined as `hybridOf lineNavigation centerNavigation` and deprecated.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)
    - [x] Actively tested against current git versions of xmonad & xmonad-contrib, just not within xmonad-testing. Hopefully that's OK, since it's such a minor change.

  - [x] I updated the `CHANGES.md` file
