### PR TITLE
X.H.RescreenHook: New module (custom rescreen and randr event hooks)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -250,6 +250,13 @@
     This lets them create custom hooks, ensure they hook into xmonad core only
     once, and possibly more.
 
+  * `XMonad.Hooks.Rescreen`
+
+    Custom hooks for screen (xrandr) configuration changes. These can be used
+    to restart/reposition status bars or systrays automatically after xrandr,
+    as well as to actually invoke xrandr or autorandr when an output is
+    (dis)connected.
+
 ### Bug Fixes and Minor Changes
 
   * Add support for GHC 9.0.1.

--- a/XMonad/Doc/Extending.hs
+++ b/XMonad/Doc/Extending.hs
@@ -543,6 +543,12 @@ Here is a list of the modules found in @XMonad.Hooks@:
     even if it was opened in a tiled layout initially. The EventHook makes sure
     that windows are deleted from the PositionStore when they are closed.
 
+* "XMonad.Hooks.Rescreen":
+    Custom hooks for screen (xrandr) configuration changes. These can be used
+    to restart/reposition status bars or systrays automatically after xrandr,
+    as well as to actually invoke xrandr or autorandr when an output is
+    (dis)connected.
+
 * "XMonad.Hooks.RestoreMinimized":
     (Deprecated: Use XMonad.Hooks.Minimize) Lets you restore minimized
     windows (see "XMonad.Layout.Minimize") by selecting them on a

--- a/XMonad/Hooks/Rescreen.hs
+++ b/XMonad/Hooks/Rescreen.hs
@@ -90,7 +90,9 @@ instance Monoid RescreenConfig where
 -- Note that 'rescreenHook' is safe to use several times, 'rescreen' is still
 -- done just once and hooks are invoked in sequence, also just once.
 rescreenHook :: RescreenConfig -> XConfig a -> XConfig a
-rescreenHook = flip XC.once rescreenHook'
+rescreenHook = XC.once $ \c -> c
+    { startupHook = startupHook c <> rescreenStartupHook
+    , handleEventHook = handleEventHook c <> rescreenEventHook }
 
 -- | Shortcut for 'rescreenHook'.
 addAfterRescreenHook :: X () -> XConfig a -> XConfig a
@@ -99,10 +101,6 @@ addAfterRescreenHook h = rescreenHook def{ afterRescreenHook = h }
 -- | Shortcut for 'rescreenHook'.
 addRandrChangeHook :: X () -> XConfig a -> XConfig a
 addRandrChangeHook h = rescreenHook def{ randrChangeHook = h }
-
-rescreenHook' :: XConfig a -> XConfig a
-rescreenHook' c = c{ startupHook = startupHook c <> rescreenStartupHook
-                   , handleEventHook = handleEventHook c <> rescreenEventHook }
 
 -- | Startup hook to listen for @RRScreenChangeNotify@ events.
 rescreenStartupHook :: X ()

--- a/XMonad/Hooks/Rescreen.hs
+++ b/XMonad/Hooks/Rescreen.hs
@@ -1,0 +1,73 @@
+-- |
+-- Module      :  XMonad.Hooks.Rescreen
+-- Copyright   :  (c) 2021 Tomáš Janoušek <tomi@nomi.cz>
+-- License     :  BSD3
+-- Maintainer  :  Tomáš Janoušek <tomi@nomi.cz>
+--
+-- Custom hooks for screen (xrandr) configuration changes.
+--
+module XMonad.Hooks.Rescreen (
+    -- * Usage
+    -- $usage
+    rescreenHook,
+    rescreenEventHook,
+    ) where
+
+import Control.Monad.Fix (fix)
+import Control.Monad (when)
+import Data.Monoid (All(..))
+
+import XMonad
+
+-- $usage
+-- This module provides a replacement for the screen configuration change
+-- handling in core that enables attaching a custom hook that can
+-- restart/reposition status bars or systray.
+--
+-- You can use it by including the following in your @~\/.xmonad\/xmonad.hs@:
+--
+-- > import XMonad.Hooks.RescreenHook
+--
+-- defining your custom rescreen hook:
+--
+-- > myRescreenHook :: X ()
+-- > myRescreenHook = …
+--
+-- and adding 'rescreenHook' to your 'xmonad' config:
+--
+-- > main = xmonad $ … . rescreenHook myRescreenHook . … $ def{…}
+
+-- | Attach a custom hook when the screen configuration changes (due to
+-- xrandr). Replaces the built-in rescreen handling of xmonad core with:
+--
+-- 1. suppress duplicate change events
+-- 2. 'rescreen'
+-- 3. invoke specified hook
+--
+-- Useful for restarting/repositioning status bars and systray.
+rescreenHook :: X () -> XConfig a -> XConfig a
+rescreenHook hook xConfig =
+    xConfig{ handleEventHook = handleEventHook xConfig <> rescreenEventHook hook }
+
+-- | Event hook with custom rescreen hook. See 'rescreenHook' for more.
+rescreenEventHook :: X () -> Event -> X All
+rescreenEventHook hook ConfigureEvent{ev_event_type = t, ev_window = w} = do
+    isRescreen <- isRoot w
+    if isRescreen
+        then do
+            -- Xorg emits several ConfigureEvents after every change,
+            -- clear them to prevent triggering the hook multiple times
+            clearTypedWindowEvents w t
+            rescreen
+            hook
+            return (All False)
+        else mempty
+rescreenEventHook _ _ = mempty
+
+-- | Remove all X events of a given window and type from the event queue.
+clearTypedWindowEvents :: Window -> EventType -> X ()
+clearTypedWindowEvents w t = withDisplay $ \d -> io $ do
+    sync d False
+    allocaXEvent $ \e -> fix $ \again -> do
+        more <- checkTypedWindowEvent d w t e
+        when more again

