### PR TITLE
Prompt: Use searchPredicate in more cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@
 
 ### Breaking Changes
 
+  * `XMonad.Prompt`
+
+    Now `mkComplFunFromList` and `mkComplFunFromList'` take an
+    additional `XPConfig` argument, so that they can take into
+    account the given `searchPredicate`.
+
   * `XMonad.Hooks.EwmhDesktops`
 
     It is no longer recommended to use `fullscreenEventHook` directly.

--- a/XMonad/Actions/DynamicWorkspaceGroups.hs
+++ b/XMonad/Actions/DynamicWorkspaceGroups.hs
@@ -133,7 +133,7 @@ instance XPrompt WSGPrompt where
 promptWSGroupView :: XPConfig -> String -> X ()
 promptWSGroupView xp s = do
   gs <- fmap (M.keys . unWSG) XS.get
-  mkXPrompt (WSGPrompt s) xp (mkComplFunFromList' gs) viewWSGroup
+  mkXPrompt (WSGPrompt s) xp (mkComplFunFromList' xp gs) viewWSGroup
 
 -- | Prompt for a name for the current workspace group.
 promptWSGroupAdd :: XPConfig -> String -> X ()
@@ -144,4 +144,4 @@ promptWSGroupAdd xp s =
 promptWSGroupForget :: XPConfig -> String -> X ()
 promptWSGroupForget xp s = do
   gs <- fmap (M.keys . unWSG) XS.get
-  mkXPrompt (WSGPrompt s) xp (mkComplFunFromList' gs) forgetWSGroup
+  mkXPrompt (WSGPrompt s) xp (mkComplFunFromList' xp gs) forgetWSGroup

--- a/XMonad/Actions/TagWindows.hs
+++ b/XMonad/Actions/TagWindows.hs
@@ -180,7 +180,7 @@ instance XPrompt TagPrompt where
 tagPrompt :: XPConfig -> (String -> X ()) -> X ()
 tagPrompt c f = do
   sc <- tagComplList
-  mkXPrompt TagPrompt c (mkComplFunFromList' sc) f
+  mkXPrompt TagPrompt c (mkComplFunFromList' c sc) f
 
 tagComplList :: X [String]
 tagComplList = gets (concat . map (integrate' . stack) . workspaces . windowset) >>=
@@ -192,7 +192,7 @@ tagDelPrompt :: XPConfig -> X ()
 tagDelPrompt c = do
   sc <- tagDelComplList
   if (sc /= [])
-    then mkXPrompt TagPrompt c (mkComplFunFromList' sc) (\s -> withFocused (delTag s))
+    then mkXPrompt TagPrompt c (mkComplFunFromList' c sc) (\s -> withFocused (delTag s))
     else return ()
 
 tagDelComplList :: X [String]

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -1605,19 +1605,18 @@ mkUnmanagedWindow d s rw x y w h = do
 
 -- | This function takes a list of possible completions and returns a
 -- completions function to be used with 'mkXPrompt'
-mkComplFunFromList :: [String] -> String -> IO [String]
-mkComplFunFromList _ [] = return []
-mkComplFunFromList l s =
-  return $ filter (\x -> take (length s) x == s) l
+mkComplFunFromList :: XPConfig -> [String] -> String -> IO [String]
+mkComplFunFromList _ _ [] = return []
+mkComplFunFromList c l s =
+  pure $ filter (searchPredicate c s) l
 
 -- | This function takes a list of possible completions and returns a
 -- completions function to be used with 'mkXPrompt'. If the string is
 -- null it will return all completions.
-mkComplFunFromList' :: [String] -> String -> IO [String]
-mkComplFunFromList' l [] = return l
-mkComplFunFromList' l s =
-  return $ filter (\x -> take (length s) x == s) l
-
+mkComplFunFromList' :: XPConfig -> [String] -> String -> IO [String]
+mkComplFunFromList' _ l [] = return l
+mkComplFunFromList' c l s =
+  pure $ filter (searchPredicate c s) l
 
 -- | Given the prompt type, the command line and the completion list,
 -- return the next completion in the list for the last word of the

--- a/XMonad/Prompt/ConfirmPrompt.hs
+++ b/XMonad/Prompt/ConfirmPrompt.hs
@@ -48,4 +48,4 @@ instance XPrompt EnterPrompt where
      and simply ask to confirm (ENTER) or cancel (ESCAPE). The actual key
      handling is done by mkXPrompt.-}
 confirmPrompt :: XPConfig -> String -> X() -> X()
-confirmPrompt config app func = mkXPrompt (EnterPrompt app) config (mkComplFunFromList []) $ const func
+confirmPrompt config app func = mkXPrompt (EnterPrompt app) config (mkComplFunFromList config []) $ const func

--- a/XMonad/Prompt/Email.hs
+++ b/XMonad/Prompt/Email.hs
@@ -56,7 +56,7 @@ import XMonad.Prompt.Input
 --   of addresses for autocompletion.
 emailPrompt :: XPConfig -> [String] -> X ()
 emailPrompt c addrs =
-    inputPromptWithCompl c "To" (mkComplFunFromList addrs) ?+ \to ->
+    inputPromptWithCompl c "To" (mkComplFunFromList c addrs) ?+ \to ->
     inputPrompt c "Subject" ?+ \subj ->
     inputPrompt c "Body" ?+ \body ->
     runProcessWithInput "mail" ["-s", subj, to] (body ++ "\n")

--- a/XMonad/Prompt/Layout.hs
+++ b/XMonad/Prompt/Layout.hs
@@ -46,4 +46,4 @@ import XMonad.Layout.LayoutCombinators ( JumpToLayout(..) )
 
 layoutPrompt :: XPConfig -> X ()
 layoutPrompt c = do ls <- gets (map (description . layout) . workspaces . windowset)
-                    mkXPrompt (Wor "") c (mkComplFunFromList' $ sort $ nub ls) (sendMessage . JumpToLayout)
+                    mkXPrompt (Wor "") c (mkComplFunFromList' c $ sort $ nub ls) (sendMessage . JumpToLayout)

--- a/XMonad/Prompt/Man.hs
+++ b/XMonad/Prompt/Man.hs
@@ -60,7 +60,7 @@ instance XPrompt Man where
 manPrompt :: XPConfig -> X ()
 manPrompt c = do
   mans <- io getMans
-  mkXPrompt Man c (manCompl mans) $ runInTerm "" . (++) "man "
+  mkXPrompt Man c (manCompl c mans) $ runInTerm "" . (++) "man "
 
 getMans :: IO [String]
 getMans = do
@@ -80,12 +80,12 @@ getMans = do
               else return []
   return $ uniqSort $ concat mans
 
-manCompl :: [String] -> String -> IO [String]
-manCompl mans s | s == "" || last s == ' ' = return []
-                | otherwise                = do
+manCompl :: XPConfig -> [String] -> String -> IO [String]
+manCompl c mans s | s == "" || last s == ' ' = return []
+                  | otherwise                = do
   -- XXX readline instead of bash's compgen?
   f <- lines <$> getCommandOutput ("bash -c 'compgen -A file " ++ s ++ "'")
-  mkComplFunFromList (f ++ mans) s
+  mkComplFunFromList c (f ++ mans) s
 
 -- | Run a command using shell and return its output.
 --

--- a/XMonad/Prompt/Ssh.hs
+++ b/XMonad/Prompt/Ssh.hs
@@ -57,14 +57,14 @@ instance XPrompt Ssh where
     showXPrompt       Ssh = "SSH to: "
     commandToComplete _ c = maybe c (\(_u,h) -> h) (parseHost c)
     nextCompletion _t c l = maybe next (\(u,_h) -> u ++ "@" ++ next) hostPared
-                            where 
+                            where
                               hostPared = parseHost c
                               next = getNextCompletion (maybe c (\(_u,h) -> h) hostPared) l
 
 sshPrompt :: XPConfig -> X ()
 sshPrompt c = do
   sc <- io sshComplList
-  mkXPrompt Ssh c (mkComplFunFromList sc) ssh
+  mkXPrompt Ssh c (mkComplFunFromList c sc) ssh
 
 ssh :: String -> X ()
 ssh = runInTerm "" . ("ssh " ++ )

--- a/XMonad/Prompt/Theme.hs
+++ b/XMonad/Prompt/Theme.hs
@@ -48,7 +48,7 @@ instance XPrompt ThemePrompt where
     nextCompletion      _ = getNextCompletion
 
 themePrompt :: XPConfig -> X ()
-themePrompt c = mkXPrompt ThemePrompt c (mkComplFunFromList' . map ppThemeInfo $ listOfThemes) changeTheme
+themePrompt c = mkXPrompt ThemePrompt c (mkComplFunFromList' c . map ppThemeInfo $ listOfThemes) changeTheme
     where changeTheme t = sendMessage . SetTheme . fromMaybe def $ M.lookup t mapOfThemes
 
 mapOfThemes :: M.Map String Theme

--- a/XMonad/Prompt/Workspace.hs
+++ b/XMonad/Prompt/Workspace.hs
@@ -46,4 +46,4 @@ workspacePrompt :: XPConfig -> (String -> X ()) -> X ()
 workspacePrompt c job = do ws <- gets (workspaces . windowset)
                            sort <- getSortByIndex
                            let ts = map tag $ sort ws
-                           mkXPrompt (Wor "") c (mkComplFunFromList' ts) job
+                           mkXPrompt (Wor "") c (mkComplFunFromList' c ts) job

--- a/XMonad/Prompt/XMonad.hs
+++ b/XMonad/Prompt/XMonad.hs
@@ -51,5 +51,5 @@ xmonadPrompt c = do
 -- | An xmonad prompt with a custom command list
 xmonadPromptC :: [(String, X ())] -> XPConfig -> X ()
 xmonadPromptC commands c =
-    mkXPrompt XMonad c (mkComplFunFromList' (map fst commands)) $
+    mkXPrompt XMonad c (mkComplFunFromList' c (map fst commands)) $
         fromMaybe (return ()) . (`lookup` commands)


### PR DESCRIPTION
### Description

Prompts based on `mkComplFunList` and `mkComplFunList'` were not taking into account the `searchPredicate` funtion from `XPConfig`. This was rather confusing.

We fix it by passing `XPConfig` to these functions; although this is strictly more than they need, it makes the breaking change very easy to fix and is also more future-proof.


### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)
 
    I'm using the amended `workspacePrompt` on my own config. The rest of the changes were type-directed.
   
  - [x] I updated the `CHANGES.md` file
