### PR TITLE
Allow build with X11-1.9

### DIFF
--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -64,7 +64,7 @@ library
                    random,
                    mtl >= 1 && < 3,
                    unix,
-                   X11>=1.6.1 && < 1.9,
+                   X11>=1.6.1 && < 1.10,
                    xmonad>=0.13   && < 0.14,
                    utf8-string,
                    semigroups


### PR DESCRIPTION
### Description

Allow build of xmonad-contrib with X11-1.9

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