--- a/XMonad/Hooks/StatusBar.hs
+++ b/XMonad/Hooks/StatusBar.hs
@@ -74,10 +74,9 @@ import qualified XMonad.Util.ExtensibleState as XS
 
 import XMonad.Layout.LayoutModifier
 import XMonad.Hooks.ManageDocks
+import XMonad.Hooks.Rescreen
 import XMonad.Hooks.StatusBar.PP
 import qualified XMonad.StackSet as W
-
-import Graphics.X11.Xrandr (xrrSelectInput)
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
@@ -342,7 +341,7 @@ statusBarPipe cmd xpp = do
 -- >
 -- > main = xmonad $ withSB (xmobarTop <> xmobarBottom <> xmobar1) myConfig
 --
--- And here is an example of the related xmobar configuration for the multiple 
+-- And here is an example of the related xmobar configuration for the multiple
 -- status bars mentioned above:
 --
 -- > xmobarrc_top
@@ -422,13 +421,9 @@ instance ExtensionClass ActiveSBs where
 --
 -- Heavily inspired by "XMonad.Hooks.DynamicBars"
 dynamicSBs :: (ScreenId -> IO StatusBarConfig) -> XConfig l -> XConfig l
-dynamicSBs f conf = conf
-  { startupHook     = startupHook conf
-                      >> setupEventHandler
-                      >> killAllStatusBars
-                      >> updateSBs f
-  , logHook         = logHook conf >> logSBs
-  , handleEventHook = eventHookSBs f <> handleEventHook conf
+dynamicSBs f conf = addAfterRescreenHook (updateSBs f) $ conf
+  { startupHook = startupHook conf >> killAllStatusBars >> updateSBs f
+  , logHook     = logHook conf >> logSBs
   }
 
 -- | Like 'dynamicSBs', but applies 'docks' to the
@@ -457,22 +452,9 @@ updateSBs f = do
   traverse_ (sbStartupHook . snd) added
   XS.put (ASB (toKeep ++ added))
 
--- | Handles 'RRScreenChangeNotifyEvent' by updating the
--- status bars.
-eventHookSBs :: (ScreenId -> IO StatusBarConfig) -> Event -> X All
-eventHookSBs f RRScreenChangeNotifyEvent{} = updateSBs f >> return (All True)
-eventHookSBs _ _                           = return (All True)
-
 -- | Run 'sbLogHook' for the saved 'StatusBarConfig's
 logSBs :: X ()
 logSBs = XS.get >>= traverse_ (sbLogHook . snd) . getASBs
-
--- | Subscribe to the 'RRScreenChangeNotifyEvent'
-setupEventHandler :: X ()
-setupEventHandler = do
-  dpy  <- asks display
-  root <- asks theRoot
-  io $ xrrSelectInput dpy root rrScreenChangeNotifyMask
 
 -- | Kill the given 'StatusBarConfig's from the given
 -- list

--- a/XMonad/Util/ExtensibleConf.hs
+++ b/XMonad/Util/ExtensibleConf.hs
@@ -113,16 +113,16 @@ add x = alter (<> Just x)
 -- This can be used to implement a composable interface for modules that must
 -- only hook into xmonad core once.
 once :: forall a l. (Semigroup a, Typeable a)
-     => a -- ^ configuration to add
-     -> (XConfig l -> XConfig l) -- ^ 'XConfig' modification done only once
+     => (XConfig l -> XConfig l) -- ^ 'XConfig' modification done only once
+     -> a -- ^ configuration to add
      -> XConfig l -> XConfig l
-once x f c = add x $ maybe f (const id) (lookup @a c) c
+once f x c = add x $ maybe f (const id) (lookup @a c) c
 
 -- | Config-time: Applicative (monadic) variant of 'once', useful if the
 -- 'XConfig' modification needs to do some 'IO' (e.g. create an
 -- 'Data.IORef.IORef').
 onceM :: forall a l m. (Applicative m, Semigroup a, Typeable a)
-      => a -- ^ configuration to add
-      -> (XConfig l -> m (XConfig l)) -- ^ 'XConfig' modification done only once
+      => (XConfig l -> m (XConfig l)) -- ^ 'XConfig' modification done only once
+      -> a -- ^ configuration to add
       -> XConfig l -> m (XConfig l)
-onceM x f c = add x <$> maybe f (const pure) (lookup @a c) c
+onceM f x c = add x <$> maybe f (const pure) (lookup @a c) c

--- a/tests/ExtensibleConf.hs
+++ b/tests/ExtensibleConf.hs
@@ -22,9 +22,9 @@ spec = do
         XC.lookup (XC.add "a" (XC.add [1 :: Int] def)) `shouldBe` (Nothing :: Maybe ())
 
     specify "once" $
-        borderWidth (XC.once "a" incBorderWidth def) `shouldBe` succ (borderWidth def)
+        borderWidth (XC.once incBorderWidth "a" def) `shouldBe` succ (borderWidth def)
     specify "once . once" $
-        borderWidth (XC.once "b" incBorderWidth (XC.once "a" incBorderWidth def))
+        borderWidth (XC.once incBorderWidth "b" (XC.once incBorderWidth "a" def))
             `shouldBe` succ (borderWidth def)
 
 incBorderWidth :: XConfig l -> XConfig l

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -184,6 +184,7 @@ library
                         XMonad.Hooks.Place
                         XMonad.Hooks.PositionStoreHooks
                         XMonad.Hooks.RefocusLast
+                        XMonad.Hooks.Rescreen
                         XMonad.Hooks.RestoreMinimized
                         XMonad.Hooks.ScreenCorners
                         XMonad.Hooks.Script


### PR DESCRIPTION
### Description

Inspired by
https://github.com/fis/dot-xmonad/blob/a8c8e804873f8657fc1f1a0d93ee3f58f7a56e22/zem/src/Zem/AutoRandr.hs
and my own
https://github.com/liskin/dotfiles/blob/43999573d006311292a9fadde02f3b234140d999/.xmonad/xmonad.hs#L308-L339,
this adds a generic hook module that allows attaching a custom hook to
rescreen and randr screen change notify event, hiding the complexity of
suppressing duplicate events (debouncing) and distinguishing actual
xrandr configuration changes from output connects/disconnects.

### Commits

#### [Add X.H.RescreenHook module (custom rescreen hooks)](../commit/4f73366bd73902e827540217a369593d8a0c69a5)


#### [X.H.{EwmhDesktops,ManageDocks}: Improve the usage doc a bit](../commit/0610a3c5a064f967402051ffe94f8c289cf1ba36)

Don't assume ewmh/docks are the only xmonad config combinator out there.

#### [X.H.RescreenHook: Add randrHook](../commit/053233782a317cc05a26a8b11969ecf6b9108978)


#### [X.H.RescreenHook: Merge the two hooks together and improve their behaviour](../commit/d106ea24a98a5f5d9ad6d0d0ed5ed39db96cedae)

Now that randrChangeHook is only invoked for changes that don't result
in rescreen, it can actually be used for autorandr.

#### [Update CHANGES, X.D.Extending: add X.H.Rescreen](../commit/6fe20e2ca56ed678a3bbe58e71ff4150a5d3e513)


### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I updated the `CHANGES.md` file

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)