### PR TITLE
Make spawnPipe to use system's locale encoding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,9 +46,13 @@
 
   * `XMonad.Util.Run` 
   
-     Added two new functions to the module: `spawnPipeWithLocaleEncoding` and
-     `spawnPipeWithUtf8Encoding`. Using these function should be
-     preferred over `spawnPipe`.
+     Added two new functions to the module:
+     `spawnPipeWithLocaleEncoding` and
+     `spawnPipeWithUtf8Encoding`. `spawnPipe` is now alias for
+     `spawnPipeWithLocaleEncoding`.
+
+     Added the function `spawnPipeWithNoEncoding` for cases where
+     binary handle is required.
 
   * `XMonad.Prompt.Window`
 

--- a/XMonad/Util/Run.hs
+++ b/XMonad/Util/Run.hs
@@ -29,6 +29,7 @@ module XMonad.Util.Run (
                           spawnPipe,
                           spawnPipeWithLocaleEncoding,
                           spawnPipeWithUtf8Encoding,
+                          spawnPipeWithNoEncoding,
                           hPutStr, hPutStrLn  -- re-export for convenience
                          ) where
 
@@ -148,11 +149,15 @@ runInTerm = unsafeRunInTerm
 safeRunInTerm :: String -> String -> X ()
 safeRunInTerm options command = asks (terminal . config) >>= \t -> safeSpawn t [options, " -e " ++ command]
 
+-- | Same as 'spawnPipeWithLocaleEncoding'
+spawnPipe :: MonadIO m => String -> m Handle
+spawnPipe = spawnPipeWithLocaleEncoding
+
 -- | Launch an external application through the system shell and
 -- return a @Handle@ to its standard input. Note that the @Handle@
 -- is a binary Handle. You should probably use 'spawnPipeWithUtf8Encoding'.
-spawnPipe :: MonadIO m => String -> m Handle
-spawnPipe x = io $ do
+spawnPipeWithNoEncoding :: MonadIO m => String -> m Handle
+spawnPipeWithNoEncoding x = io $ do
     (rd, wr) <- createPipe
     setFdOption wr CloseOnExec True
     h <- fdToHandle wr


### PR DESCRIPTION
Add a function named spawnPipeWithNoEncoding for people who might want
to use binary handles.

Fixes https://github.com/xmonad/xmonad-contrib/issues/338

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file
