### PR TITLE
Apply two xmonad core fixes to float moving/resizing in various contrib modules

### DIFF
--- a/XMonad/Actions/ConstrainedResize.hs
+++ b/XMonad/Actions/ConstrainedResize.hs
@@ -44,7 +44,6 @@ import XMonad
 -- | Resize (floating) window with optional aspect ratio constraints.
 mouseResizeWindow :: Window -> Bool -> X ()
 mouseResizeWindow w c = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     sh <- io $ getWMNormalHints d w
     io $ warpPointer d none w 0 0 0 0 (fromIntegral (wa_width wa)) (fromIntegral (wa_height wa))
@@ -53,5 +52,6 @@ mouseResizeWindow w c = whenX (isClient w) $ withDisplay $ \d -> do
                      y = ey - fromIntegral (wa_y wa)
                      sz = if c then (max x y, max x y) else (x,y)
                  io $ resizeWindow d w `uncurry`
-                    applySizeHintsContents sh sz)
+                    applySizeHintsContents sh sz
+                 float w)
               (float w)

--- a/XMonad/Actions/FlexibleManipulate.hs
+++ b/XMonad/Actions/FlexibleManipulate.hs
@@ -79,7 +79,6 @@ position = const 0.5
 --   manipulation action.
 mouseWindow :: (Double -> Double) -> Window -> X ()
 mouseWindow f w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     [wpos, wsize] <- io $ getWindowAttributes d w >>= return . winAttrs
     sh <- io $ getWMNormalHints d w
     pointer <- io $ queryPointer d w >>= return . pointerPos
@@ -89,14 +88,14 @@ mouseWindow f w = whenX (isClient w) $ withDisplay $ \d -> do
         mul = mapP (\x -> 2 P.- 2 P.* P.abs(x P.- 0.5)) fc --Fudge factors: interpolation between 1 when on edge, 2 in middle
         atl = ((1, 1) - fc) * mul
         abr = fc * mul
-    mouseDrag (\ex ey -> io $ do
+    mouseDrag (\ex ey -> do
         let offset = (fromIntegral ex, fromIntegral ey) - pointer
             npos = wpos + offset * atl
             nbr = (wpos + wsize) + offset * abr
             ntl = minP (nbr - (32, 32)) npos    --minimum size
             nwidth = applySizeHintsContents sh $ mapP (round :: Double -> Integer) (nbr - ntl)
-        moveResizeWindow d w (round $ fst ntl) (round $ snd ntl) `uncurry` nwidth
-        return ())
+        io $ moveResizeWindow d w (round $ fst ntl) (round $ snd ntl) `uncurry` nwidth
+        float w)
         (float w)
 
     float w

--- a/XMonad/Actions/FlexibleResize.hs
+++ b/XMonad/Actions/FlexibleResize.hs
@@ -50,7 +50,6 @@ mouseResizeEdgeWindow
   -> Window   -- ^ The window to resize.
   -> X ()
 mouseResizeEdgeWindow edge w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     sh <- io $ getWMNormalHints d w
     (_, _, _, _, _, ix, iy, _) <- io $ queryPointer d w
@@ -62,7 +61,8 @@ mouseResizeEdgeWindow edge w = whenX (isClient w) $ withDisplay $ \d -> do
         (cy, fy, gy) = mkSel north height pos_y
     io $ warpPointer d none w 0 0 0 0 cx cy
     mouseDrag (\ex ey -> do let (nw,nh) = applySizeHintsContents sh (gx ex, gy ey)
-                            io $ moveResizeWindow d w (fx nw) (fy nh) nw nh)
+                            io $ moveResizeWindow d w (fx nw) (fy nh) nw nh
+                            float w)
               (float w)
     where
     findPos :: CInt -> Position -> Maybe Bool

--- a/XMonad/Actions/FloatKeys.hs
+++ b/XMonad/Actions/FloatKeys.hs
@@ -43,7 +43,6 @@ import XMonad
 --   right and @dy@ pixels down.
 keysMoveWindow :: D -> Window -> X ()
 keysMoveWindow (dx,dy) w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     io $ moveWindow d w (fromIntegral (fromIntegral (wa_x wa) + dx))
                         (fromIntegral (fromIntegral (wa_y wa) + dy))
@@ -61,7 +60,6 @@ keysMoveWindow (dx,dy) w = whenX (isClient w) $ withDisplay $ \d -> do
 -- > keysMoveWindowTo (1024,0) (1, 0)      -- put window in the top right corner
 keysMoveWindowTo :: P -> G -> Window -> X ()
 keysMoveWindowTo (x,y) (gx, gy) w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     io $ moveWindow d w (x - round (gx * fromIntegral (wa_width wa)))
                         (y - round (gy * fromIntegral (wa_height wa)))
@@ -111,7 +109,6 @@ keysResizeWindow' sh (x,y) (w,h) (dx,dy) (gx, gy) = ((nx, ny), (nw, nh))
 
 keysMoveResize :: (SizeHints -> P -> D -> a -> b -> (P,D)) -> a -> b -> Window -> X ()
 keysMoveResize f move resize w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     sh <- io $ getWMNormalHints d w
     let wa_dim = (fromIntegral $ wa_width wa, fromIntegral $ wa_height wa)

--- a/XMonad/Actions/FloatSnap.hs
+++ b/XMonad/Actions/FloatSnap.hs
@@ -120,7 +120,6 @@ snapMagicResize
     -> Window      -- ^ The window to move and resize.
     -> X ()
 snapMagicResize dir collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
 
     (xbegin,xend) <- handleAxis True d wa
@@ -170,7 +169,6 @@ snapMagicMove
     -> Window    -- ^ The window to move.
     -> X ()
 snapMagicMove collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
 
     nx <- handleAxis True d wa
@@ -211,7 +209,6 @@ snapMove D = doSnapMove False False
 
 doSnapMove :: Bool -> Bool -> Maybe Int -> Window -> X ()
 doSnapMove horiz rev collidedist w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     ((bl,br,_),(fl,fr,_)) <- getSnap horiz collidedist d w
 
@@ -251,7 +248,6 @@ snapShrink = snapResize False
 
 snapResize :: Bool -> Direction2D -> Maybe Int -> Window -> X ()
 snapResize grow dir collidedist w = whenX (isClient w) $ withDisplay $ \d -> do
-    io $ raiseWindow d w
     wa <- io $ getWindowAttributes d w
     mr <- case dir of
               L -> do ((mg,ms,_),(_,_,_)) <- getSnap True collidedist d w


### PR DESCRIPTION
### Description

This applies fixes from
https://github.com/xmonad/xmonad/commit/4565e2c90ef522d23d3afc2cf95b9f0b423d8de4
and
https://github.com/xmonad/xmonad/commit/b9ce5b034ba389b95b663e9f56bbc18a227f8695.

tl;dr:
When dragging, refloat and refresh to fix https://github.com/xmonad/xmonad/issues/63.
When starting dragging, raising the window is then unnecessary, and
removing it fixes https://github.com/xmonad/xmonad/issues/208.
Also remove unnecessary raises for keyboard moving/resizing which always
refloated the window.

Fixes: https://github.com/xmonad/xmonad/issues/63
Fixes: https://github.com/xmonad/xmonad/issues/208

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)