### PR TITLE
Added cleanupStatusBars to the startup-hook

### DIFF
--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -360,7 +360,7 @@ statusBarPropTo :: LayoutClass l Window
 statusBarPropTo prop cmd pp =
     makeStatusBar
         (xmonadPropLog' prop =<< dynamicLogString pp)
-        (spawnStatusBarAndRemember cmd)
+        (cleanupStatusBars *> spawnStatusBarAndRemember cmd)
 
 -- | Spawns a status bar and saves its PID. This is useful when the status bars
 -- should be restarted with xmonad. Use this in combination with 'cleanupStatusBars'.


### PR DESCRIPTION
### Description

In #434, `cleanupStatusBars` isn't added to the `startupHook`. Thanks @slotThe for finding the issue  


### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
