### PR TITLE
Fullscreen.hs: don't lay out windows obscured by fullscreen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,6 +135,11 @@
     Added `sideNavigation` and a parameterised variant, providing a navigation
     strategy with fewer quirks for tiled layouts using X.L.Spacing.
 
+  * `XMonad.Layout.Fullscreen`
+    
+    The fullscreen layouts will now not render any window that is totally
+    obscured by fullscreen windows.
+    
   * `XMonad.Layout.Gaps`
 
     Extended the sendMessage interface with `ModifyGaps` to allow arbitrary


### PR DESCRIPTION
## Description

There's no reason to return a rectangle for any window that is totally
obscured by a full-screen window, and not doing so has the nice property that
when hidden windows' borders overlap with a full-screen window's, the user
will not be confused by overlapping partially-drawn borders. It also makes the
Fullscreen modifiers combine much better with smartBorders.

## Checklist

- [x]  I've read CONTRIBUTING.md
- [ ]  I tested my changes with xmonad-testing
  - xmonad-testing has no configs with a Fullscreen layout; I have tested on my own system and this works as described.
- [x]  I updated the CHANGES.md file