### PR TITLE
Update XMonad.Actions.TopicSpace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -177,9 +177,9 @@
   * `XMonad.Util.NamedScratchpad`
 
      Added two new exported functions to the module:
-     - `customRunNamedScratchpadAction` 
-         (provides the option to customize the `X ()` action the scratchpad is launched by) 
-     - `spawnHereNamedScratchpadAction` 
+     - `customRunNamedScratchpadAction`
+         (provides the option to customize the `X ()` action the scratchpad is launched by)
+     - `spawnHereNamedScratchpadAction`
          (uses `XMonad.Actions.SpawnOn.spawnHere` to initially start the scratchpad on the workspace it was launched on)
 
   * `XMonad.Util.Run`
@@ -265,6 +265,26 @@
     constraint which may break some advanced configs. The upside is that we
     can now add `Typeable` to `LayoutClass` in `XMonad.Core` and make it
     possible to introspect the current layout and its modifiers.
+
+  * `XMonad.Actions.TopicSpace`
+
+    - `switchTopic` now correctly updates the last used topics.
+    - `setLastFocusedTopic` will now check whether we have exceeded the
+      `maxTopicHistory` and prune the topic history as necessary, as well as
+      cons the given topic onto the list __before__ filtering it.
+    - Added `switchNthLastFocusedExclude`, which works like
+      `switchNthLastFocused` but is able to exclude certain topics.
+    - Added `switchTopicWith`, which works like `switchTopic`, but one is able
+      to give `setLastFocusedTopic` a custom filtering function as well.
+    - Instead of a hand-rolled history, use the oneu from
+      `XMonad.Hooks.WorkspaceHistory`.
+    - Added the screen-aware functions `getLastFocusedTopicsByScreen` and
+      `switchNthLastFocusedByScreen`.
+
+  * `XMonad.Hooks.WorkspaceHistory`
+
+    - Added `workspaceHistoryModify` to modify the workspace history with a pure
+      function.
 
 ## 0.16
 

--- a/XMonad/Actions/TopicSpace.hs
+++ b/XMonad/Actions/TopicSpace.hs
@@ -32,6 +32,7 @@ module XMonad.Actions.TopicSpace
   , currentTopicAction
   , switchTopic
   , switchNthLastFocused
+  , switchNthLastFocusedExclude
   , shiftNthLastFocused
   , currentTopicDir
   , checkTopicConfig
@@ -283,9 +284,13 @@ switchTopic tg topic = do
 
 -- | Switch to the Nth last focused topic or failback to the 'defaultTopic'.
 switchNthLastFocused :: TopicConfig -> Int -> X ()
-switchNthLastFocused tg depth = do
-  lastWs <- getLastFocusedTopics
-  switchTopic tg $ (lastWs ++ repeat (defaultTopic tg)) !! depth
+switchNthLastFocused = switchNthLastFocusedExclude []
+
+-- | Like 'switchNthLastFocused', but also filter out certain topics.
+switchNthLastFocusedExclude :: [Topic] -> TopicConfig -> Int -> X ()
+switchNthLastFocusedExclude excludes tc depth = do
+  lastWs <- filter (`notElem` excludes) <$> getLastFocusedTopics
+  switchTopic tc $ (lastWs ++ repeat (defaultTopic tc)) !! depth
 
 -- | Shift the focused window to the Nth last focused topic, or fallback to doing nothing.
 shiftNthLastFocused :: Int -> X ()

--- a/XMonad/Actions/TopicSpace.hs
+++ b/XMonad/Actions/TopicSpace.hs
@@ -300,7 +300,7 @@ pprWindowSet tg pp = do
   let depth topic = fromJust $ elemIndex topic (lastWs ++ [topic])
       add_depth proj topic = proj pp . (((topic++":")++) . show) . depth $ topic
       pp' = pp { ppHidden = add_depth ppHidden, ppVisible = add_depth ppVisible }
-      sortWindows = take maxDepth . sortBy (comparing $ depth . W.tag)
+      sortWindows = take maxDepth . sortOn (depth . W.tag)
   return $ DL.pprWindowSet sortWindows urgents pp' winset
 
 -- | Given a prompt configuration and a topic configuration, trigger the action associated with

--- a/XMonad/Actions/TopicSpace.hs
+++ b/XMonad/Actions/TopicSpace.hs
@@ -31,6 +31,7 @@ module XMonad.Actions.TopicSpace
   , topicAction
   , currentTopicAction
   , switchTopic
+  , switchTopicWith
   , switchNthLastFocused
   , switchNthLastFocusedExclude
   , shiftNthLastFocused
