### PR TITLE
Permissive font pattern by default (fix broken layout)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,16 @@
 
 ### Breaking Changes
 
+  * All modules that export bitmap fonts as their default
+
+    - If xmonad is compiled with XFT support (the default), use an XFT
+      font instead.  The previous default expected an X11 misc font
+      (PCF), which is not supported in pango 1.44 anymore and thus some
+      distributions have stopped shipping these.
+
+      This fixes the silent `user error (createFontSet)`; this would
+      break the respective modules.
+
   * `XMonad.Prompt`
 
     - Now `mkComplFunFromList` and `mkComplFunFromList'` take an

--- a/XMonad/Actions/ShowText.hs
+++ b/XMonad/Actions/ShowText.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE CPP                #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Actions.ShowText
@@ -74,7 +75,11 @@ data ShowTextConfig =
 
 instance Default ShowTextConfig where
   def =
+#ifdef XFT
+    STC { st_font = "xft:monospace-20"
+#else
     STC { st_font = "-misc-fixed-*-*-*-*-20-*-*-*-*-*-*-*"
+#endif
         , st_bg   = "black"
         , st_fg   = "white"
     }

--- a/XMonad/Layout/Decoration.hs
+++ b/XMonad/Layout/Decoration.hs
@@ -1,4 +1,10 @@
-{-# LANGUAGE DeriveDataTypeable, FlexibleContexts, FlexibleInstances, MultiParamTypeClasses, PatternGuards, TypeSynonymInstances #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternGuards         #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
+{-# LANGUAGE CPP                   #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Layout.Decoration
@@ -104,7 +110,11 @@ instance Default Theme where
           , activeTextColor     = "#FFFFFF"
           , inactiveTextColor   = "#BFBFBF"
           , urgentTextColor     = "#FF0000"
+#ifdef XFT
+          , fontName            = "xft:monospace"
+#else
           , fontName            = "-misc-fixed-*-*-*-*-10-*-*-*-*-*-*-*"
+#endif
           , decoWidth           = 200
           , decoHeight          = 20
           , windowTitleAddons   = []

--- a/XMonad/Layout/ShowWName.hs
+++ b/XMonad/Layout/ShowWName.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE PatternGuards, FlexibleInstances, MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternGuards         #-}
+{-# LANGUAGE CPP                   #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Layout.ShowWName
@@ -62,7 +65,11 @@ data SWNConfig =
 
 instance Default SWNConfig where
   def =
+#ifdef XFT
+    SWNC { swn_font    = "xft:monospace-20"
+#else
     SWNC { swn_font    = "-misc-fixed-*-*-*-*-20-*-*-*-*-*-*-*"
+#endif
          , swn_bgcolor = "black"
          , swn_color   = "white"
          , swn_fade    = 1

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Prompt
@@ -310,7 +311,11 @@ instance Default XPColor where
 
 instance Default XPConfig where
   def =
+#ifdef XFT
+    XPC { font                  = "xft:monospace-12"
+#else
     XPC { font                  = "-misc-fixed-*-*-*-*-12-*-*-*-*-*-*-*"
+#endif
         , bgColor               = bgNormal def
         , fgColor               = fgNormal def
         , bgHLight              = bgHighlight def


### PR DESCRIPTION
Layout broken if font is not found with `user error (createFontSet)`

Pango 1.44 dropped support for FreeType in favor of HarfBuzz thus losing support for traditional BDF/PCF bitmap fonts. There would be no `xorg-fonts-misc` on future installations.

Fixes https://github.com/xmonad/xmonad-contrib/issues/348

### Description

Change default `fontName` to accept any font.  Previous default expects XOrg misc font (PCF) which is not supported in pango 1.44 anymore and would not be present in future installations.

Font not found causes silent `user error (createFontSet)` and breaks Layout.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

I've tested with latest `git` versions of `xmonad` and `xmonad-contrib`