### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -66,8 +66,9 @@ library
                    unix,
                    X11>=1.6.1 && < 1.10,
                    xmonad >= 0.15 && < 0.16,
-                   utf8-string,
-                   semigroups
+                   utf8-string
+    if impl(ghc < 8.0)
+        build-depends: semigroups
 
     if flag(use_xft)
         build-depends: X11-xft >= 0.2


### PR DESCRIPTION
### Description

They are not needed on newer GHC.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
