### PR TITLE
Allow case-insensitive shell prompt completion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
     additional `XPConfig` argument, so that they can take into
     account the given `searchPredicate`.
 
+    A `complCaseSensitivity` field has been added to `XPConfig`, indicating
+    whether case-sensitivity is desired when performing completion.
+
   * `XMonad.Hooks.EwmhDesktops`
 
     It is no longer recommended to use `fullscreenEventHook` directly.
@@ -95,19 +98,13 @@
 
   * `XMonad.Actions.DynamicProjects`
 
-    Added four new functions:
-    - `switchProjectPrompt'`
-    - `shiftToProjectPrompt'`
-    - `renameProjectPrompt'`,
-    - `changeProjectDirPrompt'`
-
-    These are like the corresponding sans `'` functions, but accept an additional
-    `ComplCaseSensitivity` argument.
+    The `changeProjectDirPrompt` function respects the `complCaseSensitivity` field
+    of `XPConfig` when performing directory completion.
 
   * `XMonad.Layout.WorkspaceDir`
 
-    Added `changeDir'`, like `changeDir` with an additional `ComplCaseSensitivity`
-    argument.
+    The `changeDir` function respects the `complCaseSensitivity` field of `XPConfig`
+    when performing directory completion.
 
   * `XMonad.Prompt.Directory`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@
     `XMonad.Layout.Fullscreen.fullscreenSupport` now advertises it as well,
     and no configuration changes are required in this case.
 
+  * `XMonad.Prompt.Directory`
+
+    The `Dir` constructor now takes an additional `ComplCaseSensitivity`
+    argument to indicate whether directory completion is case sensitive.
+
 ### New Modules
 
   * `XMonad.Actions.RotateSome`
@@ -87,6 +92,35 @@
     clickable in XMobar (for switching focus).
 
 ### Bug Fixes and Minor Changes
+
+  * `XMonad.Actions.DynamicProjects`
+
+    Added four new functions:
+    - `switchProjectPrompt'`
+    - `shiftToProjectPrompt'`
+    - `renameProjectPrompt'`,
+    - `changeProjectDirPrompt'`
+
+    These are like the corresponding sans `'` functions, but accept an additional
+    `ComplCaseSensitivity` argument.
+
+  * `XMonad.Layout.WorkspaceDir`
+
+    Added `changeDir'`, like `changeDir` with an additional `ComplCaseSensitivity`
+    argument.
+
+  * `XMonad.Prompt.Directory`
+
+    Added `directoryMultipleModes'`, like `directoryMultipleModes` with an additional
+    `ComplCaseSensitivity` argument.
+
+  * `XMonad.Prompt.Shell`
+
+    Added `getShellCompl'`, like `getShellCompl` with an additional `ComplCaseSensitivity`
+    argument.
+
+    Added `compgenDirectories` and `compgenFiles` to get the directory/filename completion
+    matches returned by the compgen shell builtin.
 
   * `XMonad.Hooks.DynamicLog`
 

--- a/XMonad/Actions/DynamicProjects.hs
+++ b/XMonad/Actions/DynamicProjects.hs
@@ -29,9 +29,13 @@ module XMonad.Actions.DynamicProjects
 
          -- * Bindings
        , switchProjectPrompt
+       , switchProjectPrompt'
        , shiftToProjectPrompt
+       , shiftToProjectPrompt'
        , renameProjectPrompt
+       , renameProjectPrompt'
        , changeProjectDirPrompt
+       , changeProjectDirPrompt'
 
          -- * Helper Functions
        , switchProject
@@ -145,24 +149,24 @@ instance ExtensionClass ProjectState where
 
 --------------------------------------------------------------------------------
 -- Internal types for working with XPrompt.
-data ProjectPrompt = ProjectPrompt XPConfig ProjectMode [ProjectName]
+data ProjectPrompt = ProjectPrompt XPConfig ComplCaseSensitivity ProjectMode [ProjectName]
 data ProjectMode = SwitchMode | ShiftMode | RenameMode | DirMode
 
 instance XPrompt ProjectPrompt where
