### PR TITLE
X.A.MessageFeedback fix refresh behaviour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,14 @@
      `X.A.Minimize` and use `maximizeWindow` and `withLastMinimized` instead of
      sending messages to `Minimized` layout. `XMonad.Hooks.RestoreMinimized` has
      been completely deprecated, and its functions have no effect.
+     
+  * `XMonad.Actions.MessageFeedback`
+  
+     The existing functions now perform a refresh if the a message was handled by the
+     layout. The old behaviour can still be accessed by newly introduced functions.
+     Manual calls to `refresh` after calling `send` can now be removed. But in the
+     unlikely case that `send` is used from within a custom layout or any code invoked
+     via `XMonad.Operations.windows`, it needs to be replaced with `sendWithNoRefresh`.
 
   * `XMonad.Prompt.Unicode`
 

--- a/XMonad/Actions/MessageFeedback.hs
+++ b/XMonad/Actions/MessageFeedback.hs
@@ -18,18 +18,26 @@ module XMonad.Actions.MessageFeedback (
                                       -- $usage
 
                                         send
+                                      , sendWithNoRefresh
                                       , tryMessage
                                       , tryMessage_
+                                      , tryMessageWithNoRefresh
+                                      , tryMessageWithNoRefresh_
                                       , tryInOrder
                                       , tryInOrder_
+                                      , tryInOrderWithNoRefresh
+                                      , tryInOrderWithNoRefresh_
                                       , sm
                                       , sendSM
                                       , sendSM_
+                                      , sendSMWithNoRefresh
+                                      , sendSMWithNoRefresh_
                                       ) where
 
-import XMonad.Core ( X (), Message, SomeMessage(..), LayoutClass(..), windowset, catchX )
+import XMonad.Core ( X (), Message, SomeMessage(..), LayoutClass(..), windowset, catchX, whenJust )
 import XMonad.StackSet ( current, workspace, layout, tag )
-import XMonad.Operations ( updateLayout )
+import XMonad.Operations ( updateLayout, windows )
+import qualified XMonad.StackSet as W
 
 import Control.Monad.State ( gets )
 import Data.Maybe ( isJust )
@@ -63,14 +71,29 @@ import Control.Applicative ((<$>))
 send :: Message a => a -> X Bool
 send = sendSM . sm
 
+-- | Behaves like 'XMonad.Operations.sendMessageWithNoRefresh', but returns True of the
+-- message was handled by the layout, False otherwise.
+sendWithNoRefresh :: Message a => a -> X Bool
+sendWithNoRefresh = sendSMWithNoRefresh . sm
+
 -- | Sends the first message, and if it was not handled, sends the second.
 -- Returns True if either message was handled, False otherwise.
 tryMessage :: (Message a, Message b) => a -> b -> X Bool
 tryMessage m1 m2 = do b <- send m1
                       if b then return True else send m2
 
+-- | Like 'tryMessage', but discards the response.
 tryMessage_ :: (Message a, Message b) => a -> b -> X ()
 tryMessage_ m1 m2 = tryMessage m1 m2 >> return ()
+
+-- | Like 'tryMessage', but without a refresh at the end.
+tryMessageWithNoRefresh :: (Message a, Message b) => a -> b -> X Bool
+tryMessageWithNoRefresh m1 m2 = do b <- sendWithNoRefresh m1
+                                   if b then return True else sendWithNoRefresh m2
+
+-- | Like 'tryMessageWithNoRefresh', but discards the response.
+tryMessageWithNoRefresh_ :: (Message a, Message b) => a -> b -> X ()
+tryMessageWithNoRefresh_ m1 m2 = tryMessageWithNoRefresh m1 m2 >> return ()
 
 -- | Tries sending every message of the list in order until one of them
 -- is handled. Returns True if one of the messages was handled, False otherwise.
@@ -79,8 +102,19 @@ tryInOrder [] = return False
 tryInOrder (m:ms) = do b <- sendSM m
                        if b then return True else tryInOrder ms
 
+-- | Like 'tryInOrder', but discards the response.
 tryInOrder_ :: [SomeMessage] -> X ()
 tryInOrder_ ms = tryInOrder ms >> return ()
+
+-- | Like 'tryInOrder', but without a refresh at the end.
+tryInOrderWithNoRefresh :: [SomeMessage] -> X Bool
+tryInOrderWithNoRefresh [] = return False
+tryInOrderWithNoRefresh (m:ms) = do b <- sendSM m
+                                    if b then return True else tryInOrder ms
+
+-- | Like 'tryInOrderWithNoRefresh', but discards the response.
+tryInOrderWithNoRefresh_ :: [SomeMessage] -> X ()
+tryInOrderWithNoRefresh_ ms = tryInOrder ms >> return ()
 
 
 -- | Convenience shorthand for 'XMonad.Core.SomeMessage'.
@@ -88,12 +122,28 @@ sm :: Message a => a -> SomeMessage
 sm = SomeMessage
 
 
+-- | Send a 'SomeMessage' to the corrent layout and returns true if the message was handled.
 sendSM :: SomeMessage -> X Bool
 sendSM m = do w <- workspace . current <$> gets windowset
               ml' <- handleMessage (layout w) m `catchX` return Nothing
-              updateLayout (tag w) ml'
+              whenJust ml' $ \l' ->
+                  windows $ \ws -> ws { W.current = (W.current ws)
+                                          { W.workspace = (W.workspace $ W.current ws)
+                                            { W.layout = l' }}}
               return $ isJust ml'
 
-
+-- | Like 'sendSM', but discards the response.
 sendSM_ :: SomeMessage -> X ()
 sendSM_ m = sendSM m >> return ()
+
+
+-- | Like 'SendSM', but without a refresh at the end.
+sendSMWithNoRefresh :: SomeMessage -> X Bool
+sendSMWithNoRefresh m = do w <- workspace . current <$> gets windowset
+                           ml' <- handleMessage (layout w) m `catchX` return Nothing
+                           updateLayout (tag w) ml'
+                           return $ isJust ml'
+
+-- | Like 'sendSMWithNoRefresh', but discards the response.
+sendSMWithNoRefresh_ :: SomeMessage -> X ()
+sendSMWithNoRefresh_ m = sendSMWithNoRefresh m >> return ()


### PR DESCRIPTION
### Description

This fixes the issue "X.L.NoBorders not working correctly together with
X.L.Groups" (#191).

Generaly when the users sends a message, they expect the layout to be
updated, not updating they layout is the exception. In the documentation
for the send method it mentioned that it worked like X.O.sendMessage,
even though it actually behaved more like X.O.sendMessageWithNoRefresh.
This PR changes this behaviour so that send actually does an update at
the end as expected.

This fixes the behaviour of X.L.NoBorders together with X.L.Groups, when
using X.L.G.Examples and X.L.G.Helpers to send messages.

I have added a new function for each old one that keeps the old
behaviour, but refreshing is the new default. The only place this module
is used in xmonad-contrib is in X.L.G.Helpers, which is the code we
actually wanted to fix.

An alternative to this is that keep the old behaviour in the existing
functions of X.A.MessageFeedback. But looking at X.O.sendMessage and
X.O.sendMessageWithNoRefresh from xmonad, this seems like the reasonable
path forward.

### Checklist

  - [*] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [*] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [*] I updated the `CHANGES.md` file
