### PR TITLE
Use the default XFCE terminal with `XMonad.Config.Xfce`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -301,6 +301,9 @@
 
   * `XMonad.Util.DebugWindow`
     Fixed a bottom in `debugWindow` when used on windows with UTF8 encoded titles.
+    
+  * `XMonad.Config.Xfce`
+    Set `terminal` to `xfce4-terminal`.
 
 ## 0.16
 

--- a/XMonad/Config/Xfce.hs
+++ b/XMonad/Config/Xfce.hs
@@ -36,7 +36,7 @@ import qualified Data.Map as M
 -- For examples of how to further customize @xfceConfig@ see "XMonad.Config.Desktop".
 
 xfceConfig = desktopConfig
-    { terminal = "Terminal"
+    { terminal = "xfce4-terminal"
     , keys     = xfceKeys <+> keys desktopConfig }
 
 xfceKeys (XConfig {modMask = modm}) = M.fromList $


### PR DESCRIPTION
### Description

When using xmonad with XFCE the “open terminal” key binding doesn't work, because it tries to start the app which doesn't exist in the system. This PR changes the `terminal` setting to use the default XFCE terminal — `xfce4-terminal`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
