### PR TITLE
EZConfig: Learn about XF86Bluetooth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,6 +130,10 @@
     - Export `HiddenWindows` type constructor.
     - Export `popHiddenWindow` function restoring a specific window.
 
+  * `XMonad.Util.EZConfig`
+
+    - Added support for XF86Bluetooth.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Util/EZConfig.hs
+++ b/XMonad/Util/EZConfig.hs
@@ -356,6 +356,7 @@ removeMouseBindings conf mouseBindingList =
 -- > <XF86_ClearGrab>
 -- > <XF86_Next_VMode>
 -- > <XF86_Prev_VMode>
+-- > <XF86Bluetooth>
 
 mkKeymap :: XConfig l -> [(String, X ())] -> M.Map (KeyMask, KeySym) (X ())
 mkKeymap c = M.fromList . mkSubmaps . readKeymap c
@@ -677,7 +678,8 @@ multimediaKeys = filter ((/= noSymbol) . snd) . map (id &&& stringToKeysym) $
                  , "XF86_Ungrab"
                  , "XF86_ClearGrab"
                  , "XF86_Next_VMode"
-                 , "XF86_Prev_VMode" ]
+                 , "XF86_Prev_VMode"
+                 , "XF86Bluetooth" ]
 
 -- | Given a configuration record and a list of (key sequence
 --   description, action) pairs, check the key sequence descriptions


### PR DESCRIPTION
### Description

XF86Bluetooth is the keysym sent by function+F10 on my P1.  xev generates this:

```
    state 0x0, keycode 245 (keysym 0x1008ff94, XF86Bluetooth), same_screen YES,
```

Unfortunately XMonad still builds even when the keysyms don't exist, so this was nontrivial to diagnose for an outsider :)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

         That repo no longer works; see https://github.com/xmonad/xmonad-testing/issues/15

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
