### PR TITLE
XMonad.Util.Themes: Add adwaitaTheme and adwaitaDarkTheme

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,11 @@
     Add a utility function `isOnAnyVisibleWS :: Query Bool` to allow easy
     cycling between all windows on all visible workspaces.
 
+  * `XMonad.Util.Themes`
+
+    Add adwaitaTheme and adwaitaDarkTheme to match their respective
+    GTK themes.
+
 
 ## 0.15
 

--- a/XMonad/Util/Themes.hs
+++ b/XMonad/Util/Themes.hs
@@ -19,6 +19,8 @@ module XMonad.Util.Themes
     , ppThemeInfo
     , xmonadTheme
     , smallClean
+    , adwaitaTheme
+    , adwaitaDarkTheme
     , robertTheme
     , darkTheme
     , deiflTheme
@@ -91,6 +93,8 @@ ppThemeInfo t = themeName t <> themeDescription t <> "by" <> themeAuthor t
 listOfThemes :: [ThemeInfo]
 listOfThemes = [ xmonadTheme
                , smallClean
+               , adwaitaTheme
+               , adwaitaDarkTheme
                , darkTheme
                , deiflTheme
                , oxymor00nTheme
@@ -129,6 +133,48 @@ smallClean =
                                       , activeTextColor     = "white"
                                       , inactiveTextColor   = "grey"
                                       , decoHeight          = 14
+                                      }
+             }
+
+-- | Matching decorations for Adwaita GTK theme
+adwaitaTheme :: ThemeInfo
+adwaitaTheme =
+    newTheme { themeName        = "adwaitaTheme"
+             , themeAuthor      = "Alex Griffin"
+             , themeDescription = "Matching decorations for Adwaita GTK theme"
+             , theme            = def { activeColor         = "#dfdcd8"
+                                      , inactiveColor       = "#f6f5f4"
+                                      , urgentColor         = "#3584e4"
+                                      , activeBorderColor   = "#bfb8b1"
+                                      , inactiveBorderColor = "#cdc7c2"
+                                      , urgentBorderColor   = "#1658a7"
+                                      , activeTextColor     = "#2e3436"
+                                      , inactiveTextColor   = "#929595"
+                                      , urgentTextColor     = "#ffffff"
+                                      , fontName            = "xft:Cantarell:bold:size=11"
+                                      , decoWidth           = 400
+                                      , decoHeight          = 35
+                                      }
+             }
+
+-- | Matching decorations for Adwaita-dark GTK theme
+adwaitaDarkTheme :: ThemeInfo
+adwaitaDarkTheme =
+    newTheme { themeName        = "adwaitaDarkTheme"
+             , themeAuthor      = "Alex Griffin"
+             , themeDescription = "Matching decorations for Adwaita-dark GTK theme"
+             , theme            = def { activeColor         = "#2d2d2d"
+                                      , inactiveColor       = "#353535"
+                                      , urgentColor         = "#15539e"
+                                      , activeBorderColor   = "#070707"
+                                      , inactiveBorderColor = "#1c1c1c"
+                                      , urgentBorderColor   = "#030c17"
+                                      , activeTextColor     = "#eeeeec"
+                                      , inactiveTextColor   = "#929291"
+                                      , urgentTextColor     = "#ffffff"
+                                      , fontName            = "xft:Cantarell:bold:size=11"
+                                      , decoWidth           = 400
+                                      , decoHeight          = 35
                                       }
              }
 


### PR DESCRIPTION
### Description

Add themes to match Adwaita and Adwaita-dark GTK themes.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
