### PR TITLE
reSpaced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,20 @@
 
 ### Breaking Changes
 
-  * Adding handling of modifySpacing message in smartSpacing and smartSpacingWithEdge layout modifier
+  * `XMonad.Layout.Spacing`
+
+    Rewrite `XMonad.Layout.Spacing`. Borders are no longer uniform but composed
+    of four sides each with its own border width. The screen and window borders
+    are now separate and can be independently toggled on/off. The screen border
+    examines the window/rectangle list resulting from 'runLayout' rather than
+    the stack, which makes it compatible with layouts such as the builtin
+    `Full`. The child layout will always be called with the screen border. If
+    only a single window is displayed (and `smartBorder` enabled), it will be
+    expanded into the original layout rectangle. Windows that are displayed but
+    not part of the stack, such as those created by 'XMonad.Layout.Decoration',
+    will be shifted out of the way, but not scaled (not possible for windows
+    created by XMonad). This isn't perfect, so you might want to disable
+    `Spacing` on such layouts.
 
   * `XMonad.Actions.GridSelect`
 

--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -31,7 +31,6 @@ module XMonad.Layout.Spacing
     ) where
 
 import           XMonad
-import qualified XMonad.StackSet                as W
 import           XMonad.Layout.LayoutModifier
 import qualified XMonad.Util.Rectangle          as R
 
@@ -55,7 +54,7 @@ data Border = Border
     , bottom    :: Integer
     , right     :: Integer
     , left      :: Integer
-    } deriving (Read,Show)
+    } deriving (Show,Read)
 
 -- | A 'LayoutModifier' providing customizable screen and window borders.
 -- Borders are clamped to @[0,Infinity]@ before being applied.
@@ -67,19 +66,55 @@ data Spacing a = Spacing
     } deriving (Show,Read)
 
 instance LayoutModifier Spacing a where
+    -- This is a bit of a chicken-and-egg problem - the visible window list has
+    -- yet to be generated. Several workarounds to incorporate the screen
+    -- border:
+    -- 1. Call 'runLayout' twice, with/without the screen border. Since layouts
+    --    run arbitrary X actions, this breaks an important underlying
+    --    assumption. Also, doesn't really solve the chicken-egg problem.
+    -- 2. Create the screen border after and if the child layout returns more
+    --    than one window. Unfortunately this breaks the window ratios
+    --    presented by the child layout, another important assumption.
+    -- 3. Create the screen border before, and remove it after and if the child
+    --    layout returns fewer than two visible windows. This is somewhat hacky
+    --    but probably the best option. Could significantly modify the child
+    --    layout if it would have returned more than one window given the space
+    --    of the screen border, but this is the underlying chicken-egg problem,
+    --    and some concession must be made:
+    --      * no border -> multiple windows
+    --      * border -> single window
+    --    Also slightly breaks layouts that expect to present absolutely-sized
+    --    windows; a single window will be scaled up by the border size.
+    --    Overall these are trivial assumptions.
+    --
+    -- Note #1: the original code counted the windows of the 'Workspace' stack,
+    -- and so generated incorrect results even for the builtin 'Full' layout.
+    -- Even though most likely true, it isn't guaranteed that a layout will
+    -- never return windows not in the stack, specifically that an empty stack
+    -- will lead to 0 visible windows and a stack with a single window will
+    -- lead to 0-1 visible windows (see 'XMonad.Layout.Decoration'). So as much
+    -- as I would like to pass a rectangle without screen borders to the child
+    -- layout when appropriate (per the original approach), I can't. Since the
+    -- screen border is always present whether displayed or not, child layouts
+    -- can't depend on an accurate layout rectangle.
+    modifyLayout (Spacing b sb _) wsp lr = do
+        let sb1 = borderClampGTZero sb
+        (wl,ml) <- runLayout wsp (withBorder' sb1 2 lr)
+        let wl' = case wl of
+                [(w,r)] | b ->
+                    let sb2 = borderMap negate sb1
+                        r'  = withBorder' sb2 2 r
+                    in  [(w,r')]
+                _ ->
+                    wl
+        return (wl',ml)
+
+    -- This is run after 'modifyLayout'.
     pureModifier (Spacing True  _ _)  _ _ [x] =
         ([x], Nothing)
     pureModifier (Spacing _     _ wb) _ _ wrs =
         let wb' = borderClampGTZero wb
         in  (map (second $ withBorder' wb' 2) wrs, Nothing)
-
-    modifyLayout (Spacing b sb _) wsp lr
-        | b == True
-        , null . drop 1 . W.integrate' . W.stack $ wsp
-        = runLayout wsp lr
-        | otherwise
-        = let sb' = borderClampGTZero sb
-          in  runLayout wsp (withBorder' sb' 2 lr)
 
     pureMess (Spacing b sb wb) m
         | Just (ModifyWindowSpacing f) <- fromMessage m
@@ -140,6 +175,10 @@ decWindowSpacing = incWindowSpacing . negate
 -- | Inverse of 'incScreenSpacing'.
 decScreenSpacing :: Integer -> X ()
 decScreenSpacing = incScreenSpacing . negate
+
+-- | Map a function over a 'Border'. That is, over the four individual borders.
+borderMap :: (Integer -> Integer) -> Border -> Border
+borderMap f (Border t b r l) = Border (f t) (f b) (f r) (f l)
 
 -- | Change the border spacing by the provided amount, adjusted so that at
 -- least one border field is @>=0@.


### PR DESCRIPTION
### Description

#### `XMonad.Layout.Spacing`

Rewrite `XMonad.Layout.Spacing`. Borders are no longer uniform but composed of four sides each with its own border width. The screen and window borders are now separate and can be independently toggled on/off. The screen border examines the window/rectangle list resulting from 'runLayout' rather than the stack, which makes it compatible with layouts such as the builtin `Full`. The child layout will always be called with the screen border. If only a single window is displayed (and `smartBorder` enabled), it will be expanded into the original layout rectangle. Windows that are displayed but not part of the stack, such as those created by 'XMonad.Layout.Decoration', will be shifted out of the way, but not scaled (not possible for windows created by XMonad). This isn't perfect, so you might want to disable `Spacing` on such layouts.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
