### PR TITLE
Get rid of unused imports

### DIFF
--- a/XMonad/Actions/DynamicProjects.hs
+++ b/XMonad/Actions/DynamicProjects.hs
@@ -49,7 +49,6 @@ import Data.List (sort, union, stripPrefix)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isNothing)
-import Data.Monoid ((<>))
 import System.Directory (setCurrentDirectory, getHomeDirectory, makeAbsolute)
 import XMonad
 import XMonad.Actions.DynamicWorkspaces

--- a/XMonad/Actions/GridSelect.hs
+++ b/XMonad/Actions/GridSelect.hs
@@ -82,7 +82,6 @@ import Data.Maybe
 import Data.Bits
 import Data.Char
 import Data.Ord (comparing)
-import Control.Applicative
 import Control.Monad.State
 import Control.Arrow
 import Data.List as L

--- a/XMonad/Actions/ShowText.hs
+++ b/XMonad/Actions/ShowText.hs
@@ -24,7 +24,7 @@ module XMonad.Actions.ShowText
 
 import Control.Monad (when)
 import Data.Map (Map,empty,insert,lookup)
-import Data.Monoid (mempty, All)
+import Data.Monoid (All)
 import Prelude hiding (lookup)
 import XMonad
 import XMonad.StackSet (current,screen)

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -60,7 +60,6 @@ module XMonad.Actions.TreeSelect
     , treeselectAt
     ) where
 
-import Control.Applicative
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.List (find)

--- a/XMonad/Actions/WorkspaceCursors.hs
+++ b/XMonad/Actions/WorkspaceCursors.hs
@@ -50,10 +50,8 @@ import XMonad(Typeable, Message, WorkspaceId, X, XState(windowset),
               fromMessage, sendMessage, windows, gets)
 import Control.Applicative (liftA2)
 import Control.Monad((<=<), guard, when)
-import Data.Foldable(Foldable(foldMap), toList)
+import Data.Foldable(toList)
 import Data.Maybe(fromJust, listToMaybe)
-import Data.Monoid(Monoid(mappend, mconcat))
-import Data.Traversable(sequenceA)
 
 -- $usage
 --

--- a/XMonad/Config/Bluetile.hs
+++ b/XMonad/Config/Bluetile.hs
@@ -62,7 +62,6 @@ import qualified XMonad.StackSet as W
 import qualified Data.Map as M
 
 import System.Exit
-import Data.Monoid
 import Control.Monad(when)
 
 -- $usage

--- a/XMonad/Config/Dmwit.hs
+++ b/XMonad/Config/Dmwit.hs
@@ -4,7 +4,6 @@
 module XMonad.Config.Dmwit where
 
 -- system imports
-import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans
 import Data.Char

--- a/XMonad/Hooks/DebugEvents.hs
+++ b/XMonad/Hooks/DebugEvents.hs
@@ -48,7 +48,6 @@ import           Numeric                                     (showHex)
 import           System.Exit
 import           System.IO
 import           System.Process
-import           Control.Applicative
 
 -- | Event hook to dump all received events.  You should probably not use this
 --   unconditionally; it will produce massive amounts of output.

--- a/XMonad/Hooks/DynamicProperty.hs
+++ b/XMonad/Hooks/DynamicProperty.hs
@@ -27,7 +27,6 @@ module XMonad.Hooks.DynamicProperty where
 
 import XMonad
 import Data.Monoid
-import Control.Applicative
 import Control.Monad (when)
 
 -- |

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -37,7 +37,6 @@ import Data.List
 import Data.Maybe
 import Data.Monoid
 import qualified Data.Map.Strict as M
-import System.IO.Unsafe
 
 import XMonad
 import Control.Monad

--- a/XMonad/Hooks/FadeWindows.hs
+++ b/XMonad/Hooks/FadeWindows.hs
@@ -61,8 +61,7 @@ import           Control.Monad.Reader                    (ask
                                                          ,asks)
 import           Control.Monad.State                     (gets)
 import qualified Data.Map                    as M
-import           Data.Monoid                      hiding ((<>))
-import           Data.Semigroup
+import           Data.Monoid
 
 import           Graphics.X11.Xlib.Extras                (Event(..))
 

--- a/XMonad/Hooks/Focus.hs
+++ b/XMonad/Hooks/Focus.hs
@@ -65,7 +65,6 @@ module XMonad.Hooks.Focus
 import Data.Maybe
 import Data.Monoid
 import qualified Data.Semigroup as S
-import Control.Applicative
 import Control.Monad
 import Control.Monad.Reader
 import Control.Arrow hiding ((<+>))
@@ -74,7 +73,7 @@ import XMonad
 import qualified XMonad.StackSet as W
 import qualified XMonad.Util.ExtensibleState as XS
 import XMonad.Hooks.ManageHelpers (currentWs)
-import XMonad.Hooks.EwmhDesktops (activated, NetActivated(..))
+import XMonad.Hooks.EwmhDesktops (activated)
 
 
 -- $main

