### PR TITLE
X.L.MouseResizableTile borderWidth via focused win

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,11 @@
 
     The `hoogle` function now uses the new URL `hoogle.haskell.org`.
 
+  * `XMonad.Layout.MouseResizableTile`
+
+    When we calculate dragger widths, we first try to get the border width of
+    the focused window, before failing over to using the initial `borderWidth`.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/MouseResizableTile.hs
+++ b/XMonad/Layout/MouseResizableTile.hs
@@ -36,6 +36,7 @@ module XMonad.Layout.MouseResizableTile (
 import XMonad hiding (tile, splitVertically, splitHorizontallyBy)
 import qualified XMonad.StackSet as W
 import XMonad.Util.XUtils
+import Graphics.X11 as X
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
@@ -189,8 +190,17 @@ draggerGeometry :: DraggerType -> X DraggerGeometry
 draggerGeometry (FixedDragger g d) =
     return (fromIntegral $ g `div` 2, g, fromIntegral $ d `div` 2, d)
 draggerGeometry BordersDragger = do
-    w <- asks (borderWidth . config)
+    wins <- gets windowset
+    w <- case W.peek wins of
+          Just win -> getBorderWidth win
+          _        -> asks (borderWidth . config)
     return (0, 0, fromIntegral w, 2*w)
+
+getBorderWidth :: Window -> X Dimension
+getBorderWidth win = do
+    d <- asks display
+    (_,_,_,_,_,w,_) <- io $ X.getGeometry d win
+    return w
 
 adjustForMirror :: Bool -> DraggerWithRect -> DraggerWithRect
 adjustForMirror False dragger = dragger


### PR DESCRIPTION
When we calculate draggerGeometry, we should use the current width of
the border (if available), rather than the initial borderWidth.

Otherwise, we get the wrong width if the user has changed the borderWidth since XMonad started.


  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file