### PR TITLE
Use MonadFail where appropriate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
       with the documentation and now internally consistent. The old keymaps
       retain the original behavior; see the documentation to do the same your
       XMonad configuration.
+  * `XMonad.Util.Invisble`
+    - Requires `MonadFail` for `Read` instance
 
 ### New Modules
 

--- a/XMonad/Util/Invisible.hs
+++ b/XMonad/Util/Invisible.hs
@@ -34,7 +34,7 @@ import           Control.Monad.Fail  (MonadFail)
 
 newtype Invisible m a = I (m a) deriving (Monad, Applicative, Functor, MonadFail)
 
-instance (Functor m, Monad m, MonadFail (Invisible m)) => Read (Invisible m a) where
+instance (MonadFail (Invisible m)) => Read (Invisible m a) where
     readsPrec _ s = [(fail "Read Invisible", s)]
 
 instance Monad m => Show (Invisible m a) where


### PR DESCRIPTION
### Description

This makes `xmonad-contrib` work with GHC 8.8.1

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
