### PR TITLE
Export clickableWrap

### DIFF
--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -17,7 +17,8 @@
 module XMonad.Util.ClickableWorkspaces (
   -- * Usage
   -- $usage
-  clickablePP
+  clickablePP,
+  clickableWrap
   ) where
 
 import XMonad


### PR DESCRIPTION
### Description

Export `clickableWrap` from XMonad.Util.ClickableWorkspaces so users can more easily compose their own clickable pretty-printers.

Configs that apply WorkspaceId transformations, such as IndependentScreens (adding/removing a screen-number prefix) and NamedWorkspaces (adding/removing a name suffix), cannot use `clickablePP` as is, since they need to apply `clickableWrap` to an appropriately transformed WorkspaceId. Rather than force them to re-implement `clickableWrap`, export it.

An example use-case, where IndependentScreens has added a screen number prefix to the workspace ids (0_1, 0_2, ...), and we want the status-bar to show ids sans screen number (1, 2, ...) _and_ make them clickable:
```haskell
import XMonad.Util.ClickableWorkspaces (clickableWrap)

getClickable :: (WorkspaceId -> WorkspaceId) -> X (WorkspaceId -> String)
getClickable f = do
  wsIndex <- getWsIndex
  return $ \ws -> case wsIndex (f ws) of
                    Just idx -> clickableWrap idx ws
                    Nothing -> ws

composePP :: PP -> ScreenId -> X PP
composePP pp s = do
  clickable <- getClickable (marshall s)
  return
    . marshallPP s
    $ pp
      { ppCurrent         = ppCurrent         pp . clickable,
        ppVisible         = ppVisible         pp . clickable,
        ppHidden          = ppHidden          pp . clickable,
        ppHiddenNoWindows = ppHiddenNoWindows pp . clickable,
        ppUrgent          = ppUrgent          pp . clickable
      }
```

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
