### PR TITLE
Hooks.WallpaperSetter: Preserve aspect ratio while scaling images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,6 +71,12 @@
     Add a utility function `isOnAnyVisibleWS :: Query Bool` to allow easy
     cycling between all windows on all visible workspaces.
 
+  * `XMonad.Hooks.WallpaperSetter`
+
+    Preserve the aspect ratio of wallpapers that xmonad sets. When previous
+    versions would distort images to fit the screen size, it will now find a
+    best fit by cropping instead.
+
 
 ## 0.15
 

--- a/XMonad/Hooks/WallpaperSetter.hs
+++ b/XMonad/Hooks/WallpaperSetter.hs
@@ -221,7 +221,7 @@ layerCommand (rect, path) = do
   res <- getPicRes path
   return $ case needsRotation rect <$> res of
     Nothing -> ""
-    Just rotate ->
+    Just rotate -> let size = show (rect_width rect) ++ "x" ++ show (rect_height rect) in
                      " \\( '"++path++"' "++(if rotate then "-rotate 90 " else "")
-                      ++ " -scale "++(show$rect_width rect)++"x"++(show$rect_height rect)++"! \\)"
+                      ++ " -scale "++size++"^ -gravity center -extent "++size++" +gravity \\)"
                       ++ " -geometry +"++(show$rect_x rect)++"+"++(show$rect_y rect)++" -composite "


### PR DESCRIPTION
### Description

Preserve the aspect ratio of wallpapers that xmonad sets. When previous versions would distort images to fit the screen size, it will now find a best fit by cropping instead.

I don't understand the imagemagick command invocation very well, so this was put together through trial and error. I've tested it with good results though, in a dual-head setup where each monitor has a different aspect ratio (1920x1080 and 1920x1200).

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
