### PR TITLE
Add Typeable constraint to a few LayoutClass instances

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -251,6 +251,11 @@
 
     - Export `Minimize` type constructor.
 
+  * Several `LayoutClass` instances now have an additional `Typeable`
+    constraint which may break some advanced configs. The upside is that we
+    can now add `Typeable` to `LayoutClass` in `XMonad.Core` and make it
+    possible to introspect the current layout and its modifiers.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/LayoutBuilder.hs
+++ b/XMonad/Layout/LayoutBuilder.hs
@@ -259,7 +259,7 @@ relBox x y w h = SubBox (Rel x) (Rel y) (Rel w) (Rel h)
 
 --------------------------------------------------------------------------------
 instance ( LayoutClass l1 a, LayoutClass l2 a
-         , Read a, Show a, Show p, Eq a, Typeable a, Predicate p a
+         , Read a, Show a, Show p, Typeable p, Eq a, Typeable a, Predicate p a
          ) => LayoutClass (LayoutB l1 l2 p) a where
 
     -- | Update window locations.

--- a/XMonad/Layout/LayoutBuilderP.hs
+++ b/XMonad/Layout/LayoutBuilderP.hs
@@ -78,7 +78,7 @@ layoutAll box sub =
   let a = alwaysTrue (Proxy :: Proxy a)
   in  LayoutP Nothing Nothing a box Nothing sub Nothing
 
-instance (LayoutClass l1 w, LayoutClass l2 w, Predicate p w, Show w, Read w, Eq w, Typeable w, Show p) =>
+instance (LayoutClass l1 w, LayoutClass l2 w, Predicate p w, Show w, Read w, Eq w, Typeable w, Show p, Typeable p) =>
     LayoutClass (LayoutP p l1 l2) w where
 
         -- | Update window locations.

--- a/XMonad/Layout/LayoutModifier.hs
+++ b/XMonad/Layout/LayoutModifier.hs
@@ -250,7 +250,7 @@ class (Show (m a), Read (m a)) => LayoutModifier m a where
 
 -- | The 'LayoutClass' instance for a 'ModifiedLayout' defines the
 --   semantics of a 'LayoutModifier' applied to an underlying layout.
-instance (LayoutModifier m a, LayoutClass l a) => LayoutClass (ModifiedLayout m l) a where
+instance (LayoutModifier m a, LayoutClass l a, Typeable m) => LayoutClass (ModifiedLayout m l) a where
     runLayout (Workspace i (ModifiedLayout m l) ms) r =
         do ((ws, ml'),mm')  <- modifyLayoutWithUpdate m (Workspace i l ms) r
            (ws', mm'') <- redoLayout (maybe m id mm') r ms ws

--- a/XMonad/Layout/MultiToggle.hs
+++ b/XMonad/Layout/MultiToggle.hs
@@ -188,7 +188,7 @@ instance (Transformer a w, HList b w) => HList (HCons a b) w where
 geq :: (Typeable a, Eq a, Typeable b) => a -> b -> Bool
 geq a b = Just a == cast b
 
-instance (Typeable a, Show ts, HList ts a, LayoutClass l a) => LayoutClass (MultiToggle ts l) a where
+instance (Typeable a, Show ts, Typeable ts, HList ts a, LayoutClass l a) => LayoutClass (MultiToggle ts l) a where
     description mt = currLayout mt `unEL` \l -> description l
 
     runLayout (Workspace i mt s) r = case currLayout mt of

--- a/XMonad/Layout/ZoomRow.hs
+++ b/XMonad/Layout/ZoomRow.hs
@@ -185,7 +185,7 @@ zoomReset = ZoomTo 1
 
 -- * LayoutClass instance
 
-instance (EQF f a, Show a, Read a, Show (f a), Read (f a))
+instance (EQF f a, Show a, Read a, Show (f a), Read (f a), Typeable f)
     => LayoutClass (ZoomRow f) a where
     description (ZC _ Nothing) = "ZoomRow"
     description (ZC _ (Just s)) = "ZoomRow" ++ if full $ W.focus s


### PR DESCRIPTION
### Description

This enables adding the Typeable constraint to LayoutClass itself
(https://github.com/xmonad/xmonad/pull/242)
which in turn enables querying the current layout state. That might be
useful to e.g. show the current X.L.WorkspaceDir in xmobar.

Example usage: https://github.com/liskin/dotfiles/commit/6ea6c52aac4d39fa5a788372e005954715cb6d9a

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)

**before merging, I need to finish the above checklist tasks, but I'd like to gather feedback first**