### PR TITLE
Added X.A.InputMode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,12 @@
 
     Currently needs manual setting of the session start flag. This could be
     automated when this moves to the core repository.
+    
+ * `XMonad.Actions.InputMode`
+
+    A new Module that allows to declare a temporary keybindings Map. It's
+    built on top of `XMonad.Actions.Submap` by creating a recursive
+    submap that re-activate itself after each action.
 
 ### Bug Fixes and Minor Changes
 

--- a/XMonad/Actions/InputMode.hs
+++ b/XMonad/Actions/InputMode.hs
@@ -1,0 +1,65 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Actions.InputMode
+-- Copyright   :  (c) Bruno Dupuis <lisael@lisael.org>
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  Bruno Dupuis <lisael@lisael.org>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- A module that allows the user to create a so called imput mode, that is  a
+-- persistent "XMonad.Actions.Submap".
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Actions.InputMode (
+                             -- * Usage
+                             -- $usage
+                             inputMode
+                            ) where
+import XMonad hiding (keys)
+import qualified Data.Map as M
+import XMonad.Actions.Submap
+
+{- $usage
+
+
+
+
+First, import this module into your @~\/.xmonad\/xmonad.hs@:
+
+> import XMonad.Actions.InputMode
+
+Create a sub-mapping of keys. Example using "XMonad.Actions.FloatKeys":
+
+> moveMode =
+>     [ ((0, xK_h), withFocused (keysMoveWindow (-15,0) ) )
+>     , ((0, xK_l), withFocused (keysMoveWindow (15,0) ) )
+>     , ((0, xK_k), withFocused (keysMoveWindow (0,-15) ) )
+>     , ((0, xK_j), withFocused (keysMoveWindow (0,15) ) )
+>     , ((0,         xK_Tab), focusDown )
+>     ]
+
+Add a switch in your key bindings:
+
+>    , ((modm,                 xK_g), inputMode moveMode)
+
+So, you cat hit `modm+g` to activate the move mode and use
+h, j, k, l to move a window around. Hit 'Escape' to restore your normal
+bindings.
+
+For detailed instructions on editing your key bindings, see
+"XMonad.Doc.Extending#Editing_key_bindings".
+
+-}
+
+-- | Given a list of key bindings, return an action that temporay modifies
+--   your bindings. Hit `Escape` to switch back to normal key bindings.
+inputMode :: [( (KeyMask, KeySym), (X () ) )] -> X ()
+inputMode xs = do
+    submap . M.fromList $ modeMap where
+        modeMap = [ ( binding , do x
+                                   (submap . M.fromList $ modeMap) )
+                    | ( binding , x ) <- xs
+                  ] ++ [((0, xK_Escape), return ())]


### PR DESCRIPTION
    - it defines an action that switches to another key binding
      map.
    - implemented as recursive X.A.Submap

### Description

We often struggle to find binding-free keys. I, for myself, was reluctant to bind 16 keys just to move and resize floating windows ( yes 16, because I wanted 2 speeds).

`X.A.Submap`s may help sometimes but in that case it was just an no-go, so I hacked a recursive Submap, like so:

```haskell
resizeMode =
    [ ((0, xK_h), do withFocused (keysResizeWindow (-15,0) (0,0))
                     submap . M.fromList $ resizeMode)
    , ((0, xK_l), do withFocused (keysResizeWindow (15,0) (0,0))
                     submap . M.fromList $ resizeMode)
    , ((0, xK_k), do withFocused (keysResizeWindow (0,-15) (0,0))
                     submap . M.fromList $ resizeMode)
    , ((0, xK_j), do withFocused (keysResizeWindow (0,15) (0,0))
                     submap . M.fromList $ resizeMode)
    , ((controlMask, xK_h), do withFocused (keysResizeWindow (-1,0) (0,0))
                               submap . M.fromList $ resizeMode)
    , ((controlMask, xK_l), do withFocused (keysResizeWindow (1,0) (0,1))
                               submap . M.fromList $ resizeMode)
    , ((controlMask, xK_k), do withFocused (keysResizeWindow (0,-1) (0,0))
                               submap . M.fromList $ resizeMode)
    , ((controlMask, xK_j), do withFocused (keysResizeWindow (0,1) (1,0))
                               submap . M.fromList $ resizeMode)
    , ((0,         xK_Tab), do focusDown
                               submap . M.fromList $ resizeMode)
    , ((0,      xK_Escape), return ())
    ]
```

I eventually made a function generating this mess from a simple keybinding list, for usability, and heres my package proposal.

Note that it's my second real haskell program —the first one being my `xmonad.hs` :) —. I hope it's good enough.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
