### PR TITLE
XMonad/Actions/Search: fix spelling mistake

### DIFF
--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -191,7 +191,7 @@ Or in combination with XMonad.Util.EZConfig:
 >
 > searchList :: [(String, S.SearchEngine)]
 > searchList = [ ("g", S.google)
->              , ("h", S.hoohle)
+>              , ("h", S.hoogle)
 >              , ("w", S.wikipedia)
 >              ]
 


### PR DESCRIPTION
### Description

Fixing simple spelling mistake in example section of XMonad/Actions/Search.hs
hoohle -> hoogle

