### PR TITLE
XMonad.Layout.BoringWindows: add markBoringEverywhere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
   * `XMonad.Actions.Search`
 
     The `hoogle` function now uses the new URL `hoogle.haskell.org`.
+    
+  * `XMonad.Layout.BoringWindows`
+  
+    Added 'markBoringEverywhere' function, to mark the currently
+    focused window boring on all layouts, when using 'XMonad.Actions.CopyWindow'.
 
 ## 0.16
 

--- a/XMonad/Layout/BoringWindows.hs
+++ b/XMonad/Layout/BoringWindows.hs
@@ -18,8 +18,9 @@ module XMonad.Layout.BoringWindows (
                                    -- * Usage
                                    -- $usage
                                    boringWindows, boringAuto,
-                                   markBoring, clearBoring,
-                                   focusUp, focusDown, focusMaster,
+                                   markBoring, markBoringEverywhere,
+                                   clearBoring, focusUp, focusDown,
+                                   focusMaster,
 
                                    UpdateBoring(UpdateBoring),
                                    BoringMessage(Replace,Merge),
@@ -33,7 +34,7 @@ module XMonad.Layout.BoringWindows (
 import XMonad.Layout.LayoutModifier(ModifiedLayout(..),
                                     LayoutModifier(handleMessOrMaybeModifyIt, redoLayout))
 import XMonad(Typeable, LayoutClass, Message, X, fromMessage,
-              sendMessage, windows, withFocused, Window)
+              broadcastMessage, sendMessage, windows, withFocused, Window)
 import Data.List((\\), union)
 import Data.Maybe(fromMaybe, listToMaybe, maybeToList)
 import qualified Data.Map as M
@@ -80,6 +81,11 @@ clearBoring = sendMessage ClearBoring
 focusUp = sendMessage UpdateBoring >> sendMessage FocusUp
 focusDown = sendMessage UpdateBoring >> sendMessage FocusDown
 focusMaster = sendMessage UpdateBoring >> sendMessage FocusMaster
+
+-- | Mark current focused window boring for all layouts.
+-- This is useful in combination with the 'XMonad.Actions.CopyWindow' module.
+markBoringEverywhere :: X ()
+markBoringEverywhere = withFocused (broadcastMessage . IsBoring)
 
 data BoringWindows a = BoringWindows
     { namedBoring :: M.Map String [a] -- ^ store borings with a specific source


### PR DESCRIPTION
### Description

To mark the currently focused window boring on all layouts,
when using XMonad.Actions.CopyWindow.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file