### PR TITLE
Add nix packages to stack.yaml.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,13 @@ packages:
 
 extra-deps:
 - xmonad-0.15
+
+nix:
+  packages:
+    - pkg-config
+    - xorg.libX11
+    - xorg.libXext
+    - xorg.libXft
+    - xorg.libXrandr
+    - xorg.libXrender
+    - xorg.libXScrnSaver


### PR DESCRIPTION
### Description

This allows someone using NixOS to easily download and build the xmonad-contrib git repo with stack. I'm honestly not sure whether this is how it's _supposed_ to be done, but it does work (for me).

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
