### PR TITLE
Add filterOutWs[PP]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -176,17 +176,25 @@
     - Added `shortenLeft` function, like existing `shorten` but shortens by
       truncating from left instead of right. Useful for showing directories.
 
+    - Added `filterOutWsPP` for filtering out certain workspaces from being
+      displayed.
+
   * `XMonad.Layout.BoringWindows`
 
      Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.
 
   * `XMonad.Util.NamedScratchpad`
 
-     Added two new exported functions to the module:
-     - `customRunNamedScratchpadAction`
-         (provides the option to customize the `X ()` action the scratchpad is launched by)
-     - `spawnHereNamedScratchpadAction`
-         (uses `XMonad.Actions.SpawnOn.spawnHere` to initially start the scratchpad on the workspace it was launched on)
+     - Added two new exported functions to the module:
+         - `customRunNamedScratchpadAction`
+             (provides the option to customize the `X ()` action the scratchpad is launched by)
+         - `spawnHereNamedScratchpadAction`
+             (uses `XMonad.Actions.SpawnOn.spawnHere` to initially start the scratchpad on the workspace it was launched on)
+     - Deprecated `namedScratchpadFilterOutWorkspace` and
+       `namedScratchpadFilterOutWorkspacePP`.  Use
+       `XMonad.Util.WorkspaceCompare.filterOutWs` respectively
+       `XMonad.Hooks.DynamicLog.filterOutWsPP` instead.
+     - Exported the `scratchpadWorkspaceTag`.
 
   * `XMonad.Util.Run`
 
@@ -301,6 +309,10 @@
 
   * `XMonad.Util.DebugWindow`
     Fixed a bottom in `debugWindow` when used on windows with UTF8 encoded titles.
+
+  * `XMonad.Hooks.WorkspaceCompare`
+
+    - Added `filterOutWs` for workspace filtering.
 
 ## 0.16
 

--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -46,7 +46,7 @@ module XMonad.Hooks.DynamicLog (
     wrap, pad, trim, shorten, shortenLeft,
     xmobarColor, xmobarAction, xmobarBorder,
     xmobarRaw, xmobarStrip, xmobarStripTags,
-    dzenColor, dzenEscape, dzenStrip,
+    dzenColor, dzenEscape, dzenStrip, filterOutWsPP,
 
     -- * Internal formatting functions
     pprWindowSet,
@@ -507,6 +507,23 @@ xmobarStripTags tags = strip [] where
     dropTilClose = drop 1 . dropWhile (/= '>')
     openTag str = "<" ++ str ++ "="
     closeTag str = "</" ++ str ++ ">"
+
+-- | Transforms a pretty-printer into one not displaying the given workspaces.
+--
+-- For example, filtering out the @NSP@ workspace before giving the 'PP' to
+-- 'dynamicLogWithPP':
+--
+-- > logHook = dynamicLogWithPP . filterOutWsPP [scratchpadWorkspaceTag] $ def
+--
+-- Here is another example, when using "XMonad.Layout.IndependentScreens".  If
+-- you have handles @hLeft@ and @hRight@ for bars on the left and right screens,
+-- respectively, and @pp@ is a pretty-printer function that takes a handle, you
+-- could write
+--
+-- > logHook = let log screen handle = dynamicLogWithPP . filterOutWsPP [scratchpadWorkspaceTag] . marshallPP screen . pp $ handle
+-- >           in log 0 hLeft >> log 1 hRight
+filterOutWsPP :: [WorkspaceId] -> PP -> PP
+filterOutWsPP ws pp = pp { ppSort = (. filterOutWs ws) <$> ppSort pp }
 
 -- | The 'PP' type allows the user to customize the formatting of
 --   status information.

--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -17,6 +17,7 @@ module XMonad.Util.NamedScratchpad (
   -- * Usage
   -- $usage
   NamedScratchpad(..),
+  scratchpadWorkspaceTag,
   nonFloating,
   defaultFloating,
   customFloating,
@@ -176,8 +177,7 @@ someNamedScratchpadAction f runApp scratchpadConfig scratchpadName =
 
         Nothing -> return ()
 
-
--- tag of the scratchpad workspace
+-- | Tag of the scratchpad workspace
 scratchpadWorkspaceTag :: String
 scratchpadWorkspaceTag = "NSP"
 

--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -90,6 +90,12 @@ import qualified XMonad.StackSet as W
 -- For detailed instruction on editing the key binding see
 -- "XMonad.Doc.Extending#Editing_key_bindings"
 --
+-- For some applications (like displaying your workspaces in a status bar) it is
+-- convenient to filter out the @NSP@ workspace when looking at all workspaces.
+-- For this, you can use functions 'XMonad.Hooks.DynamicLog.filterOutWsPP' and
+-- 'XMonad.Util.WorkspaceCompare.filterOutWs'.  See the documentation of these
+-- functions for examples.
+--
 
 -- | Single named scratchpad configuration
 data NamedScratchpad = NS { name   :: String      -- ^ Scratchpad name
@@ -190,6 +196,7 @@ namedScratchpadManageHook = composeAll . fmap (\c -> query c --> hook c)
 -- doesn't contain it. Intended for use with logHooks.
 namedScratchpadFilterOutWorkspace :: [WindowSpace] -> [WindowSpace]
 namedScratchpadFilterOutWorkspace = filter (\(W.Workspace tag _ _) -> tag /= scratchpadWorkspaceTag)
+{-# DEPRECATED namedScratchpadFilterOutWorkspace "Use XMonad.Util.WorkspaceCompare.filterOutWs [scratchpadWorkspaceTag] instead" #-}
 
 -- | Transforms a pretty-printer into one not displaying the NSP workspace.
 --
@@ -206,5 +213,6 @@ namedScratchpadFilterOutWorkspacePP :: PP -> PP
 namedScratchpadFilterOutWorkspacePP pp = pp {
   ppSort = fmap (. namedScratchpadFilterOutWorkspace) (ppSort pp)
   }
+{-# DEPRECATED namedScratchpadFilterOutWorkspacePP "Use XMonad.Hooks.DynamicLog.filterOutWsPP [scratchpadWorkspaceTag] instead" #-}
 
 -- vim:ts=4:shiftwidth=4:softtabstop=4:expandtab:foldlevel=20:

--- a/XMonad/Util/WorkspaceCompare.hs
+++ b/XMonad/Util/WorkspaceCompare.hs
@@ -11,6 +11,7 @@
 -----------------------------------------------------------------------------
 
 module XMonad.Util.WorkspaceCompare ( WorkspaceCompare, WorkspaceSort
+                                    , filterOutWs
                                     , getWsIndex
                                     , getWsCompare
                                     , getWsCompareByTag
@@ -32,6 +33,11 @@ import Data.Function (on)
 
 type WorkspaceCompare = WorkspaceId -> WorkspaceId -> Ordering
 type WorkspaceSort = [WindowSpace] -> [WindowSpace]
+
+-- | Transforms a workspace list by filtering out the workspaces that
+-- correspond to the given 'tag's.  Intended for use with logHooks.
+filterOutWs :: [WorkspaceId] -> WorkspaceSort
+filterOutWs ws = filter (\S.Workspace{ S.tag = tag } -> tag `notElem` ws)
 
 -- | Lookup the index of a workspace id in the user's config, return Nothing
 -- if that workspace does not exist in the config.


### PR DESCRIPTION
### Description

This generalizes the `namedScratchpadFilterOutWorkspace` and `namedScratchpadFilterOutWorkspacePP` functions from `X.U.NamedScratchpad`, by allowing the user to specify a list of workspace tags themselves.  The resulting functions are `X.U.WorkspaceCompare.filterOutWs` and `X.H.DynamicLog.filterOutWsPP`.

The respective functions in `X.U.NamedScratchpad` have been deprecated accordingly.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
