### PR TITLE
NamedScratchpads + RefocusLast

### DIFF
--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -132,7 +132,7 @@ namedScratchpadAction :: NamedScratchpads -- ^ Named scratchpads configuration
                       -> X ()
 namedScratchpadAction = customRunNamedScratchpadAction runApplication
 
--- | Action to up specified named scratchpad, with RefocusLast behavior.
+-- | Action to pop up specified named scratchpad, with RefocusLast behavior.
 namedScratchpadActionRLWhen :: Query Bool       -- ^ Predicate determining whether to apply RefocusLast
                             -> NamedScratchpads -- ^ Named scratchpads configuration
                             -> String           -- ^ Scratchpad name


### PR DESCRIPTION
### Description

Dismissing a named scratchpad currently moves focus to the bottom of the stack. It would be nice if it refocused the most recently focused window. The `RefocusLast` module provides a way to do this.

Since `RefocusLast` relies on either a layout hook or log hook in the user's config, and because there may be use-cases where refocusing doesn't make sense, I left the behavior of existing exports unchanged and added a new `namedScratchpadActionRLWhen` function.

I'm not very satisfied with the shape of the code, so I'm making this a draft PR and hoping to get some suggestions about how I might clean it up. I have not yet tested with xmonad-testing, but I am currently using this in my local configuration and it's working as expected.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
