### PR TITLE
add XMonad.Layout.VoidBorders

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,11 @@
     `XMonad.Hooks.DynamicLog.dynamicLogWithPP`, will make the workspace tags
     clickable in XMobar (for switching focus).
 
+  * `XMonad.Layout.VoidBorders`
+
+    Provides a modifier that semi-permanently (requires manual intervention)
+    disables borders for windows from the layout it modifies.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Actions.DynamicProjects`

--- a/XMonad/Layout/VoidBorders.hs
+++ b/XMonad/Layout/VoidBorders.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Layout.VoidBorders
+-- Copyright   :  Wilson Sales <spoonm@spoonm.org>
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  <spoonm@spoonm.org>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Modifies a layout to set borders to 0 for all windows in the workspace.
+-- Unlike XMonad.Layout.NoBorders, this modifier will not restore the window
+-- border if the windows are moved to a different workspace or the layout is
+-- changed.
+--
+-- This modifier's primary use is to eliminate the "border flash" you get
+-- while switching workspaces with the `noBorders` modifier. It won't return
+-- the borders to their original width, however.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Layout.VoidBorders ( -- * Usage
+                                   -- $usage
+                                   voidBorders
+                                 ) where
+
+import XMonad
+import XMonad.Layout.LayoutModifier
+import XMonad.StackSet (integrate)
+
+-- $usage
+-- You can use this module with the following in your ~\/.xmonad/xmonad.hs
+-- file:
+--
+-- > import XMonad.Layout.VoidBorders
+--
+-- and modify the layouts to call 'voidBorders' on the layouts you want to
+-- remove borders from windows:
+--
+-- > layoutHook = ... ||| voidBorders Full ||| ...
+--
+-- For more detailed instructions on editing the layoutHook see:
+--
+-- "XMonad.Doc.Extending#Editing_the_layout_hook"
+
+data VoidBorders a = VoidBorders deriving (Read, Show)
+
+voidBorders :: l Window -> ModifiedLayout VoidBorders l Window
+voidBorders = ModifiedLayout VoidBorders
+
+instance LayoutModifier VoidBorders Window where
+  modifierDescription = const "VoidBorders"
+
+  redoLayout VoidBorders _ Nothing wrs = return (wrs, Nothing)
+  redoLayout VoidBorders _ (Just s) wrs = do
+    mapM_ setZeroBorder $ integrate s
+    return (wrs, Nothing)
+
+-- | Sets border width to 0 for every window from the specified layout.
+setZeroBorder :: Window -> X ()
+setZeroBorder w = withDisplay $ \d -> io $ setWindowBorderWidth d w 0

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -296,6 +296,7 @@ library
                         XMonad.Layout.TrackFloating
                         XMonad.Layout.TwoPane
                         XMonad.Layout.TwoPanePersistent
+                        XMonad.Layout.VoidBorders
                         XMonad.Layout.WindowArranger
                         XMonad.Layout.WindowNavigation
                         XMonad.Layout.WindowSwitcherDecoration


### PR DESCRIPTION
### Description

This module contains a modifier that simply sets X11 window border width
to 0 for every window in the layout it modifies. No efforts are made to
bring the border back, which can be annoying if windows are moved to a
different workspace, but it prevents the "border flash" you get with
XMonad.Layout.NoBorders.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
