### PR TITLE
Export modifyProject in XMonad.Actions.DynamicProjects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,8 +129,10 @@
 
   * `XMonad.Actions.DynamicProjects`
 
-    The `changeProjectDirPrompt` function respects the `complCaseSensitivity` field
+    - The `changeProjectDirPrompt` function respects the `complCaseSensitivity` field
     of `XPConfig` when performing directory completion.
+
+    - `modifyProject` is now exported.
 
   * `XMonad.Layout.WorkspaceDir`
 

--- a/XMonad/Actions/DynamicProjects.hs
+++ b/XMonad/Actions/DynamicProjects.hs
@@ -39,6 +39,7 @@ module XMonad.Actions.DynamicProjects
        , lookupProject
        , currentProject
        , activateProject
+       , modifyProject
        ) where
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Useful for modifying projects using non-prompt mechanisms.
