### PR TITLE
X.U.ClickableWorkspaces: Integrations with X.L.IndependentScreens and X.A.WorkspaceNames

### DIFF
--- a/XMonad/Actions/WorkspaceNames.hs
+++ b/XMonad/Actions/WorkspaceNames.hs
@@ -54,6 +54,7 @@ import XMonad.Prompt (mkXPrompt, XPConfig)
 import XMonad.Prompt.Workspace (Wor(Wor))
 import XMonad.Util.WorkspaceCompare (getSortByIndex)
 
+import Data.Functor ((<&>))
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import Data.List (isInfixOf)
@@ -146,6 +147,7 @@ workspaceNamesPP pp = do
             ppVisible         = ppVisible         pp . names,
             ppHidden          = ppHidden          pp . names,
             ppHiddenNoWindows = ppHiddenNoWindows pp . names,
+            ppVisibleNoWindows= ppVisibleNoWindows pp <&> (. names),
             ppUrgent          = ppUrgent          pp . names
         }
 

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -31,6 +31,7 @@ module XMonad.Layout.IndependentScreens (
 -- for the screen stuff
 import Control.Applicative(liftA2)
 import Control.Arrow hiding ((|||))
+import Data.Functor ((<&>))
 import Data.List (nub, genericLength)
 import Graphics.X11.Xinerama
 import XMonad
@@ -139,6 +140,7 @@ marshallPP s pp = pp {
     ppVisible           = ppVisible         pp . snd . unmarshall,
     ppHidden            = ppHidden          pp . snd . unmarshall,
     ppHiddenNoWindows   = ppHiddenNoWindows pp . snd . unmarshall,
+    ppVisibleNoWindows  = ppVisibleNoWindows pp <&> (. snd . unmarshall),
     ppUrgent            = ppUrgent          pp . snd . unmarshall,
     ppSort              = fmap (marshallSort s) (ppSort pp)
     }

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -100,7 +100,7 @@ unmarshallS = fst . unmarshall
 unmarshallW = snd . unmarshall
 
 workspaces' :: XConfig l -> [VirtualWorkspace]
-workspaces' = nub . map (snd . unmarshall) . workspaces
+workspaces' = nub . map unmarshallW . workspaces
 
 withScreens :: ScreenId            -- ^ The number of screens to make workspaces for
             -> [VirtualWorkspace]  -- ^ The desired virtual workspace names
@@ -136,12 +136,12 @@ countScreens = fmap genericLength . liftIO $ openDisplay "" >>= liftA2 (<*) getS
 -- >           in log 0 hLeft >> log 1 hRight
 marshallPP :: ScreenId -> PP -> PP
 marshallPP s pp = pp {
-    ppCurrent           = ppCurrent         pp . snd . unmarshall,
-    ppVisible           = ppVisible         pp . snd . unmarshall,
-    ppHidden            = ppHidden          pp . snd . unmarshall,
-    ppHiddenNoWindows   = ppHiddenNoWindows pp . snd . unmarshall,
-    ppVisibleNoWindows  = ppVisibleNoWindows pp <&> (. snd . unmarshall),
-    ppUrgent            = ppUrgent          pp . snd . unmarshall,
+    ppCurrent           = ppCurrent         pp . unmarshallW,
+    ppVisible           = ppVisible         pp . unmarshallW,
+    ppHidden            = ppHidden          pp . unmarshallW,
+    ppHiddenNoWindows   = ppHiddenNoWindows pp . unmarshallW,
+    ppVisibleNoWindows  = ppVisibleNoWindows pp <&> (. unmarshallW),
+    ppUrgent            = ppUrgent          pp . unmarshallW,
     ppSort              = fmap (marshallSort s) (ppSort pp)
     }
 

--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -46,11 +46,20 @@ import XMonad.Util.WorkspaceCompare (getWsIndex)
 --   * "XMonad.Hooks.EwmhDesktops" for @xdotool@ support (see Hackage docs for setup)
 --   * use of UnsafeStdinReader/UnsafeXMonadLog in xmobarrc (rather than StdinReader/XMonadLog)
 
-
+-- | Wrap string with an xmobar action that uses @xdotool@ to switch to
+-- workspace @i@.
 clickableWrap :: Int -> String -> String
 clickableWrap i ws = xmobarAction ("xdotool set_desktop " ++ show i) "1" $ xmobarRaw ws
 
--- | Use index of workspace in users config to target workspace with @xdotool@ switch.
+-- | Return a function that wraps workspace names in an xmobar action that
+-- switches to that workspace. That workspace name must be exactly as
+-- configured in 'XMonad.Core.workspaces', so this takes an additional
+-- parameter that allows renaming/marshalling of the name for display, which
+-- is applied after the workspace's index is looked up.
+--
+-- This additionally assumes that 'XMonad.Hooks.EwmhDesktops.ewmhDesktopsEventHook'
+-- isn't configured to change the workspace order. We might need to add an
+-- additional parameter if anyone needs that.
 getClickable :: (WorkspaceId -> String) -> X (WorkspaceId -> String)
 getClickable ren = do
   wsIndex <- getWsIndex

--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -28,19 +28,19 @@ import XMonad.Hooks.DynamicLog (xmobarAction, xmobarRaw, PP(..))
 -- $usage
 -- However you have set up your PP, apply @clickablePP@ to it, and bind the result
 -- to "XMonad.Hooks.DynamicLog"\'s dynamicLogWithPP like so:
--- 
+--
 -- > logHook = clickablePP xmobarPP { ... } >>= dynamicLogWithPP
 --
 -- * Requirements:
---   * wmctrl on system (in path)
---   * "XMonad.Hooks.EwmhDesktops" for wmctrl support (see Hackage docs for setup)
---   * use of UnsafeStdinReader in xmobarrc (rather than StdinReader)
+--   * @xdotool@ on system (in path)
+--   * "XMonad.Hooks.EwmhDesktops" for @xdotool@ support (see Hackage docs for setup)
+--   * use of UnsafeStdinReader/UnsafeXMonadLog in xmobarrc (rather than StdinReader/XMonadLog)
 
 
 clickableWrap :: Int -> String -> String
-clickableWrap i ws = xmobarAction ("wmctrl -s " ++ show i) "1" $ xmobarRaw ws
+clickableWrap i ws = xmobarAction ("xdotool set_desktop " ++ show i) "1" $ xmobarRaw ws
 
--- Use index of workspace in users config to target workspace with wmctrl switch.
+-- | Use index of workspace in users config to target workspace with @xdotool@ switch.
 getClickable :: X (WorkspaceId -> String)
 getClickable = do
   wsIndex <- getWsIndex

--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -27,6 +27,8 @@ module XMonad.Util.ClickableWorkspaces (
   clickableMarshallWorkspaceNamesPP
   ) where
 
+import Data.Functor ((<&>))
+
 import XMonad
 import XMonad.Actions.WorkspaceNames
 import XMonad.Hooks.DynamicLog (xmobarAction, xmobarRaw, PP(..))
@@ -72,6 +74,7 @@ clickableRenamedPP ren pp = do
        , ppVisible         = ppVisible pp . clickable
        , ppHidden          = ppHidden pp . clickable
        , ppHiddenNoWindows = ppHiddenNoWindows pp . clickable
+       , ppVisibleNoWindows= ppVisibleNoWindows pp <&> (. clickable)
        , ppUrgent          = ppUrgent pp . clickable
        }
 


### PR DESCRIPTION
### Description

Having these work together isn't entirely trivial (see my confusion in
https://github.com/xmonad/xmonad-contrib/pull/390) so let's provide the
integrations.

Also, switch from unmaintained wmctrl to xdotool (rationale in commit
msg).

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

    (I didn't, I think the entry for X.U.ClickableWorkspaces itself it sufficient.)

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)

    (I didn't, I think the entry for X.U.ClickableWorkspaces itself it sufficient.)