### PR TITLE
Use bracket pattern in XMonad.Prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,10 @@
     Added `sorter` to `XPConfig` used to sort the possible completions by how
     well they match the search string (example: `XMonad.Prompt.FuzzyMatch`).
 
+    Fixes a potential bug where an error during prompt execution would
+    leave the window open and keep the keyboard grabbed. See issue
+    [#180](https://github.com/xmonad/xmonad-contrib/issues/180).
+
 ## 0.15
 
 ### Breaking Changes


### PR DESCRIPTION
Also deduplicates some code shared by mkXPromptWithReturn and
mkXPromptWithModes.

### Description

See issue #180.  I noticed 3 obvious places where Prompt can benefit from the bracket pattern, and this PR implements that.  This should help avoid failure modes like the keyboard being grabbed forever, or leaving a prompt window open forever.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
