### PR TITLE
X.H.DynamicLog: Start recommending poperty-based logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -182,6 +182,13 @@
     - Added `filterOutWsPP` for filtering out certain workspaces from being
       displayed.
 
+    - Added `xmobarProp`, `statusBarProp`, and `statusBarPropTo` for
+      property-based alternatives to `xmobar` and `statusBar` respectively.
+
+    - Reworked the module documentation to suggest property-based logging
+      instead of pipe-based logging, due to the various issues associated with
+      the latter.
+
   * `XMonad.Layout.BoringWindows`
 
      Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.


### PR DESCRIPTION
### Description

Stop recommending pipes as the best/first thing to do and instead recommend
property based logging for all bars that support it.  Also strongly recommend
users to use the already pre-made functions that do all of the plumbing.

Using pipes is very error-prone (see e.g. #400), so this seems like a logical
step.  

Unfortunately, how we go about spawning the status bar in this case is not quite
clear.  We can't use `spawn`, nor `safeSpawn`, because that would spawn the
status bar again (without killing the other one first) when restarting xmonad
via `M-q`.  `spawnOnce` is also unsuited (and only used here as a placeholder)
because users expect changes to their bar configurations to take effect when
they `M-q` restart xmonad.  On IRC, we've discussed saving the PIDs somewhere
and killing them when executing `statusBarProp`, but there was a very good
objection to that:

> <fizzie> I'd be a little wary about something that just blindly sends
> signals. What if the process got killed in the meanwhile (crash or whatever),
> and the PID reused for something else? (Not that there's probably that great
> alternatives, and I'm sure it works in practice.)

I'm putting this up as a draft because, frankly, I've run out of ideas.

TODO: 

  - [x] Update CHANGELOG.md

  - [x] Find a good solution for spawning status bars  

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~