### PR TITLE
X.A.DynamicWorkspaceOrder: add transformation-aware withNthWorkspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,11 @@
   * `XMonad.Actions.MessageHandling`
     Refresh-performing functions updated to better reflect the new `sendMessage`.
 
+  * `XMonad.Actions.DynamicProjects`
+    Add a version of `withNthWorkspace` that takes a `[WorkspaceId] ->
+	[WorkspaceId]` transformation to apply over the list of workspace tags
+	resulting from the dynamic order.
+
 ## 0.14
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

I added an action that allows me to invoke `withNthWorkspace` while at the same time modify the list of workspace tags received from the dynamic order. This way I could avoid `M-3`, for example, from taking me to the `NSP` workspace that `X.A.NamedScratchpad` creates.

For lack of a better name, I appended `'`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
