### PR TITLE
X.L.Fullscreen: 'FullscreenFull' hides all windows

### DIFF
--- a/XMonad/Layout/Fullscreen.hs
+++ b/XMonad/Layout/Fullscreen.hs
@@ -30,17 +30,19 @@ module XMonad.Layout.Fullscreen
     ,FullscreenFloat, FullscreenFocus, FullscreenFull
     ) where
 
-import XMonad
-import XMonad.Layout.LayoutModifier
-import XMonad.Util.WindowProperties
-import XMonad.Hooks.ManageHelpers (isFullscreen)
-import qualified XMonad.StackSet as W
-import Data.List
-import Data.Maybe
-import Data.Monoid
-import qualified Data.Map as M
-import Control.Monad
-import Control.Arrow (second)
+import           XMonad
+import           XMonad.Layout.LayoutModifier
+import           XMonad.Hooks.ManageHelpers     (isFullscreen)
+import           XMonad.Util.WindowProperties
+import qualified XMonad.Util.Rectangle          as R
+import qualified XMonad.StackSet                as W
+
+import           Data.List
+import           Data.Maybe
+import           Data.Monoid
+import qualified Data.Map                       as M
+import           Control.Monad
+import           Control.Arrow                  (second)
 
 -- $usage
 -- Provides a ManageHook and an EventHook that sends layout messages
@@ -107,9 +109,12 @@ instance LayoutModifier FullscreenFull Window where
     _ -> Nothing
 
   pureModifier (FullscreenFull frect fulls) rect _ list =
-    (map (flip (,) rect') visfulls ++ rest, Nothing)
-    where visfulls = intersect fulls $ map fst list
-          rest = filter (not . (flip elem visfulls `orP` covers rect')) list
+    (visfulls' ++ rest', Nothing)
+    where (visfulls,rest) = partition (flip elem fulls . fst) list
+          visfulls' = map (second $ const rect') visfulls
+          rest' = if null visfulls'
+                  then rest
+                  else filter (not . R.supersetOf rect' . snd) rest
           rect' = scaleRationalRect rect frect
 
 instance LayoutModifier FullscreenFocus Window where
@@ -122,7 +127,7 @@ instance LayoutModifier FullscreenFocus Window where
   pureModifier (FullscreenFocus frect fulls) rect (Just (W.Stack {W.focus = f})) list
      | f `elem` fulls = ((f, rect') : rest, Nothing)
      | otherwise = (list, Nothing)
-     where rest = filter (not . ((== f) `orP` covers rect')) list
+     where rest = filter (not . orP (== f) (R.supersetOf rect')) list
            rect' = scaleRationalRect rect frect
   pureModifier _ _ Nothing list = (list, Nothing)
 
@@ -239,15 +244,6 @@ fullscreenManageHook' isFull = isFull --> do
     cw <- (W.workspace . W.current) `fmap` gets windowset
     sendMessageWithNoRefresh FullscreenChanged cw
   idHook
-
--- | True iff one rectangle completely contains another.
-covers :: Rectangle -> Rectangle -> Bool
-(Rectangle x1 y1 w1 h1) `covers` (Rectangle x2 y2 w2 h2) =
-  let fi = fromIntegral
-      in x1 <= x2 &&
-         y1 <= y2 &&
-         x1 + fi w1 >= x2 + fi w2 &&
-         y1 + fi h1 >= y2 + fi h2
 
 -- | Applies a pair of predicates to a pair of operands, combining them with ||.
 orP :: (a -> Bool) -> (b -> Bool) -> (a, b) -> Bool


### PR DESCRIPTION
The 'FullscreenFull' layout modifier hides all windows fully covered by the fullscreen area, even when no fullscreen windows are present. Fix this, closing #278. Also switch to 'X.U.Rectangle'.

Note: I haven't tested this.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
