### PR TITLE
X.H.EwmhDesktops: Avoid some unnecessary refreshes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -172,6 +172,10 @@
 
     Fixed flicker in Steam caused by no-op `_NET_ACTIVE_WINDOW` requests.
 
+  * `XMonad.Util.PureX`
+
+    Added `focusWindow` and `focusNth` to enable flicker-less keybindings.
+
 ## 0.16
 
 ### Breaking Changes
@@ -297,7 +301,7 @@
 
 ### New Modules
 
-  * `XMonad.Util.Purex`
+  * `XMonad.Util.PureX`
 
     Unlike the opaque `IO` actions that `X` actions can wrap, regular reads from
     the `XConf` and modifications to the `XState` are fundamentally pure --

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -168,6 +168,10 @@
 
     - Export `Minimize` type constructor.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    Fixed flicker in Steam caused by no-op `_NET_ACTIVE_WINDOW` requests.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -42,6 +42,7 @@ import qualified XMonad.Util.ExtensibleState as E
 import XMonad.Util.XUtils (fi)
 import XMonad.Util.WorkspaceCompare
 import XMonad.Util.WindowProperties (getProp32)
+import qualified XMonad.Util.PureX as P
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
@@ -197,7 +198,7 @@ handle f (ClientMessageEvent {
        if  mt == a_cd then do
                let n = head d
                if 0 <= n && fi n < length ws then
-                       windows $ W.view (W.tag (ws !! fi n))
+                       P.defile $ P.view (W.tag (ws !! fi n))
                  else  trace $ "Bad _NET_CURRENT_DESKTOP with data[0]="++show n
         else if mt == a_d then do
                let n = head d
@@ -205,7 +206,7 @@ handle f (ClientMessageEvent {
                        windows $ W.shiftWin (W.tag (ws !! fi n)) w
                  else  trace $ "Bad _NET_DESKTOP with data[0]="++show n
         else if mt == a_aw then
-               windows $ W.focusWindow w
+               P.defile $ P.focusWindow w
         else if mt == a_cw then
                killWindow w
         else if mt `elem` a_ignore then

--- a/XMonad/Util/PureX.hs
+++ b/XMonad/Util/PureX.hs
@@ -44,7 +44,7 @@ module XMonad.Util.PureX (
   withWindowSet', withFocii,
   modify'', modifyWindowSet',
   getStack, putStack, peek,
-  focusWindow,
+  focusWindow, focusNth,
   view, greedyView, invisiView,
   shift, curScreen, curWorkspace,
   curTag, curScreenId,
@@ -53,6 +53,7 @@ module XMonad.Util.PureX (
 -- xmonad
 import XMonad
 import qualified XMonad.StackSet as W
+import qualified XMonad.Actions.FocusNth
 
 -- mtl
 import Control.Monad.State
@@ -284,6 +285,10 @@ focusWith focuser = do
 -- | A refresh-tracking version of @W.focusWindow@.
 focusWindow :: XLike m => Window -> m Any
 focusWindow w = focusWith (W.focusWindow w)
+
+-- | A refresh-tracking version of @XMonad.Actions.FocusNth.focusNth@.
+focusNth :: XLike m => Int -> m Any
+focusNth i = focusWith (W.modify' (XMonad.Actions.FocusNth.focusNth' i))
 
 -- }}}
 

--- a/XMonad/Util/PureX.hs
+++ b/XMonad/Util/PureX.hs
@@ -44,6 +44,7 @@ module XMonad.Util.PureX (
   withWindowSet', withFocii,
   modify'', modifyWindowSet',
   getStack, putStack, peek,
+  focusWindow,
   view, greedyView, invisiView,
   shift, curScreen, curWorkspace,
   curTag, curScreenId,
@@ -271,6 +272,18 @@ shift tag = withFocii $ \ctag fw ->
     modifyWindowSet' (W.shiftWin tag fw)
     mfw' <- peek
     return (Any $ Just fw /= mfw')
+
+-- | Internal. Refresh-tracking logic of focus operations.
+focusWith :: XLike m => (WindowSet -> WindowSet) -> m Any
+focusWith focuser = do
+    old <- peek
+    modifyWindowSet' focuser
+    new <- peek
+    return (Any $ old /= new)
+
+-- | A refresh-tracking version of @W.focusWindow@.
+focusWindow :: XLike m => Window -> m Any
+focusWindow w = focusWith (W.focusWindow w)
 
 -- }}}
 


### PR DESCRIPTION
### Description

Current version of Steam sends _NET_ACTIVE_WINDOW ClientMessage for
every mouse click which results in a lot of border blinking. Adopt
XMonad.Util.PureX to avoid refreshing unless something actually changes.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)