### PR TITLE
Implement additional options for Dzen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -239,6 +239,13 @@
     passed to `dzen2` invocation. The behaviour of current `dzen` function is
     unchanged.
 
+  * `XMonad.Util.Dzen`
+
+    - Now provides functions `fgColor` and `bgColor` to specify foreground and
+    background color, `align` and `slaveAlign` to set text alignment, and
+    `lineCount` to enable a second (slave) window that displays lines beyond
+    the initial (title) one.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Some fairly common options to `dzen2` are not yet wrapped in `XMonad.Util.Dzen`.
This pull request adds the following functions, meant to be used with `dzenConfig`:
* `fgColor` and `bgColor` to set foreground/background color
* `align` and `slaveAlign` to set text alignment (using the `Align` data type from `XMonad.Util.Font`)
* `lineCount` to enable the slave window and specify the number of lines it should contain

Rather trivial change, please check formatting/style since I don't often contribute Haskell.