### PR TITLE
Add SplitShiftDirectional message into BinarySpacePartition layout.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,11 @@
     Add adwaitaTheme and adwaitaDarkTheme to match their respective
     GTK themes.
 
+  * 'XMonad.Layout.BinarySpacePartition'
+
+    Add a new `SplitShiftDirectional` message that allows moving windows by
+    splitting its neighbours.
+
 
 ## 0.15
 


### PR DESCRIPTION
### Description

This adds a new `SplitShiftDirectional` message to `BinarySpacePartition` layout.
The message allows users to easily move a window around by splitting either its left neighbor (`SplitShift Prev`) or right neighbor (`SplitShift Next`).

This functionality is similar to the existing `SelectNode` / `MoveNode` however, the usage is much easier and efficient for users if they want to quickly move neighboring windows with just a stroke of a key.

The changes introduced here do not interfere with any existing functionality.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
