### PR TITLE
New sideNavigation strategy for X.A.Navigation2D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Actions.Navigation2D`
+
+    Added `sideNavigation` and a parameterised variant, providing a navigation
+    strategy with fewer quirks for tiled layouts using X.L.Spacing.
+
   * `XMonad.Layout.Gaps`
 
     Extended the sendMessage interface with `ModifyGaps` to allow arbitrary


### PR DESCRIPTION
### Description

This time, a new navigation strategy from the ground up. It's intended to be used in the tiled layer with gapped layouts (those using modifiers from X.L.Spacing), and can be considered the extension of line navigation to the gapped case—which is to say: when unambiguous, `sideNavigation` will choose the same window as `lineNavigation` would have were the layout not gapped. A parameterised variant `sideNavigationWithBias` is also supplied. For precisely what its bias parameter does, I refer you to the comments in the generated documentation or source code.

The incompatibility of `lineNavigation` with gaps can be patched up by hybridising it with `centerNavigation`; and this is remarkably effective for how little additional code it required. However it's not ideal—both versions having some quirks:
  - `hybridOf lineNavigation centerNavigation`: When a line falls on a gap and meets no windows, motion is deferred to `centerNavigation`; you get a probably (but maybe not) sane outcome. When it falls on a gap and meets a window it wasn't supposed to, you jump past the window you wanted.
  - `hybridOf centerNavigation lineNavigation`: This prevents the second issue, at the cost of making `centerNavigation`'s wacky motions the default. As windows' aspect ratios get more extreme and they get further offset from one another, they start skipping over targets, or choosing a near neighbour to the side over the window that is directly and unambiguously in the direction you asked for, just a little further away.

Hence I wrote this. As a note, I don't believe it renders `hybridOf` obsolete, as solving this particular problem was not its only utility. See its updated comment in the source.

Feedback on and suggestions for improving the code are welcome.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

Edit: Tweaked the style of the code and extended a few of the non-documentation comments. Already squashed the new commit.