-  showXPrompt (ProjectPrompt _ submode _) =
+  showXPrompt (ProjectPrompt _ _ submode _) =
     case submode of
       SwitchMode -> "Switch or Create Project: "
       ShiftMode  -> "Send Window to Project: "
       RenameMode -> "New Project Name: "
       DirMode    -> "Change Project Directory: "
 
-  completionFunction (ProjectPrompt _ RenameMode _) = return . (:[])
-  completionFunction (ProjectPrompt _ DirMode _) =
-    let xpt = directoryMultipleModes "" (const $ return ())
+  completionFunction (ProjectPrompt _ _ RenameMode _) = return . (:[])
+  completionFunction (ProjectPrompt _ csn DirMode _) =
+    let xpt = directoryMultipleModes' csn "" (const $ return ())
     in completionFunction xpt
-  completionFunction (ProjectPrompt c _ ns) = mkComplFunFromList' c ns
+  completionFunction (ProjectPrompt c _ _ ns) = mkComplFunFromList' c ns
 
-  modeAction (ProjectPrompt _ SwitchMode _) buf auto = do
+  modeAction (ProjectPrompt _ _ SwitchMode _) buf auto = do
     let name = if null auto then buf else auto
     ps <- XS.gets projects
 
@@ -171,17 +175,17 @@ instance XPrompt ProjectPrompt where
       Nothing | null name -> return ()
               | otherwise -> switchProject (defProject name)
 
-  modeAction (ProjectPrompt _ ShiftMode _) buf auto = do
+  modeAction (ProjectPrompt _ _ ShiftMode _) buf auto = do
     let name = if null auto then buf else auto
     ps <- XS.gets projects
     shiftToProject . fromMaybe (defProject name) $ Map.lookup name ps
 
-  modeAction (ProjectPrompt _ RenameMode _) name _ =
+  modeAction (ProjectPrompt _ _ RenameMode _) name _ =
     when (not (null name) && not (all isSpace name)) $ do
       renameWorkspaceByName name
       modifyProject (\p -> p { projectName = name })
 
-  modeAction (ProjectPrompt _ DirMode _) buf auto = do
+  modeAction (ProjectPrompt _ _ DirMode _) buf auto = do
     let dir' = if null auto then buf else auto
     dir <- io $ makeAbsolute dir'
     modifyProject (\p -> p { projectDirectory = dir })
@@ -279,11 +283,16 @@ switchProject p = do
 -- | Prompt for a project name and then switch to it.  Automatically
 -- creates a project if a new name is returned from the prompt.
 switchProjectPrompt :: XPConfig -> X ()
-switchProjectPrompt = projectPrompt [ SwitchMode
-                                    , ShiftMode
-                                    , RenameMode
-                                    , DirMode
-                                    ]
+switchProjectPrompt = switchProjectPrompt' (ComplCaseSensitive True)
+
+-- | Like @switchProjectPrompt@ with a parameter controlling
+-- completion case-sensitivity.
+switchProjectPrompt' :: ComplCaseSensitivity -> XPConfig -> X ()
+switchProjectPrompt' csn = projectPrompt csn [ SwitchMode
+                                             , ShiftMode
+                                             , RenameMode
+                                             , DirMode
+                                             ]
 
 --------------------------------------------------------------------------------
 -- | Shift the currently focused window to the given project.
@@ -296,20 +305,30 @@ shiftToProject p = do
 -- | Prompts for a project name and then shifts the currently focused
 -- window to that project.
 shiftToProjectPrompt :: XPConfig -> X ()
-shiftToProjectPrompt = projectPrompt [ ShiftMode
-                                     , RenameMode
-                                     , SwitchMode
-                                     , DirMode
-                                     ]
+shiftToProjectPrompt = shiftToProjectPrompt' (ComplCaseSensitive True)
+
+-- | Like @shiftToProjectPrompt@ with a parameter controlling
+-- completion case-sensitivity.
+shiftToProjectPrompt' :: ComplCaseSensitivity -> XPConfig -> X ()
+shiftToProjectPrompt' csn = projectPrompt csn [ ShiftMode
+                                              , RenameMode
+                                              , SwitchMode
+                                              , DirMode
+                                              ]
 
 --------------------------------------------------------------------------------
 -- | Rename the current project.
 renameProjectPrompt :: XPConfig -> X ()
