### PR TITLE
X.A.Search: Add promptSearchBrowser'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,8 +51,10 @@
 
   * `XMonad.Actions.Search`
 
-    The `hoogle` function now uses the new URL `hoogle.haskell.org`.
-    
+    - The `hoogle` function now uses the new URL `hoogle.haskell.org`.
+    - Added `promptSearchBrowser'` function to only suggest previous searches of
+      the selected search engine (instead of all search engines).
+
   * `XMonad.Layout.BoringWindows`
   
     Added 'markBoringEverywhere' function, to mark the currently

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -18,6 +18,7 @@ module XMonad.Actions.Search (   -- * Usage
                                  searchEngineF,
                                  promptSearch,
                                  promptSearchBrowser,
+                                 promptSearchBrowser',
                                  selectSearch,
                                  selectSearchBrowser,
                                  isPrefixOf,
@@ -360,6 +361,18 @@ namedEngine name (SearchEngine _ site) = searchEngineF name site
 promptSearchBrowser :: XPConfig -> Browser -> SearchEngine -> X ()
 promptSearchBrowser config browser (SearchEngine name site) =
     mkXPrompt (Search name) config (historyCompletionP ("Search [" `isPrefixOf`)) $ search browser site
+
+{- | Like 'promptSearchBrowser', but only suggest previous searches for the
+   given 'SearchEngine' in the prompt. -}
+promptSearchBrowser' :: XPConfig -> Browser -> SearchEngine -> X ()
+promptSearchBrowser' config browser (SearchEngine name site) =
+    mkXPrompt
+        (Search name)
+        config
+        (historyCompletionP (searchName `isPrefixOf`))
+        $ search browser site
+  where
+    searchName = showXPrompt (Search name)
 
 {- | Like 'search', but in this case, the string is not specified but grabbed
  from the user's response to a prompt. Example:


### PR DESCRIPTION
# Description

Adds a new function, `promptSearchBrowser'`, which behaves almost exactly like `promptSearchBrowser`, the only difference being that the former only suggests previous searches of the selected search engine.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file
