### PR TITLE
Add XMonad.Doc.Extending to PR-checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,5 @@ behind them.
   - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)
 
   - [ ] I updated the `CHANGES.md` file
+
+  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)


### PR DESCRIPTION
### Description

This PR adds a new checkbox to the PR checklist, asking the contributor to document any new modules they added in `XMonad.Doc.Extending`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file