### PR TITLE
Fix Documentation in X.H.FadeWindows

### DIFF
--- a/XMonad/Hooks/FadeWindows.hs
+++ b/XMonad/Hooks/FadeWindows.hs
@@ -205,7 +205,7 @@ fadeWindowsLogHook h =  withWindowSet $ \s -> do
   forM_ visibleWins $ \w -> do
     o <- userCodeDef (Opacity 1) (runQuery h w)
     setOpacity w $ case o of
-                     OEmpty    -> 0.93
+                     OEmpty    -> 1
                      Opacity r -> r
 
 -- | A 'handleEventHook' to handle fading and unfading of newly mapped

--- a/XMonad/Hooks/FadeWindows.hs
+++ b/XMonad/Hooks/FadeWindows.hs
@@ -76,17 +76,26 @@ import           Graphics.X11.Xlib.Extras                (Event(..))
 -- >     , handleEventHook = fadeWindowsEventHook
 -- >     {- ... -}
 -- >
--- > myFadeHook = composeAll [isUnfocused --> transparency 0.2
--- >                         ,                opaque
+-- > myFadeHook = composeAll [                 opaque
+-- >                         , isUnfocused --> transparency 0.2
 -- >                         ]
 --
 -- The above is like FadeInactive with a fade value of 0.2.
 --
--- FadeHooks do not accumulate; instead, they compose from right to
--- left like 'ManageHook's, so the above example @myFadeHook@ will
--- render unfocused windows at 4/5 opacity and the focused window
--- as opaque.  The 'opaque' hook above is optional, by the way, as any
--- unmatched window will be opaque by default.
+-- 'FadeHook's do not accumulate; instead, they compose from right to
+-- left like 'ManageHook's, so in the above example @myFadeHook@ will
+-- render unfocused windows at 4/5 opacity and the focused window as
+-- opaque.  This means that, in particular, the order in the above
+-- example is important.
+--
+-- The 'opaque' hook above is optional, by the way, as any unmatched
+-- window will be opaque by default.  If you want to make all windows a
+-- bit transparent by default, you can replace 'opaque' with something
+-- like
+--
+-- > transparency 0.93
+--
+-- at the top of @myFadeHook@.
 --
 -- This module is best used with "XMonad.Hooks.MoreManageHelpers", which
 -- exports a number of Queries that can be used in either @ManageHook@


### PR DESCRIPTION
### Description

(Probably) fixes #419 (still waiting for confirmation of the person on
IRC for that)

So far, the documentation for X.H.FadeWindows had, as an example, the
following `logHook`:

``` haskell
  logHook = fadeWindowsLogHook myFadeHook

  myFadeHook = composeAll [ isUnfocused --> transparency 0.2
                          ,                 opaque
                          ]
```

The problem is that `composeAll = mconcat` and `mappend` for `FadeHook`
simply throws away the left argument if there's a right one, hence
everything gets marked opaque and `_NET_WM_WINDOW_OPACITY` is never set.

Switching things around solves this problem:

``` haskell
  myFadeHook = composeAll [                 opaque
                          , isUnfocused --> transparency 0.2
                          ]

```

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
