### PR TITLE
X.H.DynamicLog: Postpone statusBar start until after xmonad is recompiled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -165,6 +165,11 @@
     - Added `shortenLeft` function, like existing `shorten` but shortens by
       truncating from left instead of right. Useful for showing directories.
 
+    - Fixed a bug which caused the status bar command to be unnecessarily
+      invoked multiple times with no input before xmonad recompiled itself and
+      handed over execution to the configuration binary. The bar is now
+      started only once in `startupHook`.
+
   * `XMonad.Layout.BoringWindows`
 
      Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.


### PR DESCRIPTION
### Description

The sample (perhaps even recommended) usage of DynamicLog is

    main = xmonad =<< xmobar def

which invokes `spawnPipe "xmobar"` even before xmonad parses its
arguments, recompiles itself and proceeds to execute the compiled
configuration binary.

This is unnecessary, wasteful, ugly, and it occasionally triggers a bug
in xmobar, and people then waste days or even weeks chasing it as nobody
expects xmonad to start xmobar multiple times:
https://github.com/jaor/xmobar/issues/442
https://github.com/jaor/xmobar/pull/448#issuecomment-727097216
https://github.com/jaor/xmobar/pull/448#issuecomment-727161929

To fix this, we move status bar startup to the startupHook, where it
belongs, and use an IORef to pass the pipe handle to logHook.

Include a description for your changes, including the motivation
behind them.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with a minimal xmonad config

  - [x] I updated the `CHANGES.md` file

  - (n/a) I updated the `XMonad.Doc.Extending` file (if appropriate)