--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -40,8 +40,7 @@ import XMonad.Util.Types
 import XMonad.Util.WindowProperties (getProp32s)
 import XMonad.Util.XUtils (fi)
 import qualified XMonad.Util.ExtensibleState as XS
-import Data.Monoid (All(..), mempty)
-import Data.Functor((<$>))
+import Data.Monoid (All(..))
 
 import qualified Data.Set as S
 import qualified Data.Map as M

--- a/XMonad/Hooks/WallpaperSetter.hs
+++ b/XMonad/Hooks/WallpaperSetter.hs
@@ -39,10 +39,7 @@ import Data.Char (isAlphaNum)
 import Data.Ord (comparing)
 
 import Control.Monad
-import Control.Applicative
 import Data.Maybe
-import Data.Monoid hiding ((<>))
-import Data.Semigroup
 
 -- $usage
 -- This module requires imagemagick and feh to be installed, as these are utilized

--- a/XMonad/Hooks/XPropManage.hs
+++ b/XMonad/Hooks/XPropManage.hs
@@ -20,7 +20,7 @@ module XMonad.Hooks.XPropManage (
 
 import Control.Exception as E
 import Data.Char (chr)
-import Data.Monoid (mconcat, Endo(..))
+import Data.Monoid (Endo(..))
 
 import Control.Monad.Trans (lift)
 

--- a/XMonad/Layout/BinarySpacePartition.hs
+++ b/XMonad/Layout/BinarySpacePartition.hs
@@ -47,7 +47,6 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.List ((\\), elemIndex, foldl')
 import Data.Maybe (fromMaybe, isNothing, isJust, mapMaybe, catMaybes)
-import Control.Applicative
 import Control.Monad
 import Data.Ratio ((%))
 

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -31,7 +31,6 @@ module XMonad.Layout.IndependentScreens (
 -- for the screen stuff
 import Control.Applicative(liftA2)
 import Control.Arrow hiding ((|||))
-import Control.Monad
 import Data.List (nub, genericLength)
 import Graphics.X11.Xinerama
 import XMonad

--- a/XMonad/Layout/Master.hs
+++ b/XMonad/Layout/Master.hs
@@ -26,7 +26,6 @@ module XMonad.Layout.Master (
 import XMonad
 import qualified XMonad.StackSet as S
 import XMonad.Layout.LayoutModifier
-import Control.Monad
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:

--- a/XMonad/Layout/Mosaic.hs
+++ b/XMonad/Layout/Mosaic.hs
@@ -35,11 +35,9 @@ import XMonad(Typeable,
 import qualified XMonad.StackSet as W
 import Control.Arrow(second, first)
 import Control.Monad(mplus)
-import Data.Foldable(Foldable,foldMap, sum)
+import Data.Foldable(sum)
 import Data.Function(on)
 import Data.List(sortBy)
-import Data.Monoid(Monoid,mempty, mappend, (<>))
-import Data.Semigroup
 
 
 -- $usage

--- a/XMonad/Layout/SortedLayout.hs
+++ b/XMonad/Layout/SortedLayout.hs
@@ -25,7 +25,6 @@ module XMonad.Layout.SortedLayout
   ) where
 
 import           Control.Monad
-import           Data.Functor                 ((<$>))
 import           Data.List
 
 import           XMonad

--- a/XMonad/Layout/SubLayouts.hs
+++ b/XMonad/Layout/SubLayouts.hs
@@ -56,7 +56,6 @@ import Control.Monad(MonadPlus(mplus), foldM, guard, when, join)
 import Data.Function(on)
 import Data.List(nubBy, (\\), find)
 import Data.Maybe(isNothing, fromMaybe, listToMaybe, mapMaybe)
-import Data.Traversable(sequenceA)
 
 import qualified XMonad as X
 import qualified XMonad.Layout.BoringWindows as B

--- a/XMonad/Layout/TallMastersCombo.hs
+++ b/XMonad/Layout/TallMastersCombo.hs
@@ -49,19 +49,12 @@ module XMonad.Layout.TallMastersCombo (
 import XMonad hiding (focus, (|||))
 import XMonad.StackSet (Workspace(..),integrate',Stack(..))
 import qualified XMonad.StackSet as W
-import Data.Maybe (fromJust,isJust,fromMaybe)
+import Data.Maybe (isJust)
 import Data.List (delete,find)
-import Control.Monad (join, foldM)
-import XMonad.Layout (Choose, ChangeLayout(..))
-import qualified XMonad.Layout as LL
-import Data.Typeable
-import XMonad.Layout.Simplest (Simplest(..))
-import XMonad.Layout hiding ((|||))
-import XMonad.Layout.Decoration
-import XMonad.Layout.LayoutModifier
-import XMonad.Layout.Tabbed (tabbed, fontName, shrinkText)
-import Data.Maybe (fromJust,isJust)
 import Control.Monad (foldM)
+import qualified XMonad.Layout as LL
+import XMonad.Layout.Simplest (Simplest(..))
+import XMonad.Layout.Decoration
 
 ---------------------------------------------------------------------------------
 -- $usage

--- a/XMonad/Prompt/Ssh.hs
+++ b/XMonad/Prompt/Ssh.hs
@@ -28,7 +28,6 @@ import System.Environment
 import Control.Exception as E
 
 import Control.Applicative (liftA2)
-import Control.Monad
 import Data.Maybe
 import Data.List(elemIndex)
 

--- a/XMonad/Prompt/Unicode.hs
+++ b/XMonad/Prompt/Unicode.hs
@@ -29,9 +29,7 @@ import Data.Char
 import Data.Maybe
 import Data.Ord
 import Numeric
-import System.Environment
 import System.IO
-import System.IO.Unsafe
 import System.IO.Error
 import Control.Arrow
 import Data.List

--- a/XMonad/Util/Font.hs
+++ b/XMonad/Util/Font.hs
@@ -35,10 +35,8 @@ module XMonad.Util.Font
 
 import XMonad
 import Foreign
-import Control.Applicative
 import Control.Exception as E
 import Data.Maybe
-import Data.Bits (shiftR)
 import Text.Printf (printf)
 
 #ifdef XFT

--- a/XMonad/Util/Invisible.hs
+++ b/XMonad/Util/Invisible.hs
@@ -22,7 +22,6 @@ module XMonad.Util.Invisible (
                             , fromIMaybe
                             ) where
 
-import Control.Applicative
 import Control.Monad.Fail
 
 -- $usage

--- a/XMonad/Util/Loggers.hs
+++ b/XMonad/Util/Loggers.hs
@@ -53,7 +53,6 @@ import XMonad.Util.NamedWindows (getName)
 import Control.Exception as E
 import Data.List (isPrefixOf, isSuffixOf)
 import Data.Maybe (fromMaybe)
-import Data.Traversable (traverse)
 import System.Directory (getDirectoryContents)
 import System.IO
 import System.Locale

--- a/XMonad/Util/PureX.hs
+++ b/XMonad/Util/PureX.hs
@@ -58,7 +58,7 @@ import Control.Monad.State
 import Control.Monad.Reader
 
 -- base
-import Data.Semigroup (Semigroup(..), Any(..))
+import Data.Semigroup (Any(..))
 import Control.Applicative (liftA2)
 
 -- }}}

--- a/XMonad/Util/RemoteWindows.hs
+++ b/XMonad/Util/RemoteWindows.hs
@@ -38,7 +38,6 @@ module XMonad.Util.RemoteWindows
 
 import XMonad
 import XMonad.Util.WindowProperties
-import Data.Monoid
 import Data.Maybe
 import Control.Monad
 import System.Posix.Env

--- a/XMonad/Util/Timer.hs
+++ b/XMonad/Util/Timer.hs
@@ -20,7 +20,6 @@ module XMonad.Util.Timer
     ) where
 
 import XMonad
-import Control.Applicative
 import Control.Concurrent
 import Data.Unique
 

--- a/XMonad/Util/WorkspaceCompare.hs
+++ b/XMonad/Util/WorkspaceCompare.hs
@@ -27,7 +27,6 @@ import XMonad
 import qualified XMonad.StackSet as S
 import Data.List
 import Data.Maybe
-import Data.Monoid (mconcat)
 import XMonad.Actions.PhysicalScreens (ScreenComparator(ScreenComparator), getScreenIdAndRectangle, screenComparatorById)
 import Data.Function (on)
 

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -63,7 +63,11 @@ library
                    xmonad >= 0.15 && < 0.16,
                    utf8-string
 
-    ghc-options:   -fwarn-tabs -Wall -Wno-unused-do-bind
+    ghc-options:   -fwarn-tabs -Wall -Wno-unused-do-bind -Wno-unused-imports
+
+    -- Keep this in sync with the oldest version in 'tested-with'
+    if impl(ghc <= 8.4.4)
+       ghc-options: -Werror=unused-imports
 
     if flag(use_xft)
         build-depends: X11-xft >= 0.2

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -31,7 +31,7 @@ cabal-version:      >= 1.8
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with: GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.1
+tested-with:        GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.8.4
 
 source-repository head
   type:     git
@@ -62,21 +62,15 @@ library
                    X11>=1.6.1 && < 1.10,
                    xmonad >= 0.15 && < 0.16,
                    utf8-string
-    if impl(ghc < 8.0)
-        build-depends: semigroups
+
+    ghc-options:   -fwarn-tabs -Wall -Wno-unused-do-bind
 
     if flag(use_xft)
         build-depends: X11-xft >= 0.2
         cpp-options: -DXFT
 
-    if true
-        ghc-options:    -fwarn-tabs -Wall
-
     if flag(testing)
         ghc-options:    -fwarn-tabs -Werror
-
-    if impl(ghc >= 6.12.1)
-        ghc-options:    -fno-warn-unused-do-bind
 
     exposed-modules:    XMonad.Actions.AfterDrag
                         XMonad.Actions.BluetileCommands


### PR DESCRIPTION
### Description

This is the twin pr to xmonad/xmonad/pull/252, implementing all the same bells and whistles for contrib.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
