### PR TITLE
Minimize: export type constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -148,6 +148,10 @@
   * `XMonad.Hooks.DynamicLog`
     - Added `xmobarBorder` function to create borders around strings.
 
+  * `XMonad.Layout.Minimize`
+
+    - Export `Minimize` type constructor.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/Minimize.hs
+++ b/XMonad/Layout/Minimize.hs
@@ -17,6 +17,7 @@
 module XMonad.Layout.Minimize (
         -- * Usage
         -- $usage
+        Minimize,
         minimize,
     ) where
 


### PR DESCRIPTION
### Description

Some users like to include type signatures in their configuration. (I am one such user.)

The `Minimize` type constructor was not exported, making it impossible to write a type signature when using `minimize`.

With this change, a user can write an xmonad.hs like:
```haskell
import XMonad
import XMonad.Layout.Minimize (Minimize, minimize)
import XMonad.Layout.LayoutModifier

myLayout :: ModifiedLayout
            Minimize
            (Choose Tall (Choose (Mirror Tall) Full))
            Window
myLayout = minimize $ layoutHook def

main :: IO ()
main = xmonad def { layoutHook = myLayout }
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
