### PR TITLE
BoringWindows: siftUp, siftDown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,7 +78,7 @@
 
   * `XMonad.Layout.BoringWindows`
 
-     Added boring-aware `swapUp` and `swapDown` functions.
+     Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.
 
   * `XMonad.Util.NamedScratchpad`
 


### PR DESCRIPTION
### Description

Add boring-aware versions of the `siftUp` and `siftDown` functions. Since these actions never affect the position of boring windows, they work well with layouts that decide which windows are visible/hidden based on stack position, such as LimitWindows.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) (see [commit](https://github.com/ivanbrennan/xmonad-testing/commit/2acf84fd199ffd1d92a6a7d25efd18452a54241c))

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
