### PR TITLE
X.L.NoBorders: Fix float handling on multihead setups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -378,6 +378,11 @@
       window was up by allowing pointer events to pass through the
       custom tree select event loop.
 
+  * `XMonad.Layout.NoBorders`
+
+    - Fixed handling of floating window borders in multihead setups that was
+      broken since 0.14.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/NoBorders.hs
+++ b/XMonad/Layout/NoBorders.hs
@@ -246,23 +246,31 @@ instance SetsAmbiguous Ambiguity where
                                 $ W.screenDetail scr
                             ]
 
+            -- Find the screen containing the workspace being layouted.
+            -- (This is a list only to avoid the need to specialcase when it
+            -- can't be found or when several contain @lr@. When that happens,
+            -- the result will probably be incorrect.)
+            thisScreen = [ scr | scr <- W.screens wset
+                               , screenRect (W.screenDetail scr) `R.supersetOf` lr ]
+
             -- This originally considered all floating windows across all
-            -- workspaces. It seems more efficient to have each layout manage
-            -- its own floating windows - and equally valid though untested
-            -- against a multihead setup. In some cases the previous code would
-            -- redundantly add then remove borders from already-borderless
-            -- windows.
+            -- workspaces. It seems more efficient to have each screen manage
+            -- its own floating windows - and necessary to support the
+            -- additional OnlyLayoutFloat* variants correctly in multihead
+            -- setups. In some cases the previous code would redundantly add
+            -- then remove borders from already-borderless windows.
             floating = do
+                scr <- thisScreen
                 let wz :: Integer -> (Window,Rectangle)
                        -> (Integer,Window,Rectangle)
                     wz i (w,wr) = (i,w,wr)
                     -- For the following: in stacking order lowest -> highest.
                     ts = reverse . zipWith wz [-1,-2..] $ wrs
                     fs = zipWith wz [0..] $ do
-                        w       <- reverse . W.index $ wset
+                        w       <- reverse . W.integrate' . W.stack . W.workspace $ scr
                         Just wr <- [M.lookup w (W.floating wset)]
                         return (w,scaleRationalRect sr wr)
-                    sr = screenRect . W.screenDetail . W.current $ wset
+                    sr = screenRect . W.screenDetail $ scr
                 (i1,w1,wr1) <- fs
                 guard $ case amb of
                     OnlyLayoutFloatBelow ->

--- a/XMonad/Layout/NoBorders.hs
+++ b/XMonad/Layout/NoBorders.hs
@@ -301,9 +301,6 @@ data Ambiguity
         -- ^ This constructor is used to combine the borderless windows
         -- provided by the SetsAmbiguous instances from two other 'Ambiguity'
         -- data types.
-    | OnlyScreenFloat
-        -- ^ Only remove borders on floating windows that cover the whole
-        -- screen.
     | OnlyLayoutFloatBelow
         -- ^ Like 'OnlyLayoutFloat', but only removes borders if no window
         -- stacked below remains visible. Considers all floating windows on the
@@ -314,9 +311,12 @@ data Ambiguity
     | OnlyLayoutFloat
         -- ^ Only remove borders on floating windows that exactly cover the
         -- parent layout rectangle.
+    | OnlyScreenFloat
+        -- ^ Only remove borders on floating windows that cover the whole
+        -- screen.
     | Never
-        -- ^ Never remove borders when ambiguous: this is the same as
-        -- smartBorders.
+        -- ^ Like 'OnlyScreenFloat', and also remove borders of tiled windows
+        -- when not ambiguous: this is the same as 'smartBorders'.
     | EmptyScreen
         -- ^ Focus in an empty screen does not count as ambiguous.
     | OtherIndicated

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 
 import qualified ManageDocks
+import qualified NoBorders
 import qualified RotateSome
 import qualified Selective
 import qualified SwapWorkspaces
@@ -41,3 +42,4 @@ main = hspec $ do
         prop "prop_split"            $ XPrompt.prop_split
         prop "prop_spliInSubListsAt" $ XPrompt.prop_spliInSubListsAt
         prop "prop_skipGetLastWord"  $ XPrompt.prop_skipGetLastWord
+    context "NoBorders" $ NoBorders.spec

