### PR TITLE
Check for text encoding correctly and avoid bottom (#422)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -254,7 +254,7 @@
 
   * `XMonad.Util.EZConfig`
     - Added support for XF86Bluetooth.
-    
+
   * `XMonad.Util.Loggers`
     - Make `battery` and `loadAvg` distro-independent.
 
@@ -294,10 +294,13 @@
 
     - Added `workspaceHistoryModify` to modify the workspace history with a pure
       function.
-      
+
   * `XMonad.Hooks.DynamicLog`
 
-    - Add the -dock argument to the dzen spawn arguments      
+    - Add the -dock argument to the dzen spawn arguments
+
+  * `XMonad.Util.DebugWindow`
+    Fixed a bottom in `debugWindow` when used on windows with UTF8 encoded titles.
 
 ## 0.16
 

--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -120,13 +120,13 @@ getDecodedStringProp w a =  do
 tryUTF8                          :: TextProperty -> X [String]
 tryUTF8 (TextProperty s enc _ _) =  do
   uTF8_STRING <- getAtom "UTF8_STRING"
-  when (enc == uTF8_STRING) $ error "String is not UTF8_STRING"
+  when (enc /= uTF8_STRING) $ error "String is not UTF8_STRING"
   (map decodeString . splitNul) <$> io (peekCString s)
 
 tryCompound                            :: TextProperty -> X [String]
 tryCompound t@(TextProperty _ enc _ _) =  do
   cOMPOUND_TEXT <- getAtom "COMPOUND_TEXT"
-  when (enc == cOMPOUND_TEXT) $ error "String is not COMPOUND_TEXT"
+  when (enc /= cOMPOUND_TEXT) $ error "String is not COMPOUND_TEXT"
   withDisplay $ \d -> io $ wcTextPropertyToTextList d t
 
 splitNul    :: String -> [String]


### PR DESCRIPTION
### Description

The existing code has a flipped boolean logic, and incorrectly interprets UTF8_STRING as COMPOUND_TEXT and vice-versa, producing bottoms in strings when a UTF8_STRING is encountered.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
