### PR TITLE
Use `drop 1` instead of reimplementing it in terms of `tail`

### DIFF
--- a/XMonad/Prompt/Shell.hs
+++ b/XMonad/Prompt/Shell.hs
@@ -126,11 +126,9 @@ getCommands = do
 split :: Eq a => a -> [a] -> [[a]]
 split _ [] = []
 split e l =
-    f : split e (rest ls)
+    f : split e (drop 1 ls)
         where
           (f,ls) = span (/=e) l
-          rest s | s == []   = []
-                 | otherwise = tail s
 
 escape :: String -> String
 escape []       = ""


### PR DESCRIPTION
### Description

`tail` is a partial function and should be avoided where practical. In this case, it's being used to create a function exactly equivalent to `drop 1`, so just remove that function and use that instead.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file
