### PR TITLE
Add ClickableWorkspaces to exposed modules

### DIFF
--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -322,6 +322,7 @@ library
                         XMonad.Prompt.Workspace
                         XMonad.Prompt.XMonad
                         XMonad.Prompt.Zsh
+                        XMonad.Util.ClickableWorkspaces
                         XMonad.Util.Cursor
                         XMonad.Util.CustomKeys
                         XMonad.Util.DebugWindow


### PR DESCRIPTION
### Description

XMonad.Util.ClickableWorkspaces was added in #364 but never listed as an exposed module in xmonad-contrib.cabal, so any attempt to use it resulted in a compilation error.

Fix this by adding it to the list of exposed modules .

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing) (see [commits](https://github.com/xmonad/xmonad-testing/compare/e55b0999801aeddbb66be9cb95f7e6c0f514626f...ivanbrennan:export-clickable-workspaces))

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
