### PR TITLE
Fix missing usage-section in XMonad.Hooks.WindowSwallowing

### DIFF
--- a/XMonad/Hooks/WindowSwallowing.hs
+++ b/XMonad/Hooks/WindowSwallowing.hs
@@ -38,7 +38,9 @@
 --   application and asking them to set that property.
 -----------------------------------------------------------------------------
 module XMonad.Hooks.WindowSwallowing
-  ( swallowEventHook
+  ( -- * Usage
+    -- $usage
+    swallowEventHook
   )
 where
 import           XMonad


### PR DESCRIPTION
### Description

While doing my latest PR i noticed that one of my older PRs does not render the usage-section in the docs, as it is not included in the module export header.

I quickly fixed this here, to make sure that the documentation is properly included. Sorry ^^

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
