### PR TITLE
Added pretty printer for empty visible workspaces (wrapped in Maybe)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -258,6 +258,11 @@
     `lineCount` to enable a second (slave) window that displays lines beyond
     the initial (title) one.
 
+  * `XMonad.Hooks.DynamicLog`
+
+    - Added optional `ppVisibleNoWindows` to differentiate between empty
+      and non-empty visible workspaces in pretty printing.
+
 ## 0.13 (February 10, 2017)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description
Simple extensions of the pretty printer to differentiate between empty and non-empty visible workspaces. Analogical to the existing functionality for hidden workspaces. Particularly useful if some displays managed by xmonad are turned off temporarily.

The new 'ppVisibleNoWindows' function was wrapped in a Maybe data type. Its value dafaults to 'Nothing' and 'ppVisible' is used as fallback.

### Motivation
My TV is often turned off. Still I want to know if its workspace contains any windows, without having to switch workspaces.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