-renameProjectPrompt = projectPrompt [ RenameMode
-                                    , DirMode
-                                    , SwitchMode
-                                    , ShiftMode
-                                    ]
+renameProjectPrompt = renameProjectPrompt' (ComplCaseSensitive True)
+
+-- | Like @renameProjectPrompt@ with a parameter controlling
+-- completion case-sensitivity.
+renameProjectPrompt' :: ComplCaseSensitivity -> XPConfig -> X ()
+renameProjectPrompt' csn = projectPrompt csn [ RenameMode
+                                             , DirMode
+                                             , SwitchMode
+                                             , ShiftMode
+                                             ]
 
 --------------------------------------------------------------------------------
 -- | Change the working directory used for the current project.
@@ -317,21 +336,26 @@ renameProjectPrompt = projectPrompt [ RenameMode
 -- NOTE: This will only affect new processed started in this project.
 -- Existing processes will maintain the previous working directory.
 changeProjectDirPrompt :: XPConfig -> X ()
-changeProjectDirPrompt = projectPrompt [ DirMode
-                                       , SwitchMode
-                                       , ShiftMode
-                                       , RenameMode
-                                       ]
+changeProjectDirPrompt = changeProjectDirPrompt' (ComplCaseSensitive True)
+
+-- | Like @changeProjectDirPrompt@ with a parameter controlling
+-- completion case-sensitivity.
+changeProjectDirPrompt' :: ComplCaseSensitivity -> XPConfig -> X ()
+changeProjectDirPrompt' csn = projectPrompt csn [ DirMode
+                                                , SwitchMode
+                                                , ShiftMode
+                                                , RenameMode
+                                                ]
 
 --------------------------------------------------------------------------------
 -- | Prompt for a project name.
-projectPrompt :: [ProjectMode] -> XPConfig -> X ()
-projectPrompt submodes c = do
+projectPrompt :: ComplCaseSensitivity -> [ProjectMode] -> XPConfig -> X ()
+projectPrompt csn submodes c = do
   ws <- map W.tag <$> gets (W.workspaces . windowset)
   ps <- XS.gets projects
 
   let names = sort (Map.keys ps `union` ws)
-      modes = map (\m -> XPT $ ProjectPrompt c m names) submodes
+      modes = map (\m -> XPT $ ProjectPrompt c csn m names) submodes
 
   mkXPromptWithModes modes c
 

--- a/XMonad/Layout/WorkspaceDir.hs
+++ b/XMonad/Layout/WorkspaceDir.hs
@@ -26,6 +26,7 @@ module XMonad.Layout.WorkspaceDir (
                                    -- $usage
                                    workspaceDir,
                                    changeDir,
+                                   changeDir',
                                    WorkspaceDir,
                                   ) where
 
@@ -33,8 +34,8 @@ import System.Directory ( setCurrentDirectory, getCurrentDirectory )
 import Control.Monad ( when )
 
 import XMonad hiding ( focus )
