### PR TITLE
X.L.SubLayouts: Rewrite updateGroup, updateWs' using stack of stacks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -368,6 +368,10 @@
     - Made the history respect words that were "completed" by `alwaysHighlight`
       upon confirmation of the selection by the user.
 
+  * `XMonad.Layout.SubLayouts`
+
+    - Floating windows are no longer moved to the end of the window stack.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/SubLayouts.hs
+++ b/XMonad/Layout/SubLayouts.hs
@@ -468,9 +468,8 @@ mapGroups f = M.fromList . map (W.focus &&& id) . mapMaybe f . M.elems
 -- absent. See also 'W.focusWindow'
 focusWindow' :: (Eq a) => a -> W.Stack a -> Maybe (W.Stack a)
 focusWindow' w st = do
-    guard $ not $ null $ filter (w==) $ W.integrate st
-    if W.focus st == w then Just st
-        else focusWindow' w $ W.focusDown' st
+    guard $ w `elem` W.integrate st
+    return $ until ((w ==) . W.focus) W.focusDown' st
 
 -- update only when Just
 windowsMaybe :: (WindowSet -> Maybe WindowSet) -> X ()

--- a/XMonad/Layout/SubLayouts.hs
+++ b/XMonad/Layout/SubLayouts.hs
@@ -62,6 +62,7 @@ import qualified XMonad.Layout.BoringWindows as B
 import qualified XMonad.StackSet as W
 import qualified Data.Map as M
 import Data.Map(Map)
+import qualified Data.Set as S
 
 -- $screenshots
 --
@@ -442,9 +443,13 @@ updateWs = windowsMaybe . updateWs'
 updateWs' :: Groups Window -> WindowSet -> Maybe WindowSet
 updateWs' gs ws = do
     f <- W.peek ws
-    let w = W.index ws
-        nes = concatMap W.integrate $ mapMaybe (flip M.lookup gs) w
-        ws' = W.focusWindow f $ foldr W.insertUp (foldr W.delete' ws nes) nes
+    let wins = W.index ws
+    let wset = S.fromList wins
+    let gset = S.fromList $ concatMap W.integrate $ M.elems $
+            M.filterWithKey (\k _ -> k `S.member` wset) gs -- M.restrictKeys (ghc 8.2+)
+    st <- W.differentiate . concat $ flip map wins $ \w ->
+        if w `S.member` gset then maybe [] W.integrate (w `M.lookup` gs) else [w]
+    let ws' = W.focusWindow f $ W.modify' (const st) ws
     guard $ W.index ws' /= W.index ws
     return ws'
 


### PR DESCRIPTION
### Description

A stack of stacks is a more natural representation of what SubLayouts does: it packs information about the global focus as well as focus in individual groups (sublayouts).

It doesn't carry information about the sublayouts themselves (but a similar structure in X.L.Groups does), so we still use Groups and fromGroups in some places, but future refactor can simplify that as well, I'm sure.

My main motivation for this is that I need to expose the window groups to the user config, and a stack of stacks seems to be a nice data structure for that. The motivation for exposing the groups is that I want to manipulate focus a way that takes groups into account. As an example, I want the following:

 * mod-1, mod-2 to mod-0 switches to n-th group if not already focused, and if focused, focus next in the group

 * show these numbers and window titles in xmobar (like tmux/screen/vim status line), like so:

    ```
    1a weechat  1b browser  2 vim  3 mutt
    ```

Achieving this just using BoringWindows is quite tricky, but with the ability to somehow (InspectLayout, which is work-in-progress, or message with IORef) get the stack of stacks out of SubLayouts, this becomes easy.

---

- [ ] merge https://github.com/xmonad/xmonad-contrib/pull/407 first
- [ ] maybe try to refactor more of SubLayouts to use GroupStack?

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)