### PR TITLE
Added 'allApplications' to XMonad.Prompt.Window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,11 +25,11 @@
 ### New Modules
 
   * `XMonad.Layout.TallMastersCombo`
-    A layout combinator that support Shrink, Expand, and IncMasterN just as 
-    the 'Tall' layout, and also support operations of two master windows: 
+    A layout combinator that support Shrink, Expand, and IncMasterN just as
+    the 'Tall' layout, and also support operations of two master windows:
     a main master, which is the original master window;
     a sub master, the first window of the second pane.
-    This combinator can be nested, and has a good support for using 
+    This combinator can be nested, and has a good support for using
     'XMonad.Layout.Tabbed' as a sublayout.
 
   * `XMonad.Layout.TwoPanePersistent`
@@ -78,6 +78,16 @@
 
     Made password prompts traverse symlinks when gathering password names for
     autocomplete.
+
+* `XMonad.Prompt.Window`
+
+    Added 'allApplications' function which maps application executable
+    names to it's underlying window.
+
+* `XMonad.Prompt.WindowBringer`
+
+    Added 'windowApMap' function which maps application executable
+    names to it's underlying window.
 
   * `XMonad.Actions.DynamicProjects`
 

--- a/XMonad/Actions/WindowBringer.hs
+++ b/XMonad/Actions/WindowBringer.hs
@@ -21,7 +21,7 @@ module XMonad.Actions.WindowBringer (
                     WindowBringerConfig(..),
                     gotoMenu, gotoMenuConfig, gotoMenu', gotoMenuArgs, gotoMenuArgs',
                     bringMenu, bringMenuConfig, bringMenu', bringMenuArgs, bringMenuArgs',
-                    windowMap, windowMap', bringWindow, actionMenu
+                    windowMap, windowAppMap, windowMap', bringWindow, actionMenu
                    ) where
 
 import Control.Applicative((<$>))
@@ -31,7 +31,7 @@ import qualified XMonad.StackSet as W
 import XMonad
 import qualified XMonad as X
 import XMonad.Util.Dmenu (menuMapArgs)
-import XMonad.Util.NamedWindows (getName)
+import XMonad.Util.NamedWindows (getName, getNameWMClass)
 
 -- $usage
 --
@@ -137,6 +137,10 @@ actionMenu WindowBringerConfig{ menuCommand = cmd
 windowMap :: X (M.Map String Window)
 windowMap = windowMap' decorateName
 
+-- | A map from application executable names to Windows.
+windowAppMap :: X (M.Map String Window)
+windowAppMap = windowMap' decorateAppName
+
 -- | A map from window names to Windows, given a windowTitler function.
 windowMap' :: (X.WindowSpace -> Window -> X String) -> X (M.Map String Window)
 windowMap' titler = do
@@ -151,4 +155,12 @@ windowMap' titler = do
 decorateName :: X.WindowSpace -> Window -> X String
 decorateName ws w = do
   name <- show <$> getName w
+  return $ name ++ " [" ++ W.tag ws ++ "]"
+
+-- | Returns the window name as will be listed in dmenu.  This will
+-- return the executable name of the window along with it's workspace
+-- ID.
+decorateAppName :: X.WindowSpace -> Window -> X String
+decorateAppName ws w = do
+  name <- show <$> getNameWMClass w
   return $ name ++ " [" ++ W.tag ws ++ "]"

--- a/XMonad/Prompt/Window.hs
+++ b/XMonad/Prompt/Window.hs
@@ -22,6 +22,7 @@ module XMonad.Prompt.Window
     windowPrompt,
     windowMultiPrompt,
     allWindows,
+    allApplications,
     wsWindows,
     XWindowMap,
 
@@ -119,6 +120,10 @@ windowPromptBringCopy c = windowPrompt c BringCopy windowMap
 -- | A helper to get the map of all windows.
 allWindows :: XWindowMap
 allWindows = windowMap
+
+-- | A helper to get the map of all applications
+allApplications :: XWindowMap
+allApplications = windowAppMap
 
 -- | A helper to get the map of windows of the current workspace.
 wsWindows :: XWindowMap

--- a/XMonad/Util/NamedWindows.hs
+++ b/XMonad/Util/NamedWindows.hs
@@ -18,6 +18,7 @@ module XMonad.Util.NamedWindows (
                                    -- $usage
                                    NamedWindow,
                                    getName,
+                                   getNameWMClass,
                                    withNamedWindow,
                                    unName
                                   ) where
@@ -54,6 +55,20 @@ getName w = withDisplay $ \d -> do
         copy prop = fromMaybe "" . listToMaybe <$> wcTextPropertyToTextList d prop
 
     io $ getIt `E.catch` \(SomeException _) ->  ((`NW` w) . resName) `fmap` getClassHint d w
+
+-- | Get 'NamedWindow' using 'wM_CLASS'
+getNameWMClass :: Window -> X NamedWindow
+getNameWMClass w =
+  withDisplay $ \d
+    -- TODO, this code is ugly and convoluted -- clean it up
+   -> do
+    let getIt = bracket getProp (xFree . tp_value) (fmap (`NW` w) . copy)
+        getProp = getTextProperty d w wM_CLASS
+        copy prop =
+          fromMaybe "" . listToMaybe <$> wcTextPropertyToTextList d prop
+    io $
+      getIt `E.catch` \(SomeException _) ->
+        ((`NW` w) . resName) `fmap` getClassHint d w
 
 unName :: NamedWindow -> Window
 unName (NW _ w) = w


### PR DESCRIPTION
### Description

This module allows you to associate the application name of windows with them. I have been using this [module](https://github.com/psibi/dotfiles/blob/30364f1b54a1c093b6eca14e2a263a070627d29a/.xmonad/xmonad.hs#L134) for more than a month and haven't see any problems with it.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
