### PR TITLE
Grab the Pointer in X.Prompt and X.A.TreeSelect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -368,6 +368,16 @@
     - Made the history respect words that were "completed" by `alwaysHighlight`
       upon confirmation of the selection by the user.
 
+    - Fixed a crash when focusing a new window while the prompt was up
+      by allowing pointer events to pass through the custom prompt event
+      loop.
+
+  * `XMonad.Actions.TreeSelect`
+
+    - Fixed a crash when focusing a new window while the tree select
+      window was up by allowing pointer events to pass through the
+      custom tree select event loop.
+
 ## 0.16
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Closes #445 
Closes xmonad/xmonad/issues/116

I don't know how "proper" this fix is and I don't have the X11 knowledge to know if there's something more elegant to be done, but simply grabbing the pointer as well causes both the prompt and the tree select window to behave normally when one wants to focus another window.

Config to reproduce the bug and check if the fix actually works:

``` haskell
import Data.Tree (Forest, Tree (Node))

import XMonad
import XMonad.Actions.TreeSelect (toWorkspaces, treeselectWorkspace)
import XMonad.Prompt (XPConfig (font))
import XMonad.Prompt.Shell (shellPrompt)
import XMonad.Util.EZConfig (additionalKeysP)

import qualified XMonad.StackSet as W


main :: IO ()
main = xmonad $ def{ clickJustFocuses = False
                   , workspaces       = toWorkspaces myWorkspaces
                   }
  `additionalKeysP`
    [ ("M-p", shellPrompt def{font = "xft:size=11"})
    , ("M-f", treeselectWorkspace def myWorkspaces W.greedyView)
    ]

myWorkspaces :: Forest String
myWorkspaces = [Node "Browser" [], Node "Home" [Node "1" []]]
```

Steps to reproduce:

1. Open the prompt or the treeselect window
 
2. Click or double click in another application (note that for TreeSelect you need a second monitor and try to click on something there (at least that's the only way I managed to reproduce it))
 
3. The X server now stops responding to input, making it appear that xmonad froze

@crocket @fvhockney @bitdizzy @de-vri-es I'm highlighting you because you took an interesting in the original issue.  If you still care about this, it would be most appeciated if you could test this fix!

TODO: 

  - [x] I updated the `CHANGES.md` file

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
