### PR TITLE
Refactor X.H.DynamicLog and multiple loggers support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -215,6 +215,12 @@
 
     - Add the -dock argument to the dzen spawn arguments
 
+    - Added `StatusBarConfig` and `makeStatusBar` and `makeStatusBar'` as
+      an abstraction for status bars; together with `statusBarPropConfig`,
+      `statusBarPropToConfig`, `statusBarHandleConfig` and `statusBarHandleConfig'`
+      to provide the configs for the already existing functionality. This provides
+      multiple status bars support.
+
   * `XMonad.Layout.BoringWindows`
 
     - Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.


### PR DESCRIPTION
### Description

This was kinda a big one: 
- I added the datatype `StatusBarConfig` which serves as an abstraction over status bar: 
  - how to start a status bar, 
  - how to log to the status bar,
  - what to do with the status bar on restart,
  - which key to toggle the struts
  - how to toggle the struts
  
   With that, users could have more flexibility on the status bars without having to do the plumbing from scratch. I also made sure the public API does not change. It may be interesting to refactor `X.H.DynamicBars` to also use that abstraction since it offers a nice set of features but I don't recall seeing it used anywhere.

- Added support for multiple status bars, which can be implemented quite naturally given the abstraction provided.

Let me know what you think or if anything needs a second thought! I tried to write examples in the documentation, but tell me if anything needs a rewrite or more clarification
 
### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
