### PR TITLE
X.Prompt: Correct tab completion handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -386,6 +386,9 @@
       by allowing pointer events to pass through the custom prompt event
       loop.
 
+    - The prompt now cycles through its suggestions if one hits the ends
+      of the suggestion list and presses `TAB` again.
+
   * `XMonad.Actions.TreeSelect`
 
     - Fixed a crash when focusing a new window while the tree select

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -107,7 +107,7 @@ import           Data.Char                    (isSpace)
 import           Data.IORef
 import           Data.List
 import qualified Data.Map                     as M
-import           Data.Maybe                   (fromMaybe)
+import           Data.Maybe                   (fromMaybe, listToMaybe)
 import           Data.Set                     (fromList, toList)
 import           System.IO
 import           System.IO.Unsafe             (unsafePerformIO)
@@ -397,10 +397,14 @@ highlightedItem st' completions = case complWinDim st' of
     let
       (_,_,_,_,xx,yy) = winDim
       complMatrix = splitInSubListsAt (length yy) (take (length xx * length yy) completions)
-      (col_index,row_index) = (complIndex st')
+      (col_index,row_index) = complIndex st'
     in case completions of
       [] -> Nothing
-      _ -> Just $ complMatrix !! col_index !! row_index
+      _  -> complMatrix !? col_index >>= (!? row_index)
+ where
+  -- | Safe version of '(!!)'.
+  (!?) :: [a] -> Int -> Maybe a
+  (!?) xs n = listToMaybe $ drop n xs
 
 -- | Return the selected completion, i.e. the 'String' we actually act
 -- upon after the user confirmed their selection (by pressing @Enter@).


### PR DESCRIPTION
### Description

Closes #455

526336e introduced a bug where tab-completion has an issue when a
completion contains spaces; it only deletes the last word of that
completion, causing the next TAB to again select the current selection
and add it to the command.  In this way, the prompt can get "stuck" on
an item, endlessly adding all but the first word to the command every
time TAB is pressed.

This is fixed in a (hopefully) acceptable way @sam-barr can you confirm?

1. Also changes the indexing inside `highlightedItem` to a safe index;
   this way one is able to cycle through the suggestions for the prompt
   (before, the prompt would close due to an exception from `(!!)`).
   
3. Applies most of the (sane) hlint suggestions to `XMonad.Prompt`,
   because they bothered me when working on this.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
