### PR TITLE
CycleRecentWS: add non-empty and toggle functionality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,18 @@
     When we calculate dragger widths, we first try to get the border width of
     the focused window, before failing over to using the initial `borderWidth`.
 
+  * `XMonad.Actions.CycleRecentWS`
+
+    - Added `cycleRecentNonEmptyWS` function which behaves like `cycleRecentWS`
+      but is constrainded to non-empty workspaces.
+
+    - Added `toggleRecentWS` and `toggleRecentNonEmptyWS` functions which toggle
+      between the current and most recent workspace, and continue to toggle back
+      and forth on repeated presses, rather than cycling through other workspaces.
+
+    - Added `recentWS` function which allows the recency list to be filtered with
+      a user-provided predicate.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Actions/CycleRecentWS.hs
+++ b/XMonad/Actions/CycleRecentWS.hs
@@ -79,7 +79,9 @@ recentWS :: (WindowSpace -> Bool) -> WindowSet -> [WindowSet]
 recentWS p w = map (`view` w) recentTags
  where recentTags = map tag
                   $ filter p
-                  $ tail (workspaces w) ++ [head (workspaces w)]
+                  $ map workspace (visible w)
+                    ++ hidden w
+                    ++ [workspace (current w)]
 
 
 cycref :: [a] -> Int -> a

--- a/XMonad/Actions/CycleRecentWS.hs
+++ b/XMonad/Actions/CycleRecentWS.hs
@@ -23,7 +23,8 @@ module XMonad.Actions.CycleRecentWS (
                                 cycleWindowSets,
                                 toggleRecentWS,
                                 toggleRecentNonEmptyWS,
-                                toggleWindowSets
+                                toggleWindowSets,
+                                recentWS
 ) where
 
 import XMonad hiding (workspaces)
@@ -75,7 +76,11 @@ toggleRecentNonEmptyWS :: X ()
 toggleRecentNonEmptyWS = toggleWindowSets $ recentWS (not . null . stack)
 
 
-recentWS :: (WindowSpace -> Bool) -> WindowSet -> [WindowSet]
+-- | Given a predicate p and the current WindowSet w, create a list of recent WindowSets,
+-- most recent first, where the focused workspace satisfies p.
+recentWS :: (WindowSpace -> Bool) -- ^ A workspace predicate.
+         -> WindowSet             -- ^ The current WindowSet
+         -> [WindowSet]
 recentWS p w = map (`view` w) recentTags
  where recentTags = map tag
                   $ filter p


### PR DESCRIPTION
### Description

When cycling through recent workspaces, it's nice to able to ignore those that are empty. I added `cycleRecentNonEmptyWS` to support that.

Users may have their own constraints they'd like to filter by, so a `recentWS` function has been exported and can be used to apply a user-provided predicate to the list of workspaces considered.

In addition to cycling, which updates the recency list only after a modifier key is released, it's useful to have a keybinding that toggles between the current and most recent workspace, with repeated key presses toggling back and forth even if no modifier key is released. The `toggleRecentWS` and `toggleRecentNonEmptyWS` functions provide this ability.

For context, I use these in my xmonad.hs as follows:
```haskell
  , ((mod1Mask, xK_l     ), toggleRecentNonEmptyWS)
  , ((mod1Mask, xK_Tab   ), cycleRecentNonEmptyWS [xK_Alt_L, xK_Alt_R] xK_Tab xK_grave)
```

Since toggling is a bit different than cycling, I'm open to the idea of moving that into a separate module. I added it to `CycleRecentWS` since its implementation is quite similar, but could easily extract it.

I made five distinct commits to make it clear what the intent of each step was. I think that will make the review process easier, but I'm happy to squash the commits if that's preferred.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

### Testing Notes

I tested according to the instructions in xmonad-testing, and documented the exact steps [here](https://github.com/ivanbrennan/xmonad-testing/commit/5407b20d6e190b5725d9e12816662eec7402fbfb). It was basically:
- pull in the changes from this PR
- write a minimal config file, binding the cycle/toggle functions to keys not bound in my host config
- build with cabal
- run in Xephyr
- test the cycling/toggling functions

Everything worked as expected.