### PR TITLE
Add appendFilePrompt' to allow transforming text before appending

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,6 +196,11 @@
       acts as a generic function to pass the selected Unicode character to any
       program.
 
+  * `XMonad.Prompt.AppendFile`
+
+    - New function `appendFilePrompt'` which allows for transformation of the
+      string passed by a user before writing to a file.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

This change allows for transforming the string passed by a user before appending to a file.

This is my first Haskell code out into the wild. If there is anything to be improved I will be glad to do so.

I've kept the old example with date output as it hints other uses, but can remove it or change it if both the examples are overlapping too much.

The main question that appeared in my mind was if `String -> String` was enough (I imagine `String -> X String` would give greater flexibility), but my Haskell knowledge is pretty basic and I wanted to keep it simple. Any thoughts?

There are no tests for it (yet?). If this is good enough for merging and deserves testing I will open PR for them too.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
