### PR TITLE
Extend PP with ppRename: nicer compose of WorkspaceNames, ClickableWorkspaces, …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,11 @@
     - `execScriptHook` now has an `X` constraint (was: `MonadIO`), due to changes
       in how the xmonad core handles XDG directories.
 
+  * `XMonad.Actions.WorkspaceNames`
+
+    - The type of `getWorkspaceNames` was changed to fit into the new `ppRename`
+      field of `PP`.
+
 ### New Modules
 
   * `XMonad.Util.Hacks`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -229,6 +229,10 @@
       to provide the configs for the already existing functionality. This provides
       multiple status bars support.
 
+    - Added `ppRename` to `PP`, which makes it possible for extensions like
+      `workspaceNamesPP`, `marshallPP` and/or `clickablePP` to compose
+      intuitively.
+
   * `XMonad.Layout.BoringWindows`
 
     - Added boring-aware `swapUp`, `swapDown`, `siftUp`, and `siftDown` functions.

--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -587,7 +587,7 @@ pprWindowSet sort' urgents pp s = sepBy (ppWsSep pp) . map fmt . sort' $
     this     = S.currentTag s
     visibles = map (S.tag . S.workspace) (S.visible s)
 
-    fmt w = printer pp (S.tag w)
+    fmt w = printer pp (ppRename pp (S.tag w) w)
       where
         printer | any (\x -> (== Just (S.tag w)) (S.findTag x s)) urgents = ppUrgent
                 | S.tag w == this                                         = ppCurrent