@@ -318,10 +319,15 @@ currentTopicAction tg = topicAction tg =<< gets (W.tag . W.workspace . W.current
 
 -- | Switch to the given topic.
 switchTopic :: TopicConfig -> Topic -> X ()
-switchTopic tg topic = do
+switchTopic = switchTopicWith (const True)
+
+-- | Like 'switchTopic', but give a custom filtering function to
+-- 'setLastFocusedTopic'.
+switchTopicWith :: (Topic -> Bool) -> TopicConfig -> Topic -> X ()
+switchTopicWith predicate tg topic = do
   -- Switch to topic and add it to the last seen topics
   windows $ W.greedyView topic
-  setLastFocusedTopic tg topic (const True)
+  setLastFocusedTopic tg topic predicate
 
   -- If applicable, execute the topic action
   wins <- gets (W.integrate' . W.stack . W.workspace . W.current . windowset)

--- a/XMonad/Actions/TopicSpace.hs
+++ b/XMonad/Actions/TopicSpace.hs
@@ -273,7 +273,11 @@ currentTopicAction tg = topicAction tg =<< gets (W.tag . W.workspace . W.current
 -- | Switch to the given topic.
 switchTopic :: TopicConfig -> Topic -> X ()
 switchTopic tg topic = do
+  -- Switch to topic and add it to the last seen topics
   windows $ W.greedyView topic
+  setLastFocusedTopic topic (const True)
+
+  -- If applicable, execute the topic action
   wins <- gets (W.integrate' . W.stack . W.workspace . W.current . windowset)
   when (null wins) $ topicAction tg topic
 

--- a/XMonad/Actions/TopicSpace.hs
+++ b/XMonad/Actions/TopicSpace.hs
@@ -253,17 +253,17 @@ data TopicConfig = TopicConfig { topicDirs          :: M.Map Topic Dir
                                }
 
 instance Default TopicConfig where
-    def            = TopicConfig { topicDirs = M.empty
-                                 , topicActions = M.empty
-                                 , defaultTopicAction = const (ask >>= spawn . terminal . config)
-                                 , defaultTopic = "1"
-                                 , maxTopicHistory = 10
-                                 }
+  def            = TopicConfig { topicDirs = M.empty
+                               , topicActions = M.empty
+                               , defaultTopicAction = const (ask >>= spawn . terminal . config)
+                               , defaultTopic = "1"
+                               , maxTopicHistory = 10
+                               }
 
 newtype PrevTopics = PrevTopics { getPrevTopics :: [String] } deriving (Read,Show,Typeable)
 instance ExtensionClass PrevTopics where
-    initialValue = PrevTopics []
-    extensionType = PersistentExtension
+  initialValue  = PrevTopics []
+  extensionType = PersistentExtension
 
 -- | Return the (possibly empty) list of last focused topics.
 getLastFocusedTopics :: X [String]
@@ -289,18 +289,18 @@ reverseLastFocusedTopics =
 -- and highlight topics with urgent windows.
 pprWindowSet :: TopicConfig -> PP -> X String
 pprWindowSet tg pp = do
-    winset <- gets windowset
-    urgents <- readUrgents
-    let empty_workspaces = map W.tag $ filter (isNothing . W.stack) $ W.workspaces winset
-        maxDepth = maxTopicHistory tg
-    setLastFocusedTopic (W.tag . W.workspace . W.current $ winset)
-                        (`notElem` empty_workspaces)
-    lastWs <- getLastFocusedTopics
-    let depth topic = fromJust $ elemIndex topic (lastWs ++ [topic])
-        add_depth proj topic = proj pp . (((topic++":")++) . show) . depth $ topic
-        pp' = pp { ppHidden = add_depth ppHidden, ppVisible = add_depth ppVisible }
-        sortWindows = take maxDepth . sortBy (comparing $ depth . W.tag)
-    return $ DL.pprWindowSet sortWindows urgents pp' winset
+  winset <- gets windowset
+  urgents <- readUrgents
+  let empty_workspaces = map W.tag $ filter (isNothing . W.stack) $ W.workspaces winset
+      maxDepth = maxTopicHistory tg
+  setLastFocusedTopic (W.tag . W.workspace . W.current $ winset)
+                      (`notElem` empty_workspaces)
+  lastWs <- getLastFocusedTopics
+  let depth topic = fromJust $ elemIndex topic (lastWs ++ [topic])
+      add_depth proj topic = proj pp . (((topic++":")++) . show) . depth $ topic
+      pp' = pp { ppHidden = add_depth ppHidden, ppVisible = add_depth ppVisible }
+      sortWindows = take maxDepth . sortBy (comparing $ depth . W.tag)
+  return $ DL.pprWindowSet sortWindows urgents pp' winset
 
 -- | Given a prompt configuration and a topic configuration, trigger the action associated with
 -- the topic given in prompt.
@@ -352,16 +352,16 @@ currentTopicDir tg = do
 -- | Check the given topic configuration for duplicate or undefined topics.
 checkTopicConfig :: [Topic] -> TopicConfig -> IO ()
 checkTopicConfig tags tg = do
-    -- tags <- gets $ map W.tag . workspaces . windowset
+  -- tags <- gets $ map W.tag . workspaces . windowset
 
-    let
-      seenTopics = nub $ sort $ M.keys (topicDirs tg) ++ M.keys (topicActions tg)
-      dups       = tags \\ nub tags
-      diffTopic  = seenTopics \\ sort tags
-      check lst msg = unless (null lst) $ xmessage $ msg ++ " (tags): " ++ show lst
+  let
+    seenTopics = nub $ sort $ M.keys (topicDirs tg) ++ M.keys (topicActions tg)
+    dups       = tags \\ nub tags
+    diffTopic  = seenTopics \\ sort tags
+    check lst msg = unless (null lst) $ xmessage $ msg ++ " (tags): " ++ show lst
 
-    check diffTopic "Seen but missing topics/workspaces"
-    check dups      "Duplicate topics/workspaces"
+  check diffTopic "Seen but missing topics/workspaces"
+  check dups      "Duplicate topics/workspaces"
 
 -- | Display the given message using the @xmessage@ program.
 xmessage :: String -> IO ()

--- a/XMonad/Actions/TopicSpace.hs
+++ b/XMonad/Actions/TopicSpace.hs
@@ -270,14 +270,14 @@ getLastFocusedTopics :: X [String]
 getLastFocusedTopics = XS.gets getPrevTopics
 
 -- | Given a 'TopicConfig', a topic, and a predicate to select topics that one
--- wants to keep, this function will filter the list of last focused topics
--- according to the predicate and cons the topic in front of that list.  Note
--- that we prune the list in case its length exceeds 'maxTopicHistory'.
+-- wants to keep, this function will cons the topic in front of the list of
+-- last focused topics and filter it according to the predicate.  Note that we
+-- prune the list in case that its length exceeds 'maxTopicHistory'.
 setLastFocusedTopic :: TopicConfig -> Topic -> (Topic -> Bool) -> X ()
 setLastFocusedTopic tc w predicate =
   XS.modify $ PrevTopics
             . take (maxTopicHistory tc)
-            . nub . (w :) . filter predicate . getPrevTopics
+            . nub . filter predicate . (w :) . getPrevTopics
 
 -- | Reverse the list of "last focused topics"
 reverseLastFocusedTopics :: X ()

--- a/XMonad/Hooks/WorkspaceHistory.hs
+++ b/XMonad/Hooks/WorkspaceHistory.hs
@@ -25,6 +25,7 @@ module XMonad.Hooks.WorkspaceHistory (
   , workspaceHistoryWithScreen
     -- * Handling edits
   , workspaceHistoryTransaction
+  , workspaceHistoryModify
   ) where
 
 import           Control.Applicative
@@ -101,3 +102,7 @@ updateLastActiveOnEachScreen StackSet {current = cur, visible = vis} wh =
       let newEntry = (sid, wid)
           alreadyCurrent = maybe False (== newEntry) $ firstOnScreen sid curr
       in if alreadyCurrent then curr else newEntry:delete newEntry curr
+
+-- | Modify a the workspace history with a given pure function.
+workspaceHistoryModify :: ([(ScreenId, WorkspaceId)] -> [(ScreenId, WorkspaceId)]) -> X ()
+workspaceHistoryModify action = XS.modify $ WorkspaceHistory . action . history


### PR DESCRIPTION
### Description

The `XMonad.Actions.TopicSpace` module is extremely useful, but some
small idiosyncrasies make it harder to use than necessary.  This pr
tries to fix that.  I'll provide a short description of the commits and
what they aim to achieve:

  1. Makes `switchTopic` update the last focused topic properly.
     Before, this functionality was solely used for pretty printing the
     topics, making the documentation of e.g. `maxTopicHistory` very
     confusing.
  2. Adds a new function, `switchNthLastFocusedExclude`, which makes it
     possible to exclude certain topics when querying the history.
  3. Corrects several spelling mistakes and tries to make the overall
     module documentation a little more palatable.  The whole config is
     divided up into smaller chunks and some parts that have nothing to
     do with the module as such (like a lot of `myConfig`) were removed.
     Some more example configuration was also added in places where this
     made sense.
  4. Indents everything to 2 spaces (the majority of the module was
     already indented as such, but there were some outliers).
  5. Properly fixes `maxTopicHistory` by making `setLastFocusedTopic`
     aware of the length (again, so far `maxTopicHistory` was only used
     for pretty-printing).
  6. Applies some hlint hint
  7. Changes the order of filtering the topic history list and consing
     the given topic onto it (because we respect `maxTopicHistory` now
     this is much more convenient when e.g. preventing certain topics
     from ever entering the history).
  8. Adds `switchTopicWith`, which allows one to pass a custom 
     filtering function to `setLastFocusedTopic`
  9. Adds a new function to `XMonad.Hooks.WorkspaceHistory`, in order to easily
     modify the workspace history with a pure function, because
  10. Does away with the hand-rolled history that `TopicSpace` was using and uses
      the one provided by `XMonad.Hooks.WorkspaceHistory` instead.  This is not a
      user-facing change, as something like `getLastFocusedTopics` has just been
      aliased.
  11. Adds new, screen-aware, functions `getLastFocusedTopicsByScreen` and
      `switchNthLastFocusedByScreen` (that do what they say).
  12. Updates the changelog

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)