### PR TITLE
X.U.PureX: Add focusWindow and focusNth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -256,6 +256,11 @@
     - Added `workspaceNamesListTransform` which makes workspace names visible
       to external pagers.
 
+  * `XMonad.Util.PureX`
+
+    - Added `focusWindow` and `focusNth` which don't refresh (and thus
+      possibly flicker) when they happen to be a no-op.
+
   * Several `LayoutClass` instances now have an additional `Typeable`
     constraint which may break some advanced configs. The upside is that we
     can now add `Typeable` to `LayoutClass` in `XMonad.Core` and make it

--- a/XMonad/Util/PureX.hs
+++ b/XMonad/Util/PureX.hs
@@ -44,6 +44,7 @@ module XMonad.Util.PureX (
   withWindowSet', withFocii,
   modify'', modifyWindowSet',
   getStack, putStack, peek,
+  focusWindow, focusNth,
   view, greedyView, invisiView,
   shift, curScreen, curWorkspace,
   curTag, curScreenId,
@@ -52,6 +53,7 @@ module XMonad.Util.PureX (
 -- xmonad
 import XMonad
 import qualified XMonad.StackSet as W
+import qualified XMonad.Actions.FocusNth
 
 -- mtl
 import Control.Monad.State
@@ -271,6 +273,22 @@ shift tag = withFocii $ \ctag fw ->
     modifyWindowSet' (W.shiftWin tag fw)
     mfw' <- peek
     return (Any $ Just fw /= mfw')
+
+-- | Internal. Refresh-tracking logic of focus operations.
+focusWith :: XLike m => (WindowSet -> WindowSet) -> m Any
+focusWith focuser = do
+    old <- peek
+    modifyWindowSet' focuser
+    new <- peek
+    return (Any $ old /= new)
+
+-- | A refresh-tracking version of @W.focusWindow@.
+focusWindow :: XLike m => Window -> m Any
+focusWindow w = focusWith (W.focusWindow w)
+
+-- | A refresh-tracking version of @XMonad.Actions.FocusNth.focusNth@.
+focusNth :: XLike m => Int -> m Any
+focusNth i = focusWith (W.modify' (XMonad.Actions.FocusNth.focusNth' i))
 
 -- }}}
 


### PR DESCRIPTION
### Description

This can be used to reduce flicker in noop focus actions.
As an example, see #371 (which can't be merged as is due to conflicts with #192 but I'll get that sorted out after dealing with #396; but it's good enough to show motivation).

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)
