### PR TITLE
Restarting status bars on restart 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,6 +196,9 @@
       instead of pipe-based logging, due to the various issues associated with
       the latter.
 
+    - Added `spawnStatusBarAndRemember` and `cleanupStatusBars` to provide 
+      a way to safely restart status bars without relying on pipes.
+
   * `XMonad.Layout.BoringWindows`
 
      Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.


### PR DESCRIPTION
### Description

After discussing in the IRC channel and in #433 on how we should go about restarting status bars, I tried to add the proposed solution to `XMonad.Hooks.DynamicLog`. This needs to be merged after #408, since I rebased my branch on top of it (this is why the diff looks like a mess and why there are a lot of commits)

Big thanks to @liskin  and @slotThe for the tips and the discussion!

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