@@ -938,6 +938,9 @@ data PP = PP { ppCurrent :: WorkspaceId -> String
                -- ^ how to print tags of empty visible workspaces
              , ppUrgent :: WorkspaceId -> String
                -- ^ format to be applied to tags of urgent workspaces.
+             , ppRename :: String -> WindowSpace -> String
+               -- ^ rename/augment the workspace tag
+               --   (note that @WindowSpace -> …@ acts as a Reader monad)
              , ppSep :: String
                -- ^ separator to use between different log sections
                -- (window name, layout, workspaces)
@@ -989,6 +992,7 @@ instance Default PP where
                , ppHiddenNoWindows = const ""
                , ppVisibleNoWindows= Nothing
                , ppUrgent          = id
+               , ppRename          = pure
                , ppSep             = " : "
                , ppWsSep           = " "
                , ppTitle           = shorten 80

--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -583,16 +583,18 @@ dynamicLogString pp = do
 pprWindowSet :: WorkspaceSort -> [Window] -> PP -> WindowSet -> String
 pprWindowSet sort' urgents pp s = sepBy (ppWsSep pp) . map fmt . sort' $
             map S.workspace (S.current s : S.visible s) ++ S.hidden s
-   where this     = S.currentTag s
-         visibles = map (S.tag . S.workspace) (S.visible s)
+  where
+    this     = S.currentTag s
+    visibles = map (S.tag . S.workspace) (S.visible s)
 
-         fmt w = printer pp (S.tag w)
-          where printer | any (\x -> (== Just (S.tag w)) (S.findTag x s)) urgents  = ppUrgent
-                        | S.tag w == this                                               = ppCurrent
-                        | S.tag w `elem` visibles && isJust (S.stack w)                 = ppVisible
-                        | S.tag w `elem` visibles                                       = liftA2 fromMaybe ppVisible ppVisibleNoWindows
-                        | isJust (S.stack w)                                            = ppHidden
-                        | otherwise                                                     = ppHiddenNoWindows
+    fmt w = printer pp (S.tag w)
+      where
+        printer | any (\x -> (== Just (S.tag w)) (S.findTag x s)) urgents = ppUrgent
+                | S.tag w == this                                         = ppCurrent
+                | S.tag w `elem` visibles && isJust (S.stack w)           = ppVisible
+                | S.tag w `elem` visibles                                 = liftA2 fromMaybe ppVisible ppVisibleNoWindows
+                | isJust (S.stack w)                                      = ppHidden
+                | otherwise                                               = ppHiddenNoWindows
 
 -- |
 -- Workspace logger with a format designed for Xinerama:

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -31,7 +31,6 @@ module XMonad.Layout.IndependentScreens (
 -- for the screen stuff
 import Control.Applicative(liftA2)
 import Control.Arrow hiding ((|||))
-import Data.Functor ((<&>))
 import Data.List (nub, genericLength)
 import Graphics.X11.Xinerama
 import XMonad
@@ -135,15 +134,8 @@ countScreens = fmap genericLength . liftIO $ openDisplay "" >>= liftA2 (<*) getS
 -- > logHook = let log screen handle = dynamicLogWithPP . marshallPP screen . pp $ handle
 -- >           in log 0 hLeft >> log 1 hRight
 marshallPP :: ScreenId -> PP -> PP
-marshallPP s pp = pp {
-    ppCurrent           = ppCurrent         pp . unmarshallW,
-    ppVisible           = ppVisible         pp . unmarshallW,
-    ppHidden            = ppHidden          pp . unmarshallW,
-    ppHiddenNoWindows   = ppHiddenNoWindows pp . unmarshallW,
-    ppVisibleNoWindows  = ppVisibleNoWindows pp <&> (. unmarshallW),
-    ppUrgent            = ppUrgent          pp . unmarshallW,
-    ppSort              = fmap (marshallSort s) (ppSort pp)
-    }
+marshallPP s pp = pp { ppRename = ppRename pp . unmarshallW
+                     , ppSort = fmap (marshallSort s) (ppSort pp) }
 
 -- | Take a pretty-printer and turn it into one that only runs when the current
 -- workspace is one associated with the given screen. The way this works is a

--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -25,7 +25,7 @@ import Control.Monad ((>=>))
 import Data.Functor ((<&>))
 
 import XMonad
-import XMonad.Hooks.DynamicLog (xmobarAction, xmobarRaw, PP(..))
+import XMonad.Hooks.DynamicLog (xmobarAction, PP(..))
 import XMonad.Util.WorkspaceCompare (getWsIndex)
 import qualified XMonad.StackSet as W
 
@@ -39,11 +39,16 @@ import qualified XMonad.StackSet as W
 --   * @xdotool@ on system (in path)
 --   * "XMonad.Hooks.EwmhDesktops" for @xdotool@ support (see Hackage docs for setup)
 --   * use of UnsafeStdinReader/UnsafeXMonadLog in xmobarrc (rather than StdinReader/XMonadLog)
+--
+-- Note that UnsafeStdinReader is potentially dangerous if your workspace
+-- names are dynamically generated from untrusted input (like window titles).
+-- You may need to add @xmobarRaw@ to 'ppRename' before applying
+-- 'clickablePP' in such case.
 
 -- | Wrap string with an xmobar action that uses @xdotool@ to switch to
 -- workspace @i@.
 clickableWrap :: Int -> String -> String
-clickableWrap i ws = xmobarAction ("xdotool set_desktop " ++ show i) "1" $ xmobarRaw ws
+clickableWrap i ws = xmobarAction ("xdotool set_desktop " ++ show i) "1" ws
 
 -- | Return a function that wraps workspace names in an xmobar action that
 -- switches to that workspace.

--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -18,22 +18,16 @@ module XMonad.Util.ClickableWorkspaces (
   -- * Usage
   -- $usage
   clickablePP,
-  clickableRenamedPP,
   clickableWrap,
-
-  -- * Integrations
-  clickableWorkspaceNamesPP,
-  clickableMarshallPP,
-  clickableMarshallWorkspaceNamesPP
   ) where
 
+import Control.Monad ((>=>))
 import Data.Functor ((<&>))
 
 import XMonad
-import XMonad.Actions.WorkspaceNames
 import XMonad.Hooks.DynamicLog (xmobarAction, xmobarRaw, PP(..))
-import XMonad.Layout.IndependentScreens
 import XMonad.Util.WorkspaceCompare (getWsIndex)
+import qualified XMonad.StackSet as W
 
 -- $usage
 -- However you have set up your PP, apply @clickablePP@ to it, and bind the result
@@ -52,54 +46,14 @@ clickableWrap :: Int -> String -> String
 clickableWrap i ws = xmobarAction ("xdotool set_desktop " ++ show i) "1" $ xmobarRaw ws
 
 -- | Return a function that wraps workspace names in an xmobar action that
--- switches to that workspace. That workspace name must be exactly as
--- configured in 'XMonad.Core.workspaces', so this takes an additional
--- parameter that allows renaming/marshalling of the name for display, which
--- is applied after the workspace's index is looked up.
+-- switches to that workspace.
 --
--- This additionally assumes that 'XMonad.Hooks.EwmhDesktops.ewmhDesktopsEventHook'
+-- This assumes that 'XMonad.Hooks.EwmhDesktops.ewmhDesktopsEventHook'
 -- isn't configured to change the workspace order. We might need to add an
 -- additional parameter if anyone needs that.
-getClickable :: (WorkspaceId -> String) -> X (WorkspaceId -> String)
-getClickable ren = do
-  wsIndex <- getWsIndex
-  return $ \ws -> case wsIndex ws of
-                    Just idx -> clickableWrap idx (ren ws)
-                    Nothing -> ws
+getClickable :: X (String -> WindowSpace -> String)
+getClickable = getWsIndex <&> \idx s w -> maybe id clickableWrap (idx (W.tag w)) s
 
--- | Apply clickable wrapping to all workspace fields in given PP.
+-- | Apply clickable wrapping to the given PP.
 clickablePP :: PP -> X PP
-clickablePP = clickableRenamedPP id
-
--- | Alternative to 'clickablePP' that allows changing the visible workspace
--- name. Useful for integration with modules that change workspace names, such
--- as "XMonad.Layout.IndependentScreens" and "XMonad.Actions.WorkspaceNames".
-clickableRenamedPP :: (WorkspaceId -> String) -> PP -> X PP
-clickableRenamedPP ren pp = do
-  clickable <- getClickable ren
-  return $
-    pp { ppCurrent         = ppCurrent pp . clickable
-       , ppVisible         = ppVisible pp . clickable
-       , ppHidden          = ppHidden pp . clickable
-       , ppHiddenNoWindows = ppHiddenNoWindows pp . clickable
-       , ppVisibleNoWindows= ppVisibleNoWindows pp <&> (. clickable)
-       , ppUrgent          = ppUrgent pp . clickable
-       }
-
--- | Integration with "XMonad.Actions.WorkspaceNames".
-clickableWorkspaceNamesPP :: PP -> X PP
-clickableWorkspaceNamesPP pp = do
-    rename <- getWorkspaceNames
-    clickableRenamedPP rename pp
-
--- | Integration with "XMonad.Layout.IndependentScreens".
-clickableMarshallPP :: ScreenId -> PP -> X PP
-clickableMarshallPP s pp =
-    clickableRenamedPP unmarshallW pp{ ppSort = marshallSort s <$> ppSort pp }
-
--- | Integration with both "XMonad.Actions.WorkspaceNames" and
--- "XMonad.Layout.IndependentScreens".
-clickableMarshallWorkspaceNamesPP :: ScreenId -> PP -> X PP
-clickableMarshallWorkspaceNamesPP s pp = do
-    rename <- getWorkspaceNames
-    clickableRenamedPP (unmarshallW . rename) pp{ ppSort = marshallSort s <$> ppSort pp }
+clickablePP pp = getClickable <&> \ren -> pp{ ppRename = ppRename pp >=> ren }


### PR DESCRIPTION
### Description

#### [X.H.DynamicLog: Reindent pprWindowSet](../commit/fc7ea97582ddf83266d2a1c0005fc4b786f8c03b)

#### [X.H.DynamicLog: Add ppRename (composable tag augmentation)](../commit/91010f6eb916aedeb8f9f8b5d0f456a688c5f094)

This one is a Reader in WindowSpace, and therefore significantly
simplifies the composition of WorkspaceNames, IndependentScreens,
ClickableWorkspaces and possibly other similar modules.

Related: https://github.com/xmonad/xmonad-contrib/pull/390
Related: https://github.com/xmonad/xmonad-contrib/pull/462

#### [X.A.WorkspaceNames, X.L.IndependentScreens, X.U.ClickableWorkspaces: Use ppRename](../commit/275af4d4df2c20a70d238313e17960938e8bf6ee)

Also, drop now useless integrations from X.U.ClickableWorkspaces:
workspaceNamesPP, marshallPP and clickablePP can now be composed
directly using >>= and it just works.

Related: https://github.com/xmonad/xmonad-contrib/pull/390
Related: https://github.com/xmonad/xmonad-contrib/pull/462

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)