### PR TITLE
X.L.TrackFloating: Fix changing focus on inactive workspaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -407,6 +407,10 @@
     - Fixed handling of floating window borders in multihead setups that was
       broken since 0.14.
 
+  * `XMonad.Layout.TrackFloating`
+
+    - Fixed a bug that prevented changing focus on inactive workspaces.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/TrackFloating.hs
+++ b/XMonad/Layout/TrackFloating.hs
@@ -51,7 +51,7 @@ data TrackFloating a = TrackFloating (Maybe Window)
 instance LayoutModifier TrackFloating Window where
     modifyLayoutWithUpdate (TrackFloating mw) ws@(W.Workspace{ W.stack = ms }) r
       = do
-        xCur <- gets (W.peek . windowset)
+        xCur <- gets (W.peek . W.view (W.tag ws) . windowset)
         let isF = xCur /= (W.focus <$> ms)
             -- use the remembered focus point when true focus differs from
             -- what this (sub)layout is given, which happens e.g. when true
@@ -75,7 +75,7 @@ data UseTransientFor a = UseTransientFor deriving (Read,Show,Eq)
 
 instance LayoutModifier UseTransientFor Window where
     modifyLayout _ ws@(W.Workspace{ W.stack = ms }) r = do
-        m <- gets (W.peek . windowset)
+        m <- gets (W.peek . W.view (W.tag ws) . windowset)
         d <- asks display
         parent <- join <$> T.traverse (io . getTransientForHint d) m
 


### PR DESCRIPTION
### Description

#### [X.L.TrackFloating: Fix changing focus on inactive workspaces](../commit/43592c84d4dbfd170f7f29819e3a760b89626e80)

When focus changes¹ on an inactive workspace (not `current`, but
`visible`), TrackFloating and UseTransientFor would think they should
use the remembered focus point as they look at the wrong (`current`)
workspace instead of the workspace they're supposed to layout, and so
focus seems to be out of their set of windows, when actually it is not.

Fix this by looking at the correct workspace.

¹) This isn't entirely straightforward, as there are normally no
   keybindings or StackSet operations for this, but it's perfectly legal
   to `W.view` the inactive workspace, change focus, and `W.view` back
   in a single `windows` action.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)