### PR TITLE
Faster builds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,8 @@
 
 ### Bug Fixes and Minor Changes
 
+  * Add `-j +RTS -A32m -RTS` to `ghc-options`
+
   * `XMonad.Actions.DynamicProjects`
 
     The `changeProjectDirPrompt` function respects the `complCaseSensitivity` field

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -70,7 +70,7 @@ library
         cpp-options: -DXFT
 
     if true
-        ghc-options:    -fwarn-tabs -Wall
+        ghc-options:    -fwarn-tabs -Wall -j +RTS -A32m -RTS
 
     if flag(testing)
         ghc-options:    -fwarn-tabs -Werror
@@ -387,5 +387,5 @@ test-suite properties
                , unix
                , utf8-string
                , xmonad >= 0.15 && < 0.16
-  ghc-options: -i.
+  ghc-options: -i. -j +RTS -A32m -RTS
   cpp-options: -DTESTING


### PR DESCRIPTION
### Description

This speeds up builds, as `xmonad-contrib` is a "terminal" library it is often being compiled when nothing else is, so that it is not concurrent. 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
