### PR TITLE
Travis CI, and (dropping?) GHC 7.6/7.8 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 # This file has been generated -- see https://github.com/hvr/multi-ghc-travis
 language: c
 sudo: false
-dist: precise
 
 cache:
   directories:
@@ -14,27 +13,42 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1
+    - env: GHCVER=8.4.3  CABALVER=2.2
+      compiler: ": #GHC 8.4.3"
+      addons: { apt: { packages: [cabal-install-2.2,  ghc-8.4.3,  libxrandr-dev]
+                     , sources:  [hvr-ghc]
+                     } }
+    - env: GHCVER=8.2.2  CABALVER=2.0
+      compiler: ": #GHC 8.2.2"
+      addons: { apt: { packages: [cabal-install-2.0,  ghc-8.2.2,  libxrandr-dev]
+                     , sources:  [hvr-ghc]
+                     } }
+    - env: GHCVER=8.0.1  CABALVER=1.24
       compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+      addons: { apt: { packages: [cabal-install-1.24, ghc-8.0.1,  libxrandr-dev]
+                     , sources:  [hvr-ghc]
+                     } }
+    - env: GHCVER=7.10.3 CABALVER=1.22
+      compiler: ": #GHC 7.10.3"
+      addons: { apt: { packages: [cabal-install-1.22, ghc-7.10.3, libxrandr-dev]
+                     , sources:  [hvr-ghc]
+                     } }
+    - env: GHCVER=7.8.4  CABALVER=1.18
+      compiler: ": #GHC 7.8.4"
+      addons: { apt: { packages: [cabal-install-1.18, ghc-7.8.4,  libxrandr-dev]
+                     , sources:  [hvr-ghc]
+                     } }
+    - env: GHCVER=7.6.3  CABALVER=1.16
+      compiler: ": #GHC 7.6.3"
+      addons: { apt: { packages: [cabal-install-1.16, ghc-7.6.3,  libxrandr-dev]
+                     , sources:  [hvr-ghc]
+                     } }
 
 before_install:
  - unset CC
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
- # build xmonad from HEAD
- - git clone https://github.com/xmonad/xmonad.git
-
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
@@ -43,6 +57,11 @@ install:
           $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
    fi
  - travis_retry cabal update -v
+
+ # build xmonad from HEAD
+ - git clone https://github.com/xmonad/xmonad.git
+ - cabal install xmonad/
+
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
@@ -58,8 +77,8 @@ install:
      echo "cabal build-cache MISS";
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks;
    fi
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks;
 
 # snapshot package-db on cache miss
  - if [ ! -d $HOME/.cabsnap ];
@@ -69,8 +88,6 @@ install:
       cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
       cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
    fi
-
- - cabal install xmonad/
 
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,6 @@ matrix:
       addons: { apt: { packages: [cabal-install-1.18, ghc-7.8.4,  libxrandr-dev]
                      , sources:  [hvr-ghc]
                      } }
-    - env: GHCVER=7.6.3  CABALVER=1.16
-      compiler: ": #GHC 7.6.3"
-      addons: { apt: { packages: [cabal-install-1.16, ghc-7.6.3,  libxrandr-dev]
-                     , sources:  [hvr-ghc]
-                     } }
 
 before_install:
  - unset CC

--- a/XMonad/Actions/SwapPromote.hs
+++ b/XMonad/Actions/SwapPromote.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Actions.SwapPromote
@@ -63,6 +65,7 @@ import qualified Data.Set                       as S
 import           Data.List
 import           Data.Maybe
 import           Control.Arrow
+import           Control.Applicative ((<$>),(<*>))
 import           Control.Monad
 
 

--- a/XMonad/Layout/NoBorders.hs
+++ b/XMonad/Layout/NoBorders.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, TypeSynonymInstances #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE FlexibleContexts, FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances, PatternGuards, DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -42,6 +42,7 @@ import           Data.List
 import           Data.Monoid
 import qualified Data.Map                       as M
 import           Data.Function                  (on)
+import           Control.Applicative            ((<$>),(<*>),pure)
 import           Control.Monad                  (guard)
 
 

--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, DeriveDataTypeable #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/XMonad/Layout/StateFull.hs
+++ b/XMonad/Layout/StateFull.hs
@@ -34,7 +34,7 @@ import qualified XMonad.StackSet as W
 import XMonad.Util.Stack (findZ)
 
 import Data.Maybe (fromMaybe)
-import Control.Applicative ((<|>))
+import Control.Applicative ((<|>),(<$>))
 import Control.Monad (join)
 
 -- $Usage
@@ -67,7 +67,6 @@ type StateFull = FocusTracking Full
 
 -- | A pattern synonym for the primary use case of the @FocusTracking@
 --   transformer; using @Full@.
-pattern StateFull :: StateFull a
 pattern StateFull = FocusTracking Nothing Full
 
 instance LayoutClass l Window => LayoutClass (FocusTracking l) Window where

--- a/XMonad/Util/Stack.hs
+++ b/XMonad/Util/Stack.hs
@@ -80,7 +80,7 @@ module XMonad.Util.Stack ( -- * Usage
                          ) where
 
 import qualified XMonad.StackSet as W
-import Control.Applicative ((<|>))
+import Control.Applicative ((<|>),(<$>),(<$))
 import Control.Monad (guard,liftM)
 import Data.List (sortBy)
 

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -36,7 +36,7 @@ cabal-version:      >= 1.6
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with: GHC==7.6.3, GHC==7.8.4, GHC==7.10.3, GHC==8.0.1, GHC==8.2.2, GHC==8.4.1
+tested-with: GHC==7.6.3, GHC==7.8.4, GHC==7.10.3, GHC==8.0.1, GHC==8.2.2, GHC==8.4.3
 
 source-repository head
   type:     git

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -36,7 +36,7 @@ cabal-version:      >= 1.6
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with: GHC==7.6.3, GHC==7.8.4, GHC==7.10.3, GHC==8.0.1, GHC==8.2.2, GHC==8.4.3
+tested-with: GHC==7.8.4, GHC==7.10.3, GHC==8.0.1, GHC==8.2.2, GHC==8.4.3
 
 source-repository head
   type:     git


### PR DESCRIPTION
### Description

Travis CI has been broken for way too long, so I had a go at it. Fair warning: I don't actually know what I'm doing, or what half the script is doing for that matter.

There's some statefulness in the setup that has contributed to random failures, so it's hard to know whether my changes have actually fixed that issue. It looked like the problem was `cabal configure [...]` failing with missing dependencies when the "cabal build-cache HIT" case of an earlier conditional meant that `cabal install --only-dependencies [...]` did not run, so I've moved that command out of the conditional. Presumably it shouldn't need to be run in that case, but it seems it does. I imagine there is a better fix; yell out if you know.

In the process of troubleshooting that, I saw what changes needed to be made for compatibility with earlier GHC versions, and made them in separate commits:
 - 7.8: Explicitly import applicative functions from `Control.Applicative`, and use the `DeriveDataTypeable` pragma. Nothing had to be sacrificed, so I see no reason to drop compatibility at this point.  
 - 7.6: Remove `PatternSynonym` usage from `X.L.StateFull`. That module has no particular need for it, but more generally I think pattern synonyms have potential to be quite useful (unlike GHC 7.6 compatibility). I'm also using them in another module I'm writing where their role is somewhat more substantial. __I'd prefer to drop this commit and remove 7.6 compat__.
 
### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)
    - Tested on my system.
  - [x] I updated the `CHANGES.md` file
    - Only the interface to `X.L.StateFull` has changed, so the changelog is only edited for correctness re that module.