### PR TITLE
Add statusBar' to support dynamic pretty printing modifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,12 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Hooks.DynamicLog`
+
+    Added `statusBar'` function, like existing `statusBar` but accepts a pretty
+    printing options argument embedded in the X monad, to allow for dynamically
+    modified options such as `workspaceNamesPP`.
+
   * `XMonad.Layout.BoringWindows`
 
      Added boring-aware `swapUp` and `swapDown` functions.


### PR DESCRIPTION
### Description

The existing `statusBar` function accepts a `PP` (pretty printing options) argument to incorporate in the `logHook` it configures. It's not possible to inject dynamically-modified printing options, like `workspaceNamesPP`, of type `X PP`, into this, so users are forced to recreate their own version of `statusBar`, which is pretty involved.

Add a `statusBar'` function that accepts an argument of type `X PP` to solve this issue.

Example usage:
```haskell
main = xmonad =<< statusBar' "xmobar" (workspaceNamesPP xmobarPP) toggleStrutsKey conf
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) (see commits [1](https://github.com/ivanbrennan/xmonad-testing/commit/4d10e5c203a05afe3581875ca99d18bd162ce746), [2](https://github.com/ivanbrennan/xmonad-testing/commit/c95b0df7661356d8d7ce57b08a1343f620eeff65))

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
