### PR TITLE
Add Main Menu keybinding to Mate.hs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,6 +151,8 @@
       remains the same but there are now `mateLogout` and `mateShutdown` actions
       available.
 
+    - Add mod-d keybinding to open the Mate main menu.
+
   * `XMonad.Actions.DynamicProjects`
 
     - The `changeProjectDirPrompt` function respects the `complCaseSensitivity` field

--- a/XMonad/Config/Mate.hs
+++ b/XMonad/Config/Mate.hs
@@ -20,6 +20,7 @@ module XMonad.Config.Mate (
     -- $usage
     mateConfig,
     mateRun,
+    matePanel,
     mateRegister,
     mateLogout,
     mateShutdown,
@@ -29,6 +30,8 @@ module XMonad.Config.Mate (
 import XMonad
 import XMonad.Config.Desktop
 import XMonad.Util.Run (safeSpawn)
+import XMonad.Util.Ungrab
+import Data.Char (toUpper)
 
 import qualified Data.Map as M
 
@@ -51,19 +54,27 @@ mateConfig = desktopConfig
 
 mateKeys (XConfig {modMask = modm}) = M.fromList $
     [ ((modm, xK_p), mateRun)
+    , ((modm, xK_d), unGrab >> matePanel "MAIN_MENU")
     , ((modm .|. shiftMask, xK_q), mateLogout) ]
 
 -- | Launch the "Run Application" dialog.  mate-panel must be running for this
--- to work.
+-- to work.  partial application for existing keybinding compatibility.
 mateRun :: X ()
-mateRun = withDisplay $ \dpy -> do
+mateRun = matePanel "RUN_DIALOG"
+
+-- | Launch a panel action. Either the "Run Application" dialog ("run_dialog" parameter,
+-- see above) or the main menu ("main_menu" parameter).  mate-panel must be running
+-- for this to work.
+matePanel :: String -> X ()
+matePanel action = withDisplay $ \dpy -> do
+    let panel = "_MATE_PANEL_ACTION"
     rw <- asks theRoot
-    mate_panel <- getAtom "_MATE_PANEL_ACTION"
-    panel_run  <- getAtom "_MATE_PANEL_ACTION_RUN_DIALOG"
+    mate_panel <- getAtom panel
+    panel_action <- getAtom (panel ++ "_" ++ map toUpper action)
 
     io $ allocaXEvent $ \e -> do
         setEventType e clientMessage
-        setClientMessageEvent e rw mate_panel 32 panel_run 0
+        setClientMessageEvent e rw mate_panel 32 panel_action 0
         sendEvent dpy rw False structureNotifyMask e
         sync dpy False
 


### PR DESCRIPTION
Use mod+d to open the Mate Main Menu.

### Description

It is now possible to open Mate Main Menu using a keybinding (default mod+d).
This feature was missing from Mate.hs config.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
