### PR TITLE
Added javaHack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,8 @@
     Serves as a collection of hacks and fixes that should be easily acessible to users.
     The first element of this module is windowedFullscreenFix, which fixes fullscreen behaviour
     of chromium based applications when using windowed fullscreen.
+    A second entry is `javaHack`, which helps when dealing with Java applications that might
+    not work well with xmonad.
 
   * `XMonad.Util.ActionCycle`
 


### PR DESCRIPTION
### Description
Fixes Java applications that don't work well with xmonad, by setting `_JAVA_AWT_WM_NONREPARENTING=1`


I saw something similar in @geekosaur's config, and I think it's a pretty common solution. Having this in the `X.U.Hacks` can be convenient for some users.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
