### PR TITLE
X.H.UrgencyHook: EWMH fix; clearing of selected windows; doc fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -311,6 +311,8 @@
 
     - Added `doLower` and `doRaise`
 
+    - Added `windowTag`
+
   * `XMonad.Util.EZConfig`
 
     - Added support for XF86Bluetooth.
@@ -406,6 +408,15 @@
 
     - Fixed handling of floating window borders in multihead setups that was
       broken since 0.14.
+
+  * `XMonad.Hooks.UrgencyHook`
+
+    - It's now possible to clear urgency of selected windows only using the
+      newly exported `clearUrgents'` function. Also, this and `clearUrgents`
+      now clear the `_NET_WM_STATE_DEMANDS_ATTENTION` bit as well.
+
+    - Added a variant of `filterUrgencyHook` that takes a generic `Query Bool`
+      to select which windows should never be marked urgent.
 
 ## 0.16
 

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -29,6 +29,7 @@ module XMonad.Hooks.ManageHelpers (
     composeOne,
     (-?>), (/=?), (<==?), (</=?), (-->>), (-?>>),
     currentWs,
+    windowTag,
     isInProperty,
     isKDETrayWindow,
     isFullscreen,
@@ -126,6 +127,10 @@ p -?>> f = do
 -- | Return the current workspace
 currentWs :: Query WorkspaceId
 currentWs = liftX (withWindowSet $ return . W.currentTag)
+
+-- | Return the workspace tag of a window, if already managed
+windowTag :: Query (Maybe WorkspaceId)
+windowTag = ask >>= \w -> liftX $ withWindowSet $ return . W.findTag w
 
 -- | A predicate to check whether a window is a KDE system tray icon.
 isKDETrayWindow :: Query Bool

--- a/XMonad/Hooks/UrgencyHook.hs
+++ b/XMonad/Hooks/UrgencyHook.hs
@@ -61,7 +61,7 @@ module XMonad.Hooks.UrgencyHook (
                                  filterUrgencyHook,
                                  minutes, seconds,
                                  -- * Stuff for developers:
-                                 readUrgents, withUrgents,
+                                 readUrgents, withUrgents, clearUrgents',
                                  StdoutUrgencyHook(..),
                                  SpawnUrgencyHook(..),
                                  UrgencyHook(urgencyHook),

--- a/XMonad/Hooks/UrgencyHook.hs
+++ b/XMonad/Hooks/UrgencyHook.hs
@@ -30,9 +30,6 @@ module XMonad.Hooks.UrgencyHook (
                                  -- ** Useful keybinding
                                  -- $keybinding
 
-                                 -- ** Note
-                                 -- $note
-
                                  -- * Troubleshooting
                                  -- $troubleshooting
 
@@ -129,11 +126,6 @@ import Foreign.C.Types (CLong)
 --
 -- You can set up a keybinding to jump to the window that was recently marked
 -- urgent. See an example at 'focusUrgent'.
-
--- $note
--- Note: UrgencyHook installs itself as a LayoutModifier, so if you modify your
--- urgency hook and restart xmonad, you may need to rejigger your layout by
--- hitting mod-shift-space.
 
 -- $troubleshooting
 --


### PR DESCRIPTION
### Description


#### [X.H.UrgencyHook: Drop $note (obsolete for 12 years)](../commit/90737d6d037322996b8a1b408d08e605e2ccc3f8)

The note doesn't apply since 9a7dcbbabb21 ("Adjustments to use the new
event hook feature instead of Hooks.EventHook").

#### [X.H.UrgencyHook: Clear EWMH urgency in clearUrgents and filterUrgencyHook](../commit/101d6e89bd461459b3e1a6ac8a4e59c173508a7d)

The EWMH support added in 7e9c986217cf only added handling of
_NET_WM_STATE_DEMANDS_ATTENTION to handleEvent and cleanupUrgents, but
manual urgency clearing via clearUrgents or automatic urgency clearing
via filterUrgencyHook was left without EWMH support. This commit adds
the missing pieces.

Fixes: 7e9c986217cf ("Add EWMH DEMANDS_ATTENTION support to UrgencyHook.")

#### [X.H.UrgencyHook: Export clearUrgents'](../commit/13f21f47045a2430992dab29f9b74b0918cbdbf5)

This makes it possible to clear urgency of selected windows only, which
may be useful to some users (like me).

#### [X.H.UrgencyHook: Cleanup stale urgents in startupHook (small memleak workaround)](../commit/9e6e521fbba2be9d7a675a1e99dcaaf8ace54283)

If a manually crafted ClientMessageEvent with invalid (nonexistent)
ev_window is sent to xmonad (by sending it to the root window), the
nonexistent window is added to Urgents and stays there forever.

This can also happen when a window in Urgents disappears while xmonad is
restarting, in which case xmonad never sees the DestroyWindowEvent and
never gets to remove the window from Urgents.

As both of these are fairly unlikely, only do the cleanup in
startupHook to not waste cycles.

#### [X.H.ManageHelpers: Add windowTag](../commit/d49f7a49a2a716c15ffdf3c6f27952ab51646d73)

Not useful in a manageHook, but useful when a Query is used to select an
existing managed window.

#### [X.H.UrgencyHook: Generalize filterUrgencyHook to Query Bool](../commit/1b327a059aca3cbf80b894ef9bd30a6e62fbacea)

#### [Update CHANGES](../commit/3d6844c65fa9317c3e638e07dc4bb2f99fd4753d)


### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - n/a I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)