### PR TITLE
Fix broken internal Haddock links

### DIFF
--- a/XMonad/Doc/Extending.hs
+++ b/XMonad/Doc/Extending.hs
@@ -467,7 +467,7 @@ Here is a list of the modules found in @XMonad.Hooks@:
 * "XMonad.Hooks.DebugStack":
     Dump the state of the StackSet. A logHook and handleEventHook are also provided.
 
-* "Xmonad.Hooks.DynamicBars":
+* "XMonad.Hooks.DynamicBars":
     Manage per-screen status bars.
 
 * "XMonad.Hooks.DynamicHooks":

--- a/XMonad/Layout/LayoutCombinators.hs
+++ b/XMonad/Layout/LayoutCombinators.hs
@@ -214,7 +214,7 @@ infixr 5 |||
 -- layouts, and use those.
 --
 -- For the ability to select a layout from a prompt, see
--- "Xmonad.Prompt.Layout".
+-- "XMonad.Prompt.Layout".
 
 -- | A reimplementation of the combinator of the same name from the
 --   xmonad core, providing layout choice, and the ability to support

--- a/XMonad/Prompt/FuzzyMatch.hs
+++ b/XMonad/Prompt/FuzzyMatch.hs
@@ -63,7 +63,7 @@ import Data.List
 -- > , ((modm .|. shiftMask, xK_g), windowPrompt myXPConfig Goto allWindows)
 --
 -- For detailed instructions on editing the key bindings, see
--- "Xmonad.Doc.Extending#Editing_key_bindings".
+-- "XMonad.Doc.Extending#Editing_key_bindings".
 
 -- | Returns True if the first argument is a subsequence of the second argument,
 -- that is, it can be obtained from the second sequence by deleting elements.

--- a/XMonad/Util/Image.hs
+++ b/XMonad/Util/Image.hs
@@ -37,7 +37,7 @@ data Placement = OffsetLeft Int Int   -- ^ An exact amount of pixels from the up
 -- In the module we suppose that those matrices are represented as [[Bool]],
 -- so the lengths of the inner lists must be the same.
 --
--- See "Xmonad.Layout.Decoration" for usage examples
+-- See "XMonad.Layout.Decoration" for usage examples
 
 -- | Gets the ('width', 'height') of an image
 imageDims :: [[Bool]] -> (Int, Int)


### PR DESCRIPTION
### Description

Fixes a few internal links that incorrectly referred to module paths starting with `Xmonad` (with a lowercase m). For example, the first link from the top here: https://hackage.haskell.org/package/xmonad-contrib-0.15/docs/XMonad-Util-Image.html


### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
