### PR TITLE
X.H.DynamicLog: Add ppTitleUnfocused

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -201,8 +201,11 @@
       instead of pipe-based logging, due to the various issues associated with
       the latter.
 
-    - Added `spawnStatusBarAndRemember` and `cleanupStatusBars` to provide 
+    - Added `spawnStatusBarAndRemember` and `cleanupStatusBars` to provide
       a way to safely restart status bars without relying on pipes.
+
+    - Added `ppTitleUnfocused` to `PP` for showing unfocused windows on
+      the current workspace in the status bar.
 
   * `XMonad.Layout.BoringWindows`
 


### PR DESCRIPTION
### Description

Add the `ppTitleUnfocused` field to the `PP` record, in order to show
unfocused windows (on the current workspace) in a status bar.

It's sort of unfortunate we have to do this, instead of having a more
strongly-typed `ppTitle` that, instead of a `String`, takes something
like

``` haskell
  data WindowPP = WindowPP
      { win       :: !Window
      , name      :: !String
      , isUrgent  :: !Bool
      , isFocused :: !Bool
      }
```

But that would require changing the signature of `ppTitle` and thus
probably breaking every config in existence that uses this module...

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
