### PR TITLE
X.Prompt: Add maxComplColumns field to XPConfig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -418,6 +418,9 @@
     - The prompt now cycles through its suggestions if one hits the ends
       of the suggestion list and presses `TAB` again.
 
+    - Added `maxComplColumns` field to `XPConfig`, to limit the number of
+      columns in the completion window.
+
   * `XMonad.Actions.TreeSelect`
 
     - Fixed a crash when focusing a new window while the tree select


### PR DESCRIPTION
### Description

This allows limiting the number of columns in the completion window. The window width is divided equally between the columns.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
