### PR TITLE
X.L.SubLayouts: Avoid moving floats to end of window stack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -368,6 +368,10 @@
     - Made the history respect words that were "completed" by `alwaysHighlight`
       upon confirmation of the selection by the user.
 
+  * `XMonad.Layout.SubLayouts`
+
+    - Floating windows are no longer moved to the end of the window stack.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/SubLayouts.hs
+++ b/XMonad/Layout/SubLayouts.hs
@@ -62,6 +62,7 @@ import qualified XMonad.Layout.BoringWindows as B
 import qualified XMonad.StackSet as W
 import qualified Data.Map as M
 import Data.Map(Map)
+import qualified Data.Set as S
 
 -- $screenshots
 --
@@ -442,9 +443,13 @@ updateWs = windowsMaybe . updateWs'
 updateWs' :: Groups Window -> WindowSet -> Maybe WindowSet
 updateWs' gs ws = do
     f <- W.peek ws
-    let w = W.index ws
-        nes = concatMap W.integrate $ mapMaybe (flip M.lookup gs) w
-        ws' = W.focusWindow f $ foldr W.insertUp (foldr W.delete' ws nes) nes
+    let wins = W.index ws
+    let wset = S.fromList wins
+    let gset = S.fromList $ concatMap W.integrate $ M.elems $
+            M.filterWithKey (\k _ -> k `S.member` wset) gs -- M.restrictKeys (ghc 8.2+)
+    st <- W.differentiate . concat $ flip map wins $ \w ->
+        if w `S.member` gset then maybe [] W.integrate (w `M.lookup` gs) else [w]
+    let ws' = W.focusWindow f $ W.modify' (const st) ws
     guard $ W.index ws' /= W.index ws
     return ws'
 


### PR DESCRIPTION
### Description

This makes the following sequence of operations idempotent, as it should be:

    windows $ W.float w $ W.RationalRect 0 0 1 1
    windows $ W.sink w

Previously, any window not visible to the Sublayout modifier (xmonad
invokes runLayout with tiled windows only) would be reordered to the end
of stack. This commit changes the reordering logic to only reorder
windows in Groups and keep all other windows where they were.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - (n/a) I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - (n/a) I updated the `XMonad.Doc.Extending` file (if appropriate)