### PR TITLE
Export EZConfig parsers

### DIFF
--- a/XMonad/Util/EZConfig.hs
+++ b/XMonad/Util/EZConfig.hs
@@ -29,7 +29,11 @@ module XMonad.Util.EZConfig (
                              mkKeymap, checkKeymap,
                              mkNamedKeymap,
 
-                             parseKey -- used by XMonad.Util.Paste
+                             -- * Parsers
+
+                             parseKey, -- used by XMonad.Util.Paste
+                             parseKeyCombo,
+                             parseKeySequence, readKeySequence
                             ) where
 
 import XMonad


### PR DESCRIPTION
Exports parsers in `XMonad.Util.EZConfig`
See #359 

I also included `readKeySequence`, so you don't have to bother with `ReadP` if you need the top-level.