### PR TITLE
HiddenWindows: export type constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,10 @@
     - Added a `WithWindow` constructor to `WindowPrompt` to allow executing
       actions of type `Window -> X ()` on the chosen window.
 
+  * `XMonad.Layout.Hidden`
+
+    - Export `HiddenWindows` type constructor.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/Hidden.hs
+++ b/XMonad/Layout/Hidden.hs
@@ -20,7 +20,8 @@
 module XMonad.Layout.Hidden
        ( -- * Usage
          -- $usage
-         HiddenMsg (..)
+         HiddenWindows
+       , HiddenMsg (..)
        , hiddenWindows
        , hideWindow
        , popOldestHiddenWindow


### PR DESCRIPTION
### Description

Some users like to include type signatures in their configuration. (I am one such user.)

The `HiddenWindows` type constructor was not exported, making it impossible to write a type signature when using `hiddenWindows`.

With this change, a user can write an xmonad.hs like:
```haskell
import XMonad
import XMonad.Layout.Hidden (HiddenWindows, hiddenWindows)
import XMonad.Layout.LayoutModifier

myLayout :: ModifiedLayout
            HiddenWindows
            (Choose Tall (Choose (Mirror Tall) Full))
            Window
myLayout = hiddenWindows $ layoutHook def

main :: IO ()
main = xmonad def { layoutHook = myLayout }
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) (documented in [this commit](https://github.com/ivanbrennan/xmonad-testing/commit/a47f5b26dfb03c0fc5b16d21beca9b685683aeb3))

  - [x] I updated the `CHANGES.md` file
