### PR TITLE
Remove last occurences of non Data.Default defaults

### DIFF
--- a/XMonad/Actions/Prefix.hs
+++ b/XMonad/Actions/Prefix.hs
@@ -94,12 +94,12 @@ grab" and let the C-c C-u be sent to the application.
 
 The simplest way to enable this is to use 'useDefaultPrefixArgument'
 
->    xmonad $ useDefaultPrefixArgument $ defaultConfig { .. }
+>    xmonad $ useDefaultPrefixArgument $ def { .. }
 
 The default prefix argument is C-u.  If you want to customize the
 prefix argument, use the following:
 
->    xmonad $ usePrefixArgument prefixKey $ defaultConfig { .. }
+>    xmonad $ usePrefixArgument prefixKey $ def { .. }
 
 where 'prefixKey' is a function which takes 'XConfig' as an argument
 in case you wish to extract the 'modMask'.  An example

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -40,6 +40,7 @@ module XMonad.Actions.TreeSelect
 
     , TSConfig(..)
     , tsDefaultConfig
+    , def
 
       -- * Navigation
       -- $navigation
@@ -113,10 +114,10 @@ import Graphics.X11.Xrender
 --
 -- Optionally, if you add 'workspaceHistoryHook' to your 'logHook' you can use the \'o\' and \'i\' keys to select from previously-visited workspaces
 --
--- > xmonad $ defaultConfig { ...
--- >                        , workspaces = toWorkspaces myWorkspaces
--- >                        , logHook = workspaceHistoryHook
--- >                        }
+-- > xmonad $ def { ...
+-- >              , workspaces = toWorkspaces myWorkspaces
+-- >              , logHook = workspaceHistoryHook
+-- >              }
 --
 -- After that you still need to bind buttons to 'treeselectWorkspace' to start selecting a workspaces and moving windows
 --
@@ -131,22 +132,22 @@ import Graphics.X11.Xrender
 -- $config
 -- The selection menu is very configurable, you can change the font, all colors and the sizes of the boxes.
 --
--- The default config defined as 'tsDefaultConfig'
+-- The default config defined as 'def'
 --
--- > tsDefaultConfig = TSConfig { ts_hidechildren = True
--- >                            , ts_background   = 0xc0c0c0c0
--- >                            , ts_font         = "xft:Sans-16"
--- >                            , ts_node         = (0xff000000, 0xff50d0db)
--- >                            , ts_nodealt      = (0xff000000, 0xff10b8d6)
--- >                            , ts_highlight    = (0xffffffff, 0xffff0000)
--- >                            , ts_extra        = 0xff000000
--- >                            , ts_node_width   = 200
--- >                            , ts_node_height  = 30
--- >                            , ts_originX      = 0
--- >                            , ts_originY      = 0
--- >                            , ts_indent       = 80
--- >                            , ts_navigate     = defaultNavigation
--- >                            }
+-- > def = TSConfig { ts_hidechildren = True
+-- >                , ts_background   = 0xc0c0c0c0
+-- >                , ts_font         = "xft:Sans-16"
+-- >                , ts_node         = (0xff000000, 0xff50d0db)
+-- >                , ts_nodealt      = (0xff000000, 0xff10b8d6)
+-- >                , ts_highlight    = (0xffffffff, 0xffff0000)
+-- >                , ts_extra        = 0xff000000
+-- >                , ts_node_width   = 200
+-- >                , ts_node_height  = 30
+-- >                , ts_originX      = 0
+-- >                , ts_originY      = 0
+-- >                , ts_indent       = 80
+-- >                , ts_navigate     = defaultNavigation
+-- >                }
 
 -- $pixel
 --
@@ -258,6 +259,7 @@ defaultNavigation = M.fromList
 -- Using nice alternating blue nodes
 tsDefaultConfig :: TSConfig a
 tsDefaultConfig = def
