### PR TITLE
Fixes for XMonad.Prompt.Unicode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,6 +111,11 @@
     Added `directoryMultipleModes'`, like `directoryMultipleModes` with an additional
     `ComplCaseSensitivity` argument.
 
+  * `XMonad.Prompt.FuzzyMatch`
+
+    `fuzzySort` will now accept cases where the input is not a subsequence of
+    every completion.
+
   * `XMonad.Prompt.Shell`
 
     Added `getShellCompl'`, like `getShellCompl` with an additional `ComplCaseSensitivity`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,11 @@
     Added `compgenDirectories` and `compgenFiles` to get the directory/filename completion
     matches returned by the compgen shell builtin.
 
+  * `XMonad.Prompt.Unicode`
+
+    Reworked internally to be call `spawnPipe` (asynchronous) instead of
+    `runProcessWithInput` (synchronous), which fixes `typeUnicodePrompt`.
+
   * `XMonad.Hooks.DynamicLog`
 
     Added `statusBar'` function, like existing `statusBar` but accepts a pretty

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,8 @@
     Reworked internally to be call `spawnPipe` (asynchronous) instead of
     `runProcessWithInput` (synchronous), which fixes `typeUnicodePrompt`.
 
+    Now respects `searchPredicate` and `sorter` from user-supplied `XPConfig`.
+
   * `XMonad.Hooks.DynamicLog`
 
     Added `statusBar'` function, like existing `statusBar` but accepts a pretty

--- a/XMonad/Doc/Extending.hs
+++ b/XMonad/Doc/Extending.hs
@@ -1052,6 +1052,9 @@ These are the available prompts:
     intended mostly as an example of using "XMonad.Prompt.Input" to
     build an action requiring user input.
 
+* "XMonad.Prompt.FuzzyMatch":
+    A module for fuzzy completion matching in prompts akin to emacs ido mode
+
 * "XMonad.Prompt.Input":
     A generic framework for prompting the user for input and passing it
     along to some other action.
@@ -1084,6 +1087,9 @@ These are the available prompts:
 
 * "XMonad.Prompt.Theme":
     A prompt for changing the theme of the current workspace
+
+* "XMonad.Prompt.Unicode":
+    A prompt for inputting Unicode characters
 
 * "XMonad.Prompt.Window":
     xprompt operations to bring windows to you, and bring you to windows.

--- a/XMonad/Prompt/FuzzyMatch.hs
+++ b/XMonad/Prompt/FuzzyMatch.hs
@@ -80,7 +80,8 @@ fuzzySort :: String -> [String] -> [String]
 fuzzySort q = map snd . sort . map (rankMatch q)
 
 rankMatch :: String -> String -> ((Int, Int), String)
-rankMatch q s = (minimum $ rankMatches q s, s)
+rankMatch q s = (if null matches then (maxBound, maxBound) else minimum matches, s)
+  where matches = rankMatches q s
 
 rankMatches :: String -> String -> [(Int, Int)]
 rankMatches [] _ = [(0, 0)]

--- a/XMonad/Prompt/Unicode.hs
+++ b/XMonad/Prompt/Unicode.hs
@@ -112,8 +112,10 @@ mkUnicodePrompt prog args unicodeDataFilename config =
       let m = searchUnicode entries s
       return . map (\(c,d) -> printf "%s %s" [c] d) $ take 20 m
     paste [] = return ()
-    paste (c:_) = do
-      runProcessWithInput prog args [c]
+    paste (c:_) = liftIO $ do
+      handle <- spawnPipe $ unwords $ prog : args
+      hPutChar handle c
+      hClose handle
       return ()
 
 -- | Prompt the user for a Unicode character to be inserted into the paste buffer of the X server.

--- a/XMonad/Prompt/Unicode.hs
+++ b/XMonad/Prompt/Unicode.hs
@@ -96,20 +96,27 @@ parseUnicodeData = mapMaybe parseLine . BS.lines
           [(c,"")] <- return . readHex $ BS.unpack field1
           return (chr c, field2)
 
-searchUnicode :: [(Char, BS.ByteString)] -> String -> [(Char, String)]
-searchUnicode entries s = map (second BS.unpack) $ filter go entries
-  where w = map BS.pack . filter (all isAscii) . filter ((> 1) . length) . words $ map toUpper s
-        go (c,d) = all (`BS.isInfixOf` d) w
+type Predicate = String -> String -> Bool
+
+searchUnicode :: [(Char, BS.ByteString)] -> Predicate -> String -> [(Char, String)]
+searchUnicode entries p s = map (second BS.unpack) $ filter go entries
+  where w = filter (all isAscii) . filter ((> 1) . length) . words $ map toUpper s
+        go (c,d) = all (`p` (BS.unpack d)) w
 
 mkUnicodePrompt :: String -> [String] -> String -> XPConfig -> X ()
 mkUnicodePrompt prog args unicodeDataFilename config =
   whenX (populateEntries unicodeDataFilename) $ do
     entries <- fmap getUnicodeData (XS.get :: X UnicodeData)
-    mkXPrompt Unicode config (unicodeCompl entries) paste
+    mkXPrompt
+      Unicode
+      (config {sorter = sorter config . map toUpper})
+      (unicodeCompl entries $ searchPredicate config)
+      paste
   where
-    unicodeCompl _ [] = return []
-    unicodeCompl entries s = do
-      let m = searchUnicode entries s
+    unicodeCompl :: [(Char, BS.ByteString)] -> Predicate -> String -> IO [String]
+    unicodeCompl _ _ "" = return []
+    unicodeCompl entries p s = do
+      let m = searchUnicode entries p s
       return . map (\(c,d) -> printf "%s %s" [c] d) $ take 20 m
     paste [] = return ()
     paste (c:_) = liftIO $ do


### PR DESCRIPTION
### Description

`typeUnicodePrompt` hasn't worked for some time now, and even before it was kind of buggy. I determined this was caused by `runProcessWithInput` blocking on the prompt, so `xdotool` targets that instead of the active window. This is fixed by using `spawnPipe` instead.

It was also doing its own thing for searching for Unicode characters rather than respecting `XPConfig`, so I've fixed that too. I noticed that I was getting crashes when using `fuzzySort` from XMonad.Prompt.FuzzyMatch, and determined that the cause of the issue is:

```
Prelude.minimum: empty list
```

caused by XMonad.Prompt.Unicode generating a list of completions for a given input which contains some strings which are not necessarily supersequences of the input.

For instance, there is a character that is described by `DIGIT ONE`, but the search function in XMonad.Prompt.Unicode is designed disregard word order so giving `one digit` as input should yield this as a valid completion. With the fuzzy sorter, previously when you reached `one ` it would crash in the manner above because `ONE ` is not a subsequence of `DIGIT ONE`.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)