### PR TITLE
Fix XMonad.Prompt wraparound when maxComplRows not Nothing #217

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,10 @@
     Added `sorter` to `XPConfig` used to sort the possible completions by how
     well they match the search string (example: `XMonad.Prompt.FuzzyMatch`).
 
+    Fixes [issue #217](https://github.com/xmonad/xmonad-contrib/issues/217), where
+    using tab to wrap around the completion rows would fail when maxComplRows is
+    restricting the number of rows of output.
+
 ## 0.15
 
 ### Breaking Changes

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -851,8 +851,8 @@ bufferOne xs x = (null xs && null x,True)
 nextComplIndex :: XPState -> Int -> (Int,Int)
 nextComplIndex st nitems = case complWinDim st of
   Nothing -> (0,0) --no window dims (just destroyed or not created)
-  Just (_,_,_,_,_,yy) -> let
-    (ncols,nrows) = (nitems `div` length yy + if (nitems `mod` length yy > 0) then 1 else 0, length yy)
+  Just (_,_,_,_,xx,yy) -> let
+    (ncols,nrows) = (length xx, length yy)
     (currentcol,currentrow) = complIndex st
     in if (currentcol + 1 >= ncols) then --hlight is in the last column
          if (currentrow + 1 < nrows ) then --hlight is still not at the last row


### PR DESCRIPTION
### Description

When tabbing through the prompt list of completions, if the list of completions does not fit due to `maxComplRows`, without this fix an exception would be thrown.  I am not certain why, but this exception occurs due to a pattern mismatch at https://github.com/mgsloan/xmonad-contrib/blob/dda242a4597c1ed0fa895a10b9296dcc709f4937/XMonad/Prompt.hs#L919

However, the root cause appears to be in the `nextComplIndex` function.  The problem is that it was assuming that dividing the total item count by the number of rows would yield the number of columns.  This did not hold when the number of rows was being limited.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
