### PR TITLE
Fix typo in X.L.IndependentScreens example code

### DIFF
--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -54,7 +54,7 @@ import XMonad.Hooks.DynamicLog
 -- to specific workspace names.  In the default configuration, only
 -- the keybindings for changing workspace do this:
 --
--- > keyBindings conf = let m = modMask conf in fromList $
+-- > keyBindings conf = let modm = modMask conf in fromList $
 -- >     {- lots of other keybindings -}
 -- >     [((m .|. modm, k), windows $ f i)
 -- >         | (i, k) <- zip (XMonad.workspaces conf) [xK_1 .. xK_9]
@@ -62,7 +62,7 @@ import XMonad.Hooks.DynamicLog
 --
 -- This should change to
 --
--- > keyBindings conf = let m = modMask conf in fromList $
+-- > keyBindings conf = let modm = modMask conf in fromList $
 -- >     {- lots of other keybindings -}
 -- >     [((m .|. modm, k), windows $ onCurrentScreen f i)
 -- >         | (i, k) <- zip (workspaces' conf) [xK_1 .. xK_9]


### PR DESCRIPTION
Closes #111

### Description

Trivial typo fix, therefore no tests or updates to CHANGES.md/XMonad.Doc.Extending

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
