### PR TITLE
Added xmobarBorder utility function to add borders to strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -145,6 +145,8 @@
   * `XMonad.Util.EZConfig`
     - Added support for XF86Bluetooth.
 
+  * `XMonad.Hooks.DynamicLog`
+    - Added `xmobarBorder` function to create boorders around strings.
 
 ## 0.16
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -146,7 +146,7 @@
     - Added support for XF86Bluetooth.
 
   * `XMonad.Hooks.DynamicLog`
-    - Added `xmobarBorder` function to create boorders around strings.
+    - Added `xmobarBorder` function to create borders around strings.
 
 ## 0.16
 

--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -43,8 +43,8 @@ module XMonad.Hooks.DynamicLog (
 
     -- * Formatting utilities
     wrap, pad, trim, shorten,
-    xmobarColor, xmobarAction, xmobarRaw,
-    xmobarStrip, xmobarStripTags,
+    xmobarColor, xmobarAction, xmobarBorder,
+    xmobarRaw, xmobarStrip, xmobarStripTags,
     dzenColor, dzenEscape, dzenStrip,
 
     -- * Internal formatting functions
@@ -435,6 +435,18 @@ xmobarAction command button = wrap l r
     where
         l = "<action=`" ++ command ++ "` button=" ++ button ++ ">"
         r = "</action>"
+
+-- | Use xmobar box to add a border to an arbitrary string.
+xmobarBorder :: String -- ^ Border type. Possible values: VBoth, HBoth, Full,
+                       -- Top, Bottom, Left or Right
+             -> String -- ^ color: a color name, or #rrggbb format
+             -> Int    -- ^ width in pixels
+             -> String -- ^ output string
+             -> String
+xmobarBorder border color width = wrap prefix "</box>"
+  where
+    prefix = "<box type=" ++ border ++ " width=" ++ show width ++ " color="
+      ++ color ++ ">"
 
 -- | Encapsulate arbitrary text for display only, i.e. untrusted content if
 -- wrapped (perhaps from window titles) will be displayed only, with all tags


### PR DESCRIPTION
### Description

My first code contributed (ever) to an open-source project! 
The function wraps the given strings in a box with a configurable border. Practically a one-liner. I needed this utility while playing around with xmobar, and there was very little documentation on how to configure borders and how to use them, so this should provide some help in that regard.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate) (not applicable, I guess?)
