### PR TITLE
More loggers: A `maybe`-like combinator, and screen-specific loggers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -304,6 +304,12 @@
 
   * `XMonad.Util.Loggers`
     - Make `battery` and `loadAvg` distro-independent.
+    - Added `logTitleOnScreen`, `logCurrentOnScreen` and `logLayoutOnScreen`
+      as screen-specific variants of `logTitle`, `logCurrent` and `logLayout`.
+    - Added `logWhenActive` to have loggers active only when a certain
+      screen is active.
+    - Added `logConst` to log a constant `String`, and `logDefault` (infix: `.|`)
+      to combine loggers.
 
   * `XMonad.Hooks.DynamicLog`
     - Added `xmobarBorder` function to create borders around strings.


### PR DESCRIPTION
### Description

I added some more loggers:
- For multi-monitor setups:
  - `logWhenActive` to have loggers active only when a certain screen is active.
  - `logTitleOnScreen`, `logLayoutOnScreen` and `logCurrentOnScreen` as screen-specific versions of `logTitle`, `logLayout` and `logCurrent`
- A "combinator": `logMaybe` which works like `maybe` (and an infix version for it `(.|) `
- `logConst` to log a constant `String` (I find that it feels better than writing `return . Just` repeatedly, but I didn't change it in the file... maybe see first what people feel about it?)
- Minor cleanups (documentation fix, one `hlint` suggestion)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
