### PR TITLE
Add maxMagnifierOff to Magnifier layout

### DIFF
--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -23,6 +23,7 @@ module XMonad.Layout.Magnifier
       magnifier,
       magnifier',
       magnifierOff,
+      maxMagnifierOff,
       magnifiercz,
       magnifiercz',
       maximizeVertical,
@@ -97,6 +98,10 @@ magnifier' = ModifiedLayout (Mag 1 (1.5,1.5) On NoMaster)
 -- | Magnifier that defaults to Off
 magnifierOff :: l a -> ModifiedLayout Magnifier l a
 magnifierOff = ModifiedLayout (Mag 1 (1.5,1.5) Off All)
+
+-- | A magnifier that greatly magnifies with defaults to Off
+maxMagnifierOff :: l a -> ModifiedLayout Magnifier l a
+maxMagnifierOff = ModifiedLayout (Mag 1 (1000,1000) Off All)
 
 -- | Increase the size of the window that has focus by a custom zoom,
 -- unless if it is one of the the master windows.


### PR DESCRIPTION
### Description

It's useful to wrap layouts with `magnifierOff` and use Magnifier in cases when you needed to zoom window, but when you zoom window it makes sense to show it in max size without using `MagnifyMore` which is layout specific. We have `maximizeVertical` which work in a similar way but it uses only vertical space and ignores horizontal

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
