### PR TITLE
X.H.ManageDocks: Init strut cache on demand if necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -236,7 +236,11 @@
     - Export `popHiddenWindow` function restoring a specific window.
 
   * `XMonad.Hooks.ManageDocks`
+
     - Export `AvoidStruts` constructor
+
+    - Restored compatibility with pre-0.13 configs by making the startup hook
+      unnecessary for correct functioning.
 
   * `XMonad.Hooks.ManageHelpers`
     - Export `doSink`
@@ -791,6 +795,12 @@
   * `XMonad.Prompt` now stores its history file in the XMonad cache
     directory in a file named `prompt-history`.
 
+  * `XMonad.Hooks.ManageDocks` now requires an additional startup hook to be
+    added to configuration in addition to the other 3 hooks, otherwise docks
+    started before xmonad are covered by windows. It's recommended to use the
+    newly introduced `docks` function to add all necessary hooks to xmonad
+    config.
+
 ### New Modules
 
   * `XMonad.Layout.SortedLayout`
@@ -824,7 +834,7 @@
 
 ### Bug Fixes and Minor Changes
 
-  * `XMonad.Hooks.ManageDocks`,
+  * `XMonad.Hooks.ManageDocks`
 
     - Fix a very annoying bug where taskbars/docs would be
       covered by windows.


### PR DESCRIPTION
### Description

This makes docksStartupHook unnecessary. That is desirable because we
didn't add a changelog entry about it being necessary, and 4 years after
its introduction we still have users grabbing old configs and reporting
(https://github.com/xmonad/xmonad/issues/21#issuecomment-596161669) that
ManageDocks doesn't work properly.

I would love to finally settle this.

### More context

Full story follows:

xmonad-contrib 0.12 introduced (00be056a1bad, merged in April 2013)
caching to ManageDocks to avoid queryTree calls on every runLayout,
which brought in several bugs. Attempts to fix these bugs in
xmonad-contrib 0.13 introduced (28e9f8bce781, merged in February 2016) a
breaking change in ManageDocks that required users to add
docksStartupHook (or docks, after e38fb3bdb8bb got merged in November
2016) to their configs for avoidStruts to still work after xmonad
restart. Unfortunately this was never mentioned in the changelog nor in
any compilation warning (which get discarded by xmonad --recompile
anyway !!!), so as of March 2020 we still have users being bitten by
this.

Back in September 2016 in a discussion about other bugs introduced in
28e9f8bce781 I suggested that we use Maybe to indicate whether the cache
had been initialized and initialize it on demand when it had not.
Unfortunately I wasn't sufficiently clear about what I meant and Brandon
was going through some health issues, so we just got into a heated
argument and ended up merging a suboptimal solution. :-(

And since we're _still_ getting complaints from users every now and
then, I believe it's worth dealing with even after all these years.
If nothing else, let this serve as a reminder that breaking users'
configs without any warning is wrong.

(Oh and we should probably stop hiding xmonad.hs compilation warnings,
otherwise we can't ever hope to provide smooth deprecation and upgrade
paths.)

Fixes: 00be056a1bad ("Cache results from calcGap in ManageDocks")
Fixes: 28e9f8bce781 ("add docksStartupHook for handling docks when restarted")
Fixes: e38fb3bdb8bb ("Make usage of ManageDocks simpler and more robust")
Related: https://github.com/xmonad/xmonad-contrib/issues/118
Related: https://github.com/xmonad/xmonad-contrib/pull/30
Related: https://github.com/xmonad/xmonad-contrib/pull/80
Related: https://github.com/xmonad/xmonad/issues/21

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - (n/a) I updated the `XMonad.Doc.Extending` file (if appropriate)