### PR TITLE
X.Prompt: Correctly Update History with alwaysHighlight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -356,10 +356,13 @@
 
     - Added `filterOutWs` for workspace filtering.
 
-  * `XMonad.Prompt
+  * `XMonad.Prompt`
 
     - Accommodate completion of multiple words even when `alwaysHighlight` is
       enabled.
+
+    - Made the history respect words that were "completed" by `alwaysHighlight`
+      upon confirmation of the selection by the user.
 
 ## 0.16
 


### PR DESCRIPTION
### Description

So far, when `alwaysHighlight` was enabled and the user selected an item
while not having completely written it out in the prompt, the raw input
string and not the eventual completion string would be entered into the
prompt history, which is obviously not the desired behaviour.  This can
cause the history to clutter up with all these abbreviations, making
subsequent invocations of the prompt tedious to work with.

For example, an input of "xm" would narrow to both "xmonad" and
"xmobar", but thanks to `alwaysHighlight` "xmobar" was selected.  If the
user now pressed enter, the prompt would correctly return "xmobar" as
the string to act upon, but "xm" would be entered into the prompt
history!

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