+{-# DEPRECATED tsDefaultConfig "Use def (from Data.Default, and re-exported by XMonad.Actions.TreeSelect) instead." #-}
 
 -- | Tree Node With a name and extra text
 data TSNode a = TSNode { tsn_name  :: String

--- a/XMonad/Hooks/UrgencyHook.hs
+++ b/XMonad/Hooks/UrgencyHook.hs
@@ -533,7 +533,7 @@ instance UrgencyHook StdoutUrgencyHook where
 --
 -- Useful for scratchpad workspaces perhaps:
 --
--- > main = xmonad (withUrgencyHook (filterUrgencyHook ["NSP", "SP"]) defaultConfig)
+-- > main = xmonad (withUrgencyHook (filterUrgencyHook ["NSP", "SP"]) def)
 filterUrgencyHook :: [WorkspaceId] -> Window -> X ()
 filterUrgencyHook skips w = do
     ws <- gets windowset

--- a/XMonad/Hooks/WallpaperSetter.hs
+++ b/XMonad/Hooks/WallpaperSetter.hs
@@ -53,7 +53,7 @@ import Data.Maybe
 --
 -- > myWorkspaces = ["1:main","2:misc","3","4"]
 -- > ...
--- > main = xmonad $ defaultConfig {
+-- > main = xmonad $ def {
 -- >   logHook = wallpaperSetter defWallpaperConf {
 -- >                                wallpapers = defWPNames myWorkspaces
 -- >                                          <> WallpaperList [("1:main",WallpaperDir "1")]

--- a/XMonad/Layout/Fullscreen.hs
+++ b/XMonad/Layout/Fullscreen.hs
@@ -72,7 +72,7 @@ import           Control.Arrow                  (second)
 --
 -- > main = xmonad
 -- >      $ fullscreenSupport
--- >      $ defaultConfig { ... }
+-- >      $ def { ... }
 fullscreenSupport :: LayoutClass l Window =>
   XConfig l -> XConfig (ModifiedLayout FullscreenFull l)
 fullscreenSupport c = c {

--- a/XMonad/Util/SpawnNamedPipe.hs
+++ b/XMonad/Util/SpawnNamedPipe.hs
@@ -3,7 +3,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Util.SpawnNamedPipe
--- Copyright   :  (c) Christian Wills 2014 
+-- Copyright   :  (c) Christian Wills 2014
 -- License     :  BSD3-style (see LICENSE)
 --
 -- Maintainer  :  cwills.dev@gmail.com
@@ -35,10 +35,10 @@ import qualified Data.Map as Map
 --
 -- > import XMonad.Util.SpawnNamedPipe
 -- > import Data.Maybe
--- > 
+-- >
 -- > -- StartupHook
--- > startupHook' = spawnNamedPipe "dzen2" "dzenPipe" 
--- > 
+-- > startupHook' = spawnNamedPipe "dzen2" "dzenPipe"
+-- >
 -- > -- LogHook
 -- > logHook' = do
 -- >     mh <- getNamedPipeHandle "dzenPipe"
@@ -46,31 +46,30 @@ import qualified Data.Map as Map
 -- >             ppOutput = maybe (\s -> return ()) (hPutStrLn) mh}
 -- >
 -- > -- Main
--- > main = xmonad $ defaultConfig {
--- >                      startupHook = startupHook'
--- >                    , logHook = logHook'}
+-- > main = xmonad $ def { startupHook = startupHook'
+-- >                     , logHook = logHook'}
 --
 
 data NamedPipes = NamedPipes { pipeMap :: Map.Map String Handle }
     deriving (Show, Typeable)
 
 instance ExtensionClass NamedPipes where
-    initialValue = NamedPipes Map.empty 
+    initialValue = NamedPipes Map.empty
 
 -- | When 'spawnNamedPipe' is executed with a command "String" and a name
 -- "String" respectively.  The command string is spawned with 'spawnPipe' (as
 -- long as the name chosen hasn't been used already) and the "Handle" returned
--- is saved in Xmonad's state associated with the name "String". 
+-- is saved in Xmonad's state associated with the name "String".
 spawnNamedPipe :: String -> String -> X ()
 spawnNamedPipe cmd name = do
-  b <- XS.gets (Map.member name . pipeMap) 
+  b <- XS.gets (Map.member name . pipeMap)
   unless b $ do
-    h <- spawnPipe cmd 
-    XS.modify (NamedPipes . Map.insert name h . pipeMap)   
+    h <- spawnPipe cmd
+    XS.modify (NamedPipes . Map.insert name h . pipeMap)
 
 -- | Attempts to retrieve a "Handle" to a pipe previously stored in Xmonad's
 -- state associated with the given string via a call to 'spawnNamedPipe'. If the
 -- given string doesn't exist in the map stored in Xmonad's state Nothing is
--- returned.   
+-- returned.
 getNamedPipe :: String -> X (Maybe Handle)
 getNamedPipe name = XS.gets (Map.lookup name . pipeMap)


### PR DESCRIPTION
### Description

1. Remove mentions of `defaultConfig`, as this was removed in favour of `def` a while ago.
2. Deprecate `X.A.TreeSelect.tsDefaultConfig` in favour of `def`, as this was apparently forgotten.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~
  This didn't happen with other `Data.Default` deprecations, so I don't think it's necessary in this case either.

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
