### PR TITLE
Support OTP in XMonad.Prompt.Pass

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,12 @@
     using tab to wrap around the completion rows would fail when maxComplRows is
     restricting the number of rows of output.
 
+  * `XMonad.Prompt.Pass`
+
+    Added 'passOTPPrompt' to support getting OTP type password. This require
+    pass-otp (https://github.com/tadfisher/pass-otp) has been setup in the running
+    machine.
+
   * `XMonad.Actions.DynamicProjects`
 
     Make the input directory read from the prompt in `DynamicProjects`

--- a/XMonad/Prompt/Pass.hs
+++ b/XMonad/Prompt/Pass.hs
@@ -44,6 +44,7 @@ module XMonad.Prompt.Pass (
                             -- * Usage
                             -- $usage
                               passPrompt
+                            , passOTPPrompt
                             , passGeneratePrompt
                             , passRemovePrompt
                             , passEditPrompt
@@ -125,6 +126,11 @@ mkPassPrompt promptLabel passwordFunction xpconfig = do
 passPrompt :: XPConfig -> X ()
 passPrompt = mkPassPrompt "Select password" selectPassword
 
+-- | A prompt to retrieve a OTP from a given entry.
+--
+passOTPPrompt :: XPConfig -> X ()
+passOTPPrompt = mkPassPrompt "Select OTP" selectOTP
+
 -- | A prompt to generate a password for a given entry.
 -- This can be used to override an already stored entry.
 -- (Beware that no confirmation is asked)
@@ -154,6 +160,11 @@ passEditPrompt = mkPassPrompt "Edit password" editPassword
 --
 selectPassword :: String -> X ()
 selectPassword passLabel = spawn $ "pass --clip \"" ++ escapeQuote passLabel ++ "\""
+
+-- | Select a OTP.
+--
+selectOTP :: String -> X ()
+selectOTP passLabel = spawn $ "pass otp --clip \"" ++ escapeQuote passLabel ++ "\""
 
 -- | Generate a 30 characters password for a given entry.
 -- If the entry already exists, it is updated with a new password.


### PR DESCRIPTION
### Description

Support OTP type password in XMonad.Prompt.Pass. This require pass-otp (https://github.com/tadfisher/pass-otp) has been setup in the running machine.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
