### PR TITLE
Add the X.L.MultiToggle.TabBarDecoration module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,11 @@
 
 ### New Modules
 
+  * `XMonad.Layout.MultiToggle.TabBarDecoration`
+
+    Provides a simple transformer for use with `XMonad.Layout.MultiToggle` to
+    dynamically toggle `XMonad.Layout.TabBarDecoration`.
+
   * `XMonad.Hooks.RefocusLast`
 
     Provides log and event hooks that keep track of recently focused windows on

--- a/XMonad/Layout/MultiToggle/TabBarDecoration.hs
+++ b/XMonad/Layout/MultiToggle/TabBarDecoration.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE TypeSynonymInstances, DeriveDataTypeable, MultiParamTypeClasses #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Layout.MultiToggle.TabBarDecoration
+-- Copyright   :  (c) 2018  Lucian Poston
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  <lucianposton@pm.me>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Provides a simple transformer for use with "XMonad.Layout.MultiToggle" to
+-- dynamically toggle "XMonad.Layout.TabBarDecoration".
+-----------------------------------------------------------------------------
+
+module XMonad.Layout.MultiToggle.TabBarDecoration (
+    SimpleTabBar(..)
+) where
+
+import XMonad.Layout.MultiToggle
+
+import XMonad
+import XMonad.Layout.LayoutModifier
+import XMonad.Layout.TabBarDecoration
+
+-- $usage
+-- To use this module with "XMonad.Layout.MultiToggle", add the @SIMPLETABBAR@
+-- to your layout For example, from a basic layout like
+--
+-- > layout = tiled ||| Full
+--
+-- Add @SIMPLETABBAR@ by changing it this to
+--
+-- > layout = mkToggle (single SIMPLETABBAR) (tiled ||| Full)
+--
+-- You can now dynamically toggle the 'XMonad.Layout.TabBarDecoration'
+-- transformation by adding a key binding such as @mod-x@ as follows.
+--
+-- > ...
+-- >   , ((modm,               xK_x     ), sendMessage $ Toggle SIMPLETABBAR)
+-- > ...
+
+-- | Transformer for "XMonad.Layout.TabBarDecoration".
+data SimpleTabBar = SIMPLETABBAR deriving (Read, Show, Eq, Typeable)
+instance Transformer SimpleTabBar Window where
+    transform _ x k = k (simpleTabBar x) (\(ModifiedLayout _ (ModifiedLayout _ x')) -> x')

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -253,6 +253,7 @@ library
                         XMonad.Layout.MultiColumns
                         XMonad.Layout.MultiToggle
                         XMonad.Layout.MultiToggle.Instances
+                        XMonad.Layout.MultiToggle.TabBarDecoration
                         XMonad.Layout.Named
                         XMonad.Layout.NoBorders
                         XMonad.Layout.NoFrillsDecoration


### PR DESCRIPTION
### Description

Add the X.L.MultiToggle.TabBarDecoration module

Provides a simple transformer for use with "XMonad.Layout.MultiToggle" to dynamically toggle "XMonad.Layout.TabBarDecoration".

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
