### PR TITLE
Mate logout option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,6 +140,12 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Config.Mate`
+  
+    - Split out the logout dialog and add a shutdown dialog. The default behavior
+      remains the same but there are now `mateLogout` and `mateShutdown` actions
+      available.
+
   * `XMonad.Actions.DynamicProjects`
 
     - The `changeProjectDirPrompt` function respects the `complCaseSensitivity` field

--- a/XMonad/Config/Mate.hs
+++ b/XMonad/Config/Mate.hs
@@ -21,6 +21,8 @@ module XMonad.Config.Mate (
     mateConfig,
     mateRun,
     mateRegister,
+    mateLogout,
+    mateShutdown,
     desktopLayoutModifiers
     ) where
 
@@ -49,7 +51,7 @@ mateConfig = desktopConfig
 
 mateKeys (XConfig {modMask = modm}) = M.fromList $
     [ ((modm, xK_p), mateRun)
-    , ((modm .|. shiftMask, xK_q), spawn "mate-session-save --logout-dialog") ]
+    , ((modm .|. shiftMask, xK_q), mateLogout) ]
 
 -- | Launch the "Run Application" dialog.  mate-panel must be running for this
 -- to work.
@@ -86,3 +88,9 @@ mateRegister = io $ do
             ,"org.mate.SessionManager.RegisterClient"
             ,"string:xmonad"
             ,"string:"++sessionId]
+
+mateLogout :: MonadIO m => m ()
+mateLogout = spawn "mate-session-save --logout-dialog"
+
+mateShutdown :: MonadIO m => m ()
+mateShutdown = spawn "mate-session-save --shutdown-dialog"

--- a/XMonad/Config/Mate.hs
+++ b/XMonad/Config/Mate.hs
@@ -89,8 +89,11 @@ mateRegister = io $ do
             ,"string:xmonad"
             ,"string:"++sessionId]
 
+-- | Display MATE logout dialog. This is the default mod-q action.
 mateLogout :: MonadIO m => m ()
 mateLogout = spawn "mate-session-save --logout-dialog"
 
+-- | Display MATE shutdown dialog. You can override mod-q to invoke this, or bind it
+-- to another key if you prefer.
 mateShutdown :: MonadIO m => m ()
 mateShutdown = spawn "mate-session-save --shutdown-dialog"


### PR DESCRIPTION
### Description

Refactor logout and provide an option to display the system shutdown dialog.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
