### PR TITLE
XMonad.Actions.Sift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,12 @@
 
 ### New Modules
 
+  * `XMonad.Actions.Sift`
+
+    Provide 'siftUp' and 'siftDown' actions, which behave like 'swapUp' and 'swapDown'
+    but handle the wrapping case by exchanging the windows at either end of the stack
+    instead of rotating the stack.
+
   * `XMonad.Hooks.WindowSwallowing`
 
     A handleEventHook that implements window swallowing:

--- a/XMonad/Actions/Sift.hs
+++ b/XMonad/Actions/Sift.hs
@@ -1,0 +1,57 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Actions.Sift
+-- Copyright   :  (c) 2020 Ivan Brennan <ivanbrennan@gmail.com>
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  Ivan Brennan <ivanbrennan@gmail.com>
+-- Stability   :  stable
+-- Portability :  unportable
+--
+-- Functions for sifting windows up and down. Sifts behave identically to
+-- swaps (i.e. 'swapUp' and 'swapDown' from "XMonad.StackSet"), except in
+-- the wrapping case: rather than rotating the entire stack by one position
+-- like a swap would, a sift causes the windows at either end of the stack
+-- to trade positions.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Actions.Sift (
+    -- * Usage
+    -- $usage
+    siftUp,
+    siftDown,
+  ) where
+
+import XMonad.StackSet (Stack (Stack), StackSet, modify')
+
+-- $usage
+-- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
+--
+-- > import XMonad.Actions.Sift
+--
+-- and add keybindings such as the following:
+--
+-- >   , ((modMask .|. shiftMask, xK_j ), windows siftDown)
+-- >   , ((modMask .|. shiftMask, xK_k ), windows siftUp  )
+--
+
+-- |
+-- siftUp, siftDown. Exchange the focused window with its neighbour in
+-- the stack ordering, wrapping if we reach the end. Unlike 'swapUp' and
+-- 'swapDown', wrapping is handled by trading positions with the window
+-- at the other end of the stack.
+--
+siftUp, siftDown :: StackSet i l a s sd -> StackSet i l a s sd
+siftUp   = modify' siftUp'
+siftDown = modify' (reverseStack . siftUp' . reverseStack)
+
+siftUp' :: Stack a -> Stack a
+siftUp' (Stack t (l:ls) rs) = Stack t ls (l:rs)
+siftUp' (Stack t []     rs) =
+  case reverse rs of
+    (x:xs) -> Stack t (xs ++ [x]) []
+    []     -> Stack t []          []
+
+reverseStack :: Stack a -> Stack a
+reverseStack (Stack t ls rs) = Stack t rs ls

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -127,6 +127,7 @@ library
                         XMonad.Actions.RotSlaves
                         XMonad.Actions.Search
                         XMonad.Actions.ShowText
+                        XMonad.Actions.Sift
                         XMonad.Actions.SimpleDate
                         XMonad.Actions.SinkAll
                         XMonad.Actions.SpawnOn


### PR DESCRIPTION
### Description

When `swapUp`/`swapDown` wrap around the top/bottom of the stack, they rotate the entire stack rather than swapping position with their (wrapped) neighbor. Provide an alternative pair of functions, `siftUp`/`siftDown`, that exchange the windows at either end of the stack when wrapping. Non-wrapping cases behave identically to swaps.

For example, with focus on the master (_A_),
```
┌─────┬─────┐           ┌─────┬─────┐
│     │  B  │           │     │  C  │
│ *A* ├─────┤ swapUp -> │  B  ├─────┤
│     │  C  │           │     │ *A* │
└─────┴─────┘           └─────┴─────┘

┌─────┬─────┐           ┌─────┬─────┐
│     │  B  │           │     │  B  │
│ *A* ├─────┤ siftUp -> │  C  ├─────┤
│     │  C  │           │     │ *A* │
└─────┴─────┘           └─────┴─────┘
```

Related: https://github.com/xmonad/xmonad/issues/234

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) (see [commit](https://github.com/ivanbrennan/xmonad-testing/commit/23f566e7ecf0ffef8c42250f062137586fed16d2))

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
