### PR TITLE
Add restoreHiddenWindow function to XMonad.Layout.Hidden

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,7 @@
   * `XMonad.Layout.Hidden`
 
     - Export `HiddenWindows` type constructor.
+    - Export `popHiddenWindow` function restoring a specific window.
 
 ## 0.16
 


### PR DESCRIPTION
### Description

This PR adds the `restoreHiddenWindow` function add the `PopSpecificHiddenWindow` message to `XMonad.Layout.Hidden`, allowing the user to request restoring a specific window.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
