### PR TITLE
Add a doSink manage hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -513,7 +513,8 @@
 
   * `XMonad.Hooks.ManageHelpers`
 
-    Make type of ManageHook combinators more general.
+    - Make type of ManageHook combinators more general.
+    - New manage hook `doSink` for sinking windows (as upposed to the `doFloat` manage hook)
 
   * `XMonad.Prompt`
 

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -226,3 +226,7 @@ doCenterFloat = doSideFloat C
 -- | Hides window and ignores it.
 doHideIgnore :: ManageHook
 doHideIgnore = ask >>= \w -> liftX (hide w) >> doF (W.delete w)
+
+-- | Sinks a window
+doSink :: ManageHook
+doSink = reader (Endo . sink)

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -229,4 +229,4 @@ doHideIgnore = ask >>= \w -> liftX (hide w) >> doF (W.delete w)
 
 -- | Sinks a window
 doSink :: ManageHook
-doSink = reader (Endo . sink)
+doSink = reader (Endo . W.sink)


### PR DESCRIPTION
### Description

Added a new manage hook `doSink`, which does the opposite of `doFloat`.
It seemed like a gap in the available configuration functions that was easy to fill.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
