### PR TITLE
Control.Exception.Extensible -> Control.Exception

### DIFF
--- a/XMonad/Hooks/DebugEvents.hs
+++ b/XMonad/Hooks/DebugEvents.hs
@@ -30,7 +30,7 @@ import           XMonad.Util.DebugWindow                     (debugWindow)
 
 -- import           Graphics.X11.Xlib.Extras.GetAtomName        (getAtomName)
 
-import           Control.Exception.Extensible         as E
+import           Control.Exception                    as E
 import           Control.Monad.State
 import           Control.Monad.Reader
 import           Data.Char                                   (isDigit)

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -100,7 +100,7 @@ import           XMonad.Util.XSelection       (getSelection)
 import           Codec.Binary.UTF8.String     (decodeString,isUTF8Encoded)
 import           Control.Arrow                (first, second, (&&&), (***))
 import           Control.Concurrent           (threadDelay)
-import           Control.Exception.Extensible as E hiding (handle)
+import           Control.Exception            as E hiding (handle)
 import           Control.Monad.State
 import           Data.Bits
 import           Data.Char                    (isSpace)

--- a/XMonad/Prompt/AppendFile.hs
+++ b/XMonad/Prompt/AppendFile.hs
@@ -31,7 +31,7 @@ import XMonad.Core
 import XMonad.Prompt
 
 import System.IO
-import Control.Exception.Extensible (bracket)
+import Control.Exception (bracket)
 
 -- $usage
 --

--- a/XMonad/Prompt/Man.hs
+++ b/XMonad/Prompt/Man.hs
@@ -33,7 +33,7 @@ import System.Directory
 import System.Process
 import System.IO
 
-import qualified Control.Exception.Extensible as E
+import qualified Control.Exception as E
 import Control.Monad
 import Data.List
 import Data.Maybe

--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -20,7 +20,7 @@ import           Prelude
 import           XMonad
 
 import           Codec.Binary.UTF8.String        (decodeString)
-import           Control.Exception.Extensible                          as E
+import           Control.Exception                                     as E
 import           Control.Monad                   (when)
 import           Data.List                       (unfoldr
                                                  ,intercalate

--- a/XMonad/Util/NamedWindows.hs
+++ b/XMonad/Util/NamedWindows.hs
@@ -23,7 +23,7 @@ module XMonad.Util.NamedWindows (
                                    unName
                                   ) where
 
-import Control.Exception.Extensible as E
+import Control.Exception as E
 import Data.Maybe ( fromMaybe, listToMaybe )
 
 import qualified XMonad.StackSet as W ( peek )

--- a/XMonad/Util/XSelection.hs
+++ b/XMonad/Util/XSelection.hs
@@ -22,7 +22,7 @@ module XMonad.Util.XSelection (  -- * Usage
                                  transformPromptSelection,
                                  transformSafePromptSelection) where
 
-import Control.Exception.Extensible as E (catch,SomeException(..))
+import Control.Exception as E (catch,SomeException(..))
 import Data.Maybe (fromMaybe)
 import XMonad
 import XMonad.Util.Run (safeSpawn, unsafeSpawn)

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -51,7 +51,6 @@ library
                    bytestring >= 0.10 && < 0.11,
                    containers >= 0.5 && < 0.7,
                    directory,
-                   extensible-exceptions,
                    filepath,
                    old-locale,
                    old-time,
@@ -377,7 +376,6 @@ test-suite properties
   build-depends: base
                , QuickCheck >= 2
                , containers
-               , extensible-exceptions
                , xmonad-contrib
                , directory
                , X11>=1.6.1 && < 1.10


### PR DESCRIPTION
### Description

According to its documentation[1], this module simply re-exports
Control.Exception on recent GHC versions.  As we only support recent
versions, this import is unnecessary.

[1] http://hackage.haskell.org/package/extensible-exceptions-0.1.1.4/docs/Control-Exception-Extensible.html

This should probably be merged in conjunction with xmonad/xmonad/pull/263

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~
  Not needed, we've already dropped support for compilers this old.

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