--- a/tests/NoBorders.hs
+++ b/tests/NoBorders.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wall #-}
+module NoBorders where
+
+import Test.Hspec
+
+import qualified Data.Map as M
+
+import XMonad hiding (Screen)
+import qualified XMonad.Layout.NoBorders as NB
+import XMonad.StackSet
+
+spec :: Spec
+spec = do
+    describe "dualhead, fullscreen float on each" $ do
+        let s1 = differentiate [1]
+        let s2 = differentiate [2]
+        let floats = [(1, rrFull), (2, rrFull)]
+        let ws = wsDualHead s1 s2 floats
+        context "Ambiguity(Never)" $ do
+            let amb = NB.Never
+            it "removes border on current screen" $ do
+                NB.hiddens amb ws r1 s1 [] `shouldBe` [1]
+                NB.hiddens amb ws r3 s1 [] `shouldBe` [1]
+            it "removes border on visible screen" $ do
+                NB.hiddens amb ws r2 s2 [] `shouldBe` [2]
+                NB.hiddens amb ws r4 s2 [] `shouldBe` [2]
+        context "Ambiguity(OnlyScreenFloat)" $ do
+            let amb = NB.OnlyScreenFloat
+            it "removes border on current screen" $ do
+                NB.hiddens amb ws r1 s1 [] `shouldBe` [1]
+                NB.hiddens amb ws r3 s1 [] `shouldBe` [1]
+            it "removes border on visible screen" $ do
+                NB.hiddens amb ws r2 s2 [] `shouldBe` [2]
+                NB.hiddens amb ws r4 s2 [] `shouldBe` [2]
+        context "Ambiguity(OnlyLayoutFloat)" $ do
+            let amb = NB.OnlyLayoutFloat
+            it "removes border on current screen" $ do
+                NB.hiddens amb ws r1 s1 [] `shouldBe` [1]
+            it "removes border on visible screen" $ do
+                NB.hiddens amb ws r2 s2 [] `shouldBe` [2]
+
+-- +------+------+
+-- |  r1  |  r2  |
+-- |      |      |
+-- |+----+|+----+|
+-- || r3 ||| r4 ||
+-- |+----+|+----+|
+-- +------+------+
+r1, r2, r3, r4 :: Rectangle
+r1 = Rectangle   0  0 100 100
+r2 = Rectangle 100  0 100 100
+r3 = Rectangle  10 10  80  80
+r4 = Rectangle 110 10  80  80
+
+rrFull :: RationalRect
+rrFull = RationalRect 0 0 1 1
+
+-- | Current screen @r1@ with window stack @w1@,
+-- visible screen @r2@ with ws @w2@,
+-- no hidden screens, maybe some floats.
+wsDualHead :: Maybe (Stack Window) -> Maybe (Stack Window)
+           -> [(Window, RationalRect)] -> WindowSet
+wsDualHead w1 w2 f = StackSet{..}
+    where
+        current = mkScreen 1 r1 w1; visible = [mkScreen 2 r2 w2]; hidden = []
+        floating = M.fromList f
+
+mkScreen :: ScreenId -> Rectangle -> Maybe (Stack Window)
+         -> Screen WorkspaceId l Window ScreenId ScreenDetail
+mkScreen i r s = Screen{ workspace = w, screen = i, screenDetail = sd }
+    where
+        w = Workspace{ tag = show i, layout = undefined, stack = s }
+        sd = SD{ screenRect = r }

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -366,6 +366,7 @@ test-suite tests
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   other-modules:  ManageDocks
+                  NoBorders
                   RotateSome
                   Selective
                   SwapWorkspaces
@@ -382,6 +383,7 @@ test-suite tests
                   XMonad.Hooks.WorkspaceHistory
                   XMonad.Layout.LayoutModifier
                   XMonad.Layout.LimitWindows
+                  XMonad.Layout.NoBorders
                   XMonad.Prompt
                   XMonad.Prompt.Shell
                   XMonad.Util.ExtensibleState


### PR DESCRIPTION
### Description

Before c6cdb77e3b3d6a3842b914a0cf64357f03fcf0c1, handling of floats was trivial (too trivial, and thus inefficient and flickery): any float whose rectangle covered (RationalRect 0 0 1 1), regardless of what screen or workspace it belonged to, got its borders hidden.

Then c6cdb77e3b3d6a3842b914a0cf64357f03fcf0c1 added some nuance (OnlyLayoutFloatBelow, OnlyLayoutFloat, OnlyScreenFloat) which requires looking at floats in the context of individual screens. Unfortunately the implementation only worked in singlehead setups, as it always used only the active screen/workspace regardless of which screen/workspace was currently being layouted. This resulted in the new functionality not working correctly on inactive screens and also regressed the handling of fullscreen floats on inactive screens.

The fix is conceptually easy: use the screen that is being layouted.

There is a catch, unfortunately: this code runs in redoLayout, but the information we need is only available in modifyLayout and modifyLayoutWithUpdate. I could store a screen id in the ConfigurableBorder record in modifyLayoutWithUpdate and use it later in redoLayout, but that'd be a massive hack, so what I do instead is to find the relevant screen by searching for one that covers the `lr` (layout/screen rectangle). In most setups, this should be reliable. If it turns out it is not, we can fix this later.

Fixes: c6cdb77e3b3d ("'XMonad.Layout.NoBorders': various improvements:") 
Fixes: https://github.com/xmonad/xmonad-contrib/issues/280

### Also

#### X.L.NoBorders: Fix docs of data Ambiguity

In c6cdb77e3b3d6a3842b914a0cf64357f03fcf0c1, several new constructors were added but not "In order of increasing ambiguity (less borders more frequently)" as the docs for data Ambiguity say. Correct the order and clarify that Never only considers ambiguity of tiled windows (as in the doc for smartBorders).

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - (n/a) I updated the `XMonad.Doc.Extending` file (if appropriate)