### PR TITLE
XMonad.Prompt sorter for FuzzyMatch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,12 @@
   * `XMonad.Actions.MessageHandling`
     Refresh-performing functions updated to better reflect the new `sendMessage`.
 
+  * `XMonad.Prompt`
+
+	Added `sorter` to `XPConfig` used to sort the possible completions by how
+	well they match the search string (example: `XMonad.Prompt.FuzzyMatch`).
+
+
 ## 0.14
 
 ### Breaking Changes

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -156,6 +156,10 @@ data XPConfig =
         , searchPredicate   :: String -> String -> Bool
                                           -- ^ Given the typed string and a possible
                                           --   completion, is the completion valid?
+        , sorter            :: String -> [String] -> [String]
+                                          -- ^ Used to sort the possible completions by how well they
+                                          --   match the search string (see X.P.FuzzyMatch for an
+                                          --   example).
         }
 
 data XPType = forall p . XPrompt p => XPT p
@@ -268,6 +272,7 @@ instance Default XPConfig where
         , showCompletionOnTab = False
         , searchPredicate   = isPrefixOf
         , alwaysHighlight   = False
+        , sorter            = const id
         }
 {-# DEPRECATED defaultXPConfig "Use def (from Data.Default, and re-exported from XMonad.Prompt) instead." #-}
 defaultXPConfig = def
@@ -956,8 +961,10 @@ getCompletionFunction st = case operationMode st of
 getCompletions :: XP [String]
 getCompletions = do
   s <- get
-  io $ getCompletionFunction s (commandToComplete (currentXPMode s) (command s))
-       `E.catch` \(SomeException _) -> return []
+  let q     = commandToComplete (currentXPMode s) (command s)
+      compl = getCompletionFunction s
+      srt   = sorter (config s)
+  io $ (srt q <$> compl q) `E.catch` \(SomeException _) -> return []
 
 setComplWin :: Window -> ComplWindowDim -> XP ()
 setComplWin w wi =

--- a/XMonad/Prompt/FuzzyMatch.hs
+++ b/XMonad/Prompt/FuzzyMatch.hs
@@ -48,10 +48,10 @@ import Data.List
 -- 11.  "FastSPR" is ranked before "FasterSPR" because its match starts at
 -- position 5 while the match in "FasterSPR" starts at position 7.
 --
--- To use these functions in an XPrompt, for example, for windowPromptGoto:
+-- To use these functions in an XPrompt, for example, for windowPrompt:
 --
 -- > import XMonad.Prompt
--- > import XMonad.Prompt.Window ( windowPromptGoto )
+-- > import XMonad.Prompt.Window ( windowPrompt )
 -- > import XMonad.Prompt.FuzzyMatch
 -- >
 -- > myXPConfig = def { searchPredicate = fuzzyMatch
@@ -60,7 +60,7 @@ import Data.List
 -- 
 -- then add this to your keys definition:
 --
--- > , ((modm .|. shiftMask, xK_g), windowPromptGoto myXPConfig)
+-- > , ((modm .|. shiftMask, xK_g), windowPrompt myXPConfig Goto allWindows)
 --
 -- For detailed instructions on editing the key bindings, see
 -- "Xmonad.Doc.Extending#Editing_key_bindings".

--- a/XMonad/Prompt/FuzzyMatch.hs
+++ b/XMonad/Prompt/FuzzyMatch.hs
@@ -55,8 +55,8 @@ import Data.List
 -- > import XMonad.Prompt.FuzzyMatch
 -- >
 -- > myXPConfig = def { searchPredicate = fuzzyMatch
---                    , sorter          = fuzzySort
---                    }
+-- >                  , sorter          = fuzzySort
+-- >                  }
 -- 
 -- then add this to your keys definition:
 --


### PR DESCRIPTION
### Description

Extend `XPConfig` in `XMonad.Prompt` to provide a `sorter` which is useful for example in `XMonad.Prompt.FuzzyMatch` via `fuzzySort`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
