### PR TITLE
X.U.DynamicScratchpads: Make any window a scratchpad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,11 @@
     conditions on a window, basis. Useful for creating bindings that are
     excluded or exclusive for some windows.
 
+  * `XMonad.Util.DynamicScratchpads`
+
+    Declare any window as a scratchpad on the fly. Once declared, the
+    scratchpad behaves like `XMonad.Util.NamedScratchpad`.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Util.Run` 

--- a/XMonad/Util/DynamicScratchpads.hs
+++ b/XMonad/Util/DynamicScratchpads.hs
@@ -1,0 +1,96 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Util.DynamicScratchpads
+-- Copyright   :  (c) Robin Oberschweiber <mephory@mephory.com>
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  Robin Obercshweiber <mephory@mephory.com>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Dynamically declare any window as a scratchpad.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Util.DynamicScratchpads (
+  -- * Usage
+  -- $usage
+  makeDynamicSP,
+  spawnDynamicSP
+  ) where
+
+import Graphics.X11.Types
+import XMonad.Core
+import XMonad.Operations
+import qualified Data.Map as M
+import qualified XMonad.StackSet as W
+import qualified XMonad.Util.ExtensibleState as XS
+
+
+-- $usage
+-- Allows you to dynamically declare windows as scratchpads. You can bind a key
+-- to make a window start/stop being a scratchpad, and another key to
+-- spawn/hide that scratchpad.
+--
+-- Like with XMonad.Util.NamedScratchpad, you have to have a workspace called
+-- NSP, where hidden scratchpads will be moved to.
+--
+-- You can declare dynamic scrachpads in your xmonad.hs like so:
+--
+-- import XMonad.Util.DynamicScratchpads
+--
+-- , ((modm .|. shiftMask, xK_a), withFocused $ makeDynamicSP "dyn1")
+-- , ((modm .|. shiftMask, xK_b), withFocused $ makeDynamicSP "dyn2")
+-- , ((modm              , xK_a), spawnDynamicSP "dyn1")
+-- , ((modm              , xK_b), spawnDynamicSP "dyn2")
+
+-- | Stores dynamic scratchpads as a map of name to window
+data SPStorage = SPStorage (M.Map String Window)
+    deriving (Typeable,Read,Show)
+
+instance ExtensionClass SPStorage where
+    initialValue = SPStorage $ M.fromList []
+    extensionType = PersistentExtension
+
+-- | Makes a window a dynamic scratchpad with the given name, or stop a window
+-- | from being a dynamic scratchpad, if it already is.
+makeDynamicSP :: String -- ^ Scratchpad name
+              -> Window -- ^ Window to be made a scratchpad
+              -> X ()
+makeDynamicSP s w = do
+    (SPStorage m) <- XS.get
+    case M.lookup s m of
+        Nothing -> addDynamicSP s w
+        Just ow  -> if w == ow
+                    then removeDynamicSP s
+                    else (showWindow ow >> addDynamicSP s w)
+
+-- | Spawn the specified dynamic scratchpad
+spawnDynamicSP :: String -- ^ Scratchpad name
+               -> X ()
+spawnDynamicSP s = do
+    (SPStorage m) <- XS.get
+    case M.lookup s m of
+        Nothing -> mempty
+        Just w  -> spawnDynamicSP' w
+
+spawnDynamicSP' :: Window -> X ()
+spawnDynamicSP' w = withWindowSet $ \s -> do
+    let matchingWindows = filter (== w) ((maybe [] W.integrate . W.stack . W.workspace . W.current) s)
+    case matchingWindows of
+        [] -> showWindow w
+        _  -> hideWindow w
+
+-- | Make a window a dynamic scratchpad
+addDynamicSP :: String -> Window -> X ()
+addDynamicSP s w = XS.modify $ alterSPStorage (\_ -> Just w) s
+
+-- | Make a window stop being a dynamic scratchpad
+removeDynamicSP :: String -> X ()
+removeDynamicSP s = XS.modify $ alterSPStorage (\_ -> Nothing) s
+
+-- | Moves window to the scratchpad workspace, effectively hiding it
+hideWindow :: Window -> X ()
+hideWindow = windows . W.shiftWin "NSP"
+
+-- vim:ts=4:shiftwidth=4:softtabstop=4:expandtab:

--- a/XMonad/Util/DynamicScratchpads.hs
+++ b/XMonad/Util/DynamicScratchpads.hs
@@ -93,4 +93,12 @@ removeDynamicSP s = XS.modify $ alterSPStorage (\_ -> Nothing) s
 hideWindow :: Window -> X ()
 hideWindow = windows . W.shiftWin "NSP"
 
+-- | Move window to current workspace and focus it
+showWindow :: Window -> X ()
+showWindow w = windows $ \ws ->
+    (W.focusWindow w) . (W.shiftWin (W.currentTag ws) w) $ ws
+
+alterSPStorage :: (Maybe Window -> Maybe Window) -> String -> SPStorage -> SPStorage
+alterSPStorage f k (SPStorage m) = SPStorage $ M.alter f k m
+
 -- vim:ts=4:shiftwidth=4:softtabstop=4:expandtab:

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -319,6 +319,7 @@ library
                         XMonad.Util.CustomKeys
                         XMonad.Util.DebugWindow
                         XMonad.Util.Dmenu
+                        XMonad.Util.DynamicScratchpads
                         XMonad.Util.Dzen
                         XMonad.Util.EZConfig
                         XMonad.Util.ExclusiveScratchpads


### PR DESCRIPTION
### Description

This is a module I built for myself, and I think it could potentially be interesting for others, too. It allows you to bind a key to make any window a scratchpad that behaves just like `XMonad.Util.NamedScratchpad`. You can then bind another key to spawn or hide that scratchpad.

So, with the following key bindings, you could hit `mod+Shift+A` to declare the focused window as a scratchpad. You can then show or hide the window with `mod+A`.

```haskell
 , ((modm .|. shiftMask, xK_a), withFocused $ makeDynamicSP "dyn1")
 , ((modm              , xK_a), spawnDynamicSP "dyn1")
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
