### PR TITLE
Use absolute paths in DynamicProjects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,16 @@
     using tab to wrap around the completion rows would fail when maxComplRows is
     restricting the number of rows of output.
 
+  * `XMonad.Actions.DynamicProjects`
+    
+    Make the input directory read from the prompt in `DynamicProjects`
+    absolute wrt the current directory.
+    
+    Before this, the directory set by the prompt was treated like a relative
+    directory. This means that when you switch from a project with directory
+    `foo` into a project with directory `bar`, xmonad actually tries to `cd`
+    into `foo/bar`, instead of `~/bar` as expected.
+    
 ## 0.15
 
 ### Breaking Changes

--- a/XMonad/Actions/DynamicProjects.hs
+++ b/XMonad/Actions/DynamicProjects.hs
@@ -50,7 +50,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Monoid ((<>))
-import System.Directory (setCurrentDirectory, getHomeDirectory)
+import System.Directory (setCurrentDirectory, getHomeDirectory, makeAbsolute)
 import XMonad
 import XMonad.Actions.DynamicWorkspaces
 import XMonad.Prompt
@@ -182,7 +182,8 @@ instance XPrompt ProjectPrompt where
       modifyProject (\p -> p { projectName = name })
 
   modeAction (ProjectPrompt DirMode _) buf auto = do
-    let dir = if null auto then buf else auto
+    let dir' = if null auto then buf else auto
+    dir <- io $ makeAbsolute dir'
     modifyProject (\p -> p { projectDirectory = dir })
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

This makes the input directory read from the prompt in `DynamicProjects` absolute wrt the current directory.

Without this patch, the directory set by the prompt is treated like a relative directory. This means that when you switch from a project with directory `foo` into a project with directory `bar`, xmonad actually
tries to `cd` into `foo/bar`, instead of `~/bar` as expected.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