-import XMonad.Prompt ( XPConfig )
-import XMonad.Prompt.Directory ( directoryPrompt )
+import XMonad.Prompt ( ComplCaseSensitivity (ComplCaseSensitive), XPConfig )
+import XMonad.Prompt.Directory ( directoryPrompt' )
 import XMonad.Layout.LayoutModifier
 import XMonad.StackSet ( tag, currentTag )
 
@@ -87,4 +88,7 @@ scd :: String -> X ()
 scd x = catchIO $ setCurrentDirectory x
 
 changeDir :: XPConfig -> X ()
-changeDir c = directoryPrompt c "Set working directory: " (sendMessage . Chdir)
+changeDir = changeDir' (ComplCaseSensitive True)
+
+changeDir' :: ComplCaseSensitivity -> XPConfig -> X ()
+changeDir' csn c = directoryPrompt' csn c "Set working directory: " (sendMessage . Chdir)

--- a/XMonad/Layout/WorkspaceDir.hs
+++ b/XMonad/Layout/WorkspaceDir.hs
@@ -26,7 +26,6 @@ module XMonad.Layout.WorkspaceDir (
                                    -- $usage
                                    workspaceDir,
                                    changeDir,
-                                   changeDir',
                                    WorkspaceDir,
                                   ) where
 
@@ -34,8 +33,8 @@ import System.Directory ( setCurrentDirectory, getCurrentDirectory )
 import Control.Monad ( when )
 
 import XMonad hiding ( focus )
-import XMonad.Prompt ( ComplCaseSensitivity (ComplCaseSensitive), XPConfig )
-import XMonad.Prompt.Directory ( directoryPrompt' )
+import XMonad.Prompt ( XPConfig )
+import XMonad.Prompt.Directory ( directoryPrompt )
 import XMonad.Layout.LayoutModifier
 import XMonad.StackSet ( tag, currentTag )
 
@@ -61,7 +60,8 @@ import XMonad.StackSet ( tag, currentTag )
 --
 -- If you prefer a prompt with case-insensitive completion:
 --
--- >  , ((modm .|. shiftMask, xK_x     ), changeDir' (ComplCaseSensitive False) def)
+-- >  , ((modm .|. shiftMask, xK_x     ),
+--       changeDir def {complCaseSensitivity = ComplCaseSensitive False})
 --
 -- For detailed instruction on editing the key binding see:
 --
@@ -92,7 +92,4 @@ scd :: String -> X ()
 scd x = catchIO $ setCurrentDirectory x
 
 changeDir :: XPConfig -> X ()
-changeDir = changeDir' (ComplCaseSensitive True)
-
-changeDir' :: ComplCaseSensitivity -> XPConfig -> X ()
-changeDir' csn c = directoryPrompt' csn c "Set working directory: " (sendMessage . Chdir)
+changeDir c = directoryPrompt c "Set working directory: " (sendMessage . Chdir)

--- a/XMonad/Layout/WorkspaceDir.hs
+++ b/XMonad/Layout/WorkspaceDir.hs
@@ -59,6 +59,10 @@ import XMonad.StackSet ( tag, currentTag )
 --
 -- >  , ((modm .|. shiftMask, xK_x     ), changeDir def)
 --
+-- If you prefer a prompt with case-insensitive completion:
+--
+-- >  , ((modm .|. shiftMask, xK_x     ), changeDir' (ComplCaseSensitive False) def)
+--
 -- For detailed instruction on editing the key binding see:
 --
 -- "XMonad.Doc.Extending#Editing_key_bindings".

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -60,6 +60,7 @@ module XMonad.Prompt
     , moveHistory, setSuccess, setDone, setModeDone
     , Direction1D(..)
     , ComplFunction
+    , ComplCaseSensitivity(..)
     -- * X Utilities
     -- $xutils
     , mkUnmanagedWindow
@@ -199,6 +200,8 @@ data XPType = forall p . XPrompt p => XPT p
 type ComplFunction = String -> IO [String]
 type XPMode = XPType
 data XPOperationMode = XPSingleMode ComplFunction XPType | XPMultipleModes (W.Stack XPType)
+
+newtype ComplCaseSensitivity = ComplCaseSensitive Bool
 
 instance Show XPType where
     show (XPT p) = showXPrompt p

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -185,6 +185,8 @@ data XPConfig =
         , autoComplete          :: Maybe Int    -- ^ Just x: if only one completion remains, auto-select it,
                                                 --   and delay by x microseconds
         , showCompletionOnTab   :: Bool         -- ^ Only show list of completions when Tab was pressed
+        , complCaseSensitivity  :: ComplCaseSensitivity
+                                                -- ^ Perform completion in a case-sensitive manner
         , searchPredicate       :: String -> String -> Bool
                                                 -- ^ Given the typed string and a possible
                                                 --   completion, is the completion valid?
@@ -323,6 +325,7 @@ instance Default XPConfig where
         , defaultText           = []
         , autoComplete          = Nothing
         , showCompletionOnTab   = False
+        , complCaseSensitivity  = ComplCaseSensitive True
         , searchPredicate       = isPrefixOf
         , alwaysHighlight       = False
         , defaultPrompter       = id

--- a/XMonad/Prompt/Directory.hs
+++ b/XMonad/Prompt/Directory.hs
@@ -16,7 +16,6 @@ module XMonad.Prompt.Directory (
                              -- * Usage
                              -- $usage
                              directoryPrompt,
-                             directoryPrompt',
                              directoryMultipleModes,
                              directoryMultipleModes',
                              Dir
@@ -39,10 +38,8 @@ instance XPrompt Dir where
       in f dir
 
 directoryPrompt :: XPConfig -> String -> (String -> X ()) -> X ()
-directoryPrompt = directoryPrompt' (ComplCaseSensitive True)
-
-directoryPrompt' :: ComplCaseSensitivity -> XPConfig -> String -> (String -> X ()) -> X ()
-directoryPrompt' csn c prom f = mkXPrompt (Dir prom csn f) c (getDirCompl csn) f
+directoryPrompt c prom f = mkXPrompt (Dir prom csn f) c (getDirCompl csn) f
+    where csn = complCaseSensitivity c
 
 -- | A @XPType@ entry suitable for using with @mkXPromptWithModes@.
 directoryMultipleModes :: String            -- ^ Prompt.

--- a/XMonad/Prompt/Shell.hs
+++ b/XMonad/Prompt/Shell.hs
@@ -22,10 +22,13 @@ module XMonad.Prompt.Shell
     , unsafePrompt
 
     -- * Utility functions
+    , compgenDirectories
+    , compgenFiles
     , getCommands
     , getBrowser
     , getEditor
     , getShellCompl
+    , getShellCompl'
     , split
     ) where
 
@@ -95,10 +98,12 @@ unsafePrompt c config = mkXPrompt Shell config (getShellCompl [c] $ searchPredic
     where run a = unsafeSpawn $ c ++ " " ++ a
 
 getShellCompl :: [String] -> Predicate -> String -> IO [String]
-getShellCompl cmds p s | s == "" || last s == ' ' = return []
-                       | otherwise                = do
-    f     <- fmap lines $ runProcessWithInput "bash" [] ("compgen -A file -- "
-                                                        ++ s ++ "\n")
+getShellCompl = getShellCompl' (ComplCaseSensitive True)
+
+getShellCompl' :: ComplCaseSensitivity -> [String] -> Predicate -> String -> IO [String]
+getShellCompl' csn cmds p s | s == "" || last s == ' ' = return []
+                            | otherwise                = do
+    f     <- fmap lines (compgenFiles csn s)
     files <- case f of
                [x] -> do fs <- getFileStatus (encodeString x)
                          if isDirectory fs then return [x ++ "/"]
@@ -111,6 +116,23 @@ getShellCompl cmds p s | s == "" || last s == ' ' = return []
         | y `startsWith` s && not (x `startsWith` s) = GT
         | otherwise = x `compare` y
     startsWith str ps = isPrefixOf (map toLower ps) (map toLower str)
+
+compgenFiles :: ComplCaseSensitivity -> String -> IO String
+compgenFiles csn = compgen csn "file"
+
+compgenDirectories :: ComplCaseSensitivity -> String -> IO String
+compgenDirectories csn = compgen csn "directory"
+
+compgen :: ComplCaseSensitivity -> String -> String -> IO String
+compgen csn actionOpt s = runProcessWithInput "bash" [] $
+    complCaseSensitivityCmd csn ++ " ; " ++ compgenCmd actionOpt s
+
+complCaseSensitivityCmd :: ComplCaseSensitivity -> String
+complCaseSensitivityCmd (ComplCaseSensitive b) =
+    "bind 'set completion-ignore-case " ++ (if b then "off" else "on") ++ "'"
+
+compgenCmd :: String -> String -> String
+compgenCmd actionOpt s = "compgen -A " ++ actionOpt ++ " -- " ++ s ++ "\n"
 
 commandCompletionFunction :: [String] -> Predicate -> String -> [String]
 commandCompletionFunction cmds p str | '/' `elem` str = []


### PR DESCRIPTION
### Description

Directory/file prompt completions are currently case-sensitive. Provide a way to configure case-insensitive completion.

This is achieved by setting the readline `completion-ignore-case` variable prior to generating completions, e.g.
```sh
bind 'set completion-ignore-case on'
compgen -A directory -- foobar
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) (see [commits](https://github.com/xmonad/xmonad-testing/compare/e55b0999801aeddbb66be9cb95f7e6c0f514626f...ivanbrennan:compl-case-sensitivity))

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
