### PR TITLE
Add XMonad.Prompt.Zsh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,11 @@
     Declare any window as a scratchpad on the fly. Once declared, the
     scratchpad behaves like `XMonad.Util.NamedScratchpad`.
 
+  * `XMonad.Prompt.Zsh`
+
+    A version of `XMonad.Prompt.Shell` that lets you use completions supplied by
+    zsh.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Util.Run` 

--- a/XMonad/Prompt/Zsh.hs
+++ b/XMonad/Prompt/Zsh.hs
@@ -1,0 +1,64 @@
+{- |
+Module      :  XMonad.Prompt.Zsh
+Copyright   :  (C) 2020 Zubin Duggal
+License     :  BSD3
+
+Maintainer  :  zubin.duggal@gmail.com
+Stability   :  unstable
+Portability :  unportable
+
+A version of "XMonad.Prompt.Shell" that lets you access the awesome power of Zsh
+completions in your xmonad prompt
+-}
+
+module XMonad.Prompt.Zsh
+    ( -- * Usage
+      -- $usage
+      Zsh (..)
+    , zshPrompt
+    -- * Utility functions
+    , getZshCompl
+    , stripZsh
+    ) where
+
+import XMonad
+import XMonad.Prompt
+import XMonad.Util.Run
+
+{- $usage
+1. Grab the @capture.zsh@ script to capture zsh completions from <https://github.com/Valodim/zsh-capture-completion>
+2. In your @~\/.xmonad\/xmonad.hs@:
+
+> import XMonad.Prompt
+> import XMonad.Prompt.Zsh
+
+3. In your keybindings add something like:
+
+>   , ((modm .|. controlMask, xK_x), zshPrompt def "/path/to/capture.zsh")
+
+For detailed instruction on editing the key binding see
+"XMonad.Doc.Extending#Editing_key_bindings". -}
+
+data Zsh = Zsh
+
+instance XPrompt Zsh where
+    showXPrompt Zsh       = "Run: "
+    completionToCommand _ = stripZsh
+    commandToComplete _ s = s
+    nextCompletion _ s cs = getNextCompletion s (map stripZsh cs)
+
+zshPrompt :: XPConfig -> FilePath -> X ()
+zshPrompt c capture = mkXPrompt Zsh c (getZshCompl capture) (\x -> safeSpawn "zsh" ["-c",x])
+
+getZshCompl :: FilePath -> String -> IO [String]
+getZshCompl capture s
+  | s == ""   = return []
+  | otherwise = processCompls <$> runProcessWithInput capture [s] ""
+    where processCompls = map (\x -> (skipLastWord s ++ filter (/= '\r') x)) . lines
+
+-- | Removes the argument description from the zsh completion
+stripZsh :: String -> String
+stripZsh "" = ""
+stripZsh (' ':'-':'-':' ':_) = ""
+stripZsh (x:xs) = x : stripZsh xs
+

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -316,6 +316,7 @@ library
                         XMonad.Prompt.Window
                         XMonad.Prompt.Workspace
                         XMonad.Prompt.XMonad
+                        XMonad.Prompt.Zsh
                         XMonad.Util.Cursor
                         XMonad.Util.CustomKeys
                         XMonad.Util.DebugWindow


### PR DESCRIPTION
### Description

Add a prompt mode similar to `XMonad.Prompt.Shell` that uses zsh completions.

![screenshot](https://i.postimg.cc/MTBX4d7Z/2020-06-13-035235-1920x1080-scrot.png)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
