### PR TITLE
Allow WindowPrompt to execute arbitrary actions with the window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,11 @@
     - Added `recentWS` function which allows the recency list to be filtered with
       a user-provided predicate.
 
+  * `XMonad.Prompt.Window`
+    
+    - Added a `WithWindow` constructor to `WindowPrompt` to allow executing
+      actions of type `Window -> X ()` on the chosen window.
+
 ## 0.16
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

I use it to add windows to the current tab group like so:

```
bringAsTabbed :: WindowPrompt
bringAsTabbed = WithWindow "Bring to tab group: " $ \w -> do
  cur <- getFocused
  windows $ \ss -> W.shiftWin (W.currentTag ss) w ss
  maybe (pure ()) (sendMessage . Migrate w) cur

```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
