### PR TITLE
X.U.Themes: Add darkTheme

### DIFF
--- a/XMonad/Util/Themes.hs
+++ b/XMonad/Util/Themes.hs
@@ -20,6 +20,7 @@ module XMonad.Util.Themes
     , xmonadTheme
     , smallClean
     , robertTheme
+    , darkTheme
     , deiflTheme
     , oxymor00nTheme
     , donaldTheme
@@ -90,6 +91,7 @@ ppThemeInfo t = themeName t <> themeDescription t <> "by" <> themeAuthor t
 listOfThemes :: [ThemeInfo]
 listOfThemes = [ xmonadTheme
                , smallClean
+               , darkTheme
                , deiflTheme
                , oxymor00nTheme
                , robertTheme
@@ -160,6 +162,22 @@ robertTheme =
                                       , inactiveTextColor   = "#d5d3a7"
                                       , fontName            = "-*-profont-*-*-*-*-11-*-*-*-*-*-iso8859"
                                       , decoHeight          = 16
+                                      }
+             }
+
+-- | Dark Theme, by Lucian Poston.
+darkTheme :: ThemeInfo
+darkTheme =
+    newTheme { themeName        = "darkTheme"
+             , themeAuthor      = "Lucian Poston"
+             , themeDescription = "Dark Theme"
+             , theme            = def { inactiveBorderColor = "#202030"
+                                      , activeBorderColor   = "#a0a0d0"
+                                      , inactiveColor       = "#000000"
+                                      , activeColor         = "#000000"
+                                      , inactiveTextColor   = "#607070"
+                                      , activeTextColor     = "#a0d0d0"
+                                      , decoHeight          = 15
                                       }
              }
 


### PR DESCRIPTION
### Description

Adds darkTheme to X.U.Themes.

Let me know if CHANGES should be updated for a small patch like this. I didn't see any update notes for any of the existing themes, so I'm assuming it shouldn't be.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file


![lol2](https://user-images.githubusercontent.com/646121/42856630-e51be0c8-89fa-11e8-9fb6-161697fa6671.png)
