### PR TITLE
Added module X.A.PerWindowKeys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,12 @@
     that are exclusive on the same screen. It also allows to remove this
     constraint of being mutually exclusive with another scratchpad.
 
+  * `XMonad.Actions.PerWindowKeys`
+
+    Create actions that run on a `Query Bool`, usually associated with
+    conditions on a window, basis. Useful for creating bindings that are
+    excluded or exclusive for some windows.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Prompt`

--- a/XMonad/Actions/PerWindowKeys.hs
+++ b/XMonad/Actions/PerWindowKeys.hs
@@ -1,0 +1,60 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Actions.PerWindowKeys
+-- Copyright   :  (c) Wilson Sales, 2019
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  Wilson Sales <spoonm@spoonm.org>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Define key-bindings on per-window basis.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Actions.PerWindowKeys (
+                                    -- * Usage
+                                    -- $usage
+                                    bindAll,
+                                    bindFirst
+                                   ) where
+
+import XMonad
+
+-- $usage
+--
+-- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
+--
+-- >  import XMonad.Actions.PerWindowKeys
+--
+-- >   ,((0, xK_F2), bindFirst [(className =? "firefox", spawn "dmenu"), (isFloat, withFocused $ windows . W.sink)])
+--
+-- >   ,((0, xK_F3), bindAll [(isDialog, kill), (pure True, doSomething)])
+--
+-- If you want an action that will always run, but also want to do something for
+-- other queries, you can use @'bindAll' [(query1, action1), ..., (pure True,
+-- alwaysDoThisAction)]@.
+--
+-- Similarly, if you want a default action to be run if all the others failed,
+-- you can use @'bindFirst' [(query1, action1), ..., (pure True,
+-- doThisIfTheOthersFail)]@.
+--
+-- For detailed instructions on editing your key bindings, see
+-- "XMonad.Doc.Extending#Editing_key_bindings".
+
+-- | Run an action if a Query holds true. Doesn't stop at the first one that
+-- does, however, and could potentially run all actions.
+bindAll :: [(Query Bool, X ())] -> X ()
+bindAll = mapM_ choose where
+  choose (mh,action) = withFocused $ \w -> whenX (runQuery mh w) action
+
+-- | Run the action paired with the first Query that holds true.
+bindFirst :: [(Query Bool, X ())] -> X ()
+bindFirst = withFocused . chooseOne
+
+chooseOne :: [(Query Bool, X ())] -> Window -> X ()
+chooseOne [] _ = return ()
+chooseOne ((mh,a):bs) w = do
+  c <- runQuery mh w
+  if c then a
+       else chooseOne bs w

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -116,6 +116,7 @@ library
                         XMonad.Actions.Navigation2D
                         XMonad.Actions.NoBorders
                         XMonad.Actions.OnScreen
+                        XMonad.Actions.PerWindowKeys
                         XMonad.Actions.PerWorkspaceKeys
                         XMonad.Actions.PhysicalScreens
                         XMonad.Actions.Plane


### PR DESCRIPTION
Allows one to shortcut actions that are performed based on queries.

### Description

Some XMonad users might want keybinds to perform different actions based on which window they are currently focusing. This adds two functions that allow them to perform either all actions for which a `Query Bool` holds true, or the first action for which that applies. One could also sequence the two for more complex behavior.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
