### PR TITLE
Export AvoidStruts constructor and doSink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -136,6 +136,12 @@
     - Export `HiddenWindows` type constructor.
     - Export `popHiddenWindow` function restoring a specific window.
 
+  * `XMonad.Hooks.ManageDocks`
+    - Export `AvoidStruts` constructor
+
+  * `XMonad.Hooks.ManageHelpers`
+    - Export `doSink`
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -15,7 +15,7 @@
 module XMonad.Hooks.ManageDocks (
     -- * Usage
     -- $usage
-    docks, manageDocks, checkDock, AvoidStruts, avoidStruts, avoidStrutsOn,
+    docks, manageDocks, checkDock, AvoidStruts(..), avoidStruts, avoidStrutsOn,
     docksEventHook, docksStartupHook,
     ToggleStruts(..),
     SetStruts(..),

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -46,6 +46,7 @@ module XMonad.Hooks.ManageHelpers (
     doFloatAt,
     doFloatDep,
     doHideIgnore,
+    doSink,
     Match,
 ) where
 


### PR DESCRIPTION
### Description

Export the constructor for the AvoidStruts layout modifier. I have a newtype wrapper on AvoidStruts in my config file to alter some of the behavior of AvoidStruts, and currently I have no option but to attempt to mirror the internals of AvoidStruts myself.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
