### PR TITLE
Fix issue with colors in X.A.TreeSelect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,10 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Actions.TreeSelect`
+
+    - Fix the blue and green colors being swapped.
+
   * `XMonad.Layout.Fullscreen`
 
     - Add fullscreenSupportBorder which uses smartBorders to remove

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -137,8 +137,8 @@ import Graphics.X11.Xrender
 -- > def = TSConfig { ts_hidechildren = True
 -- >                , ts_background   = 0xc0c0c0c0
 -- >                , ts_font         = "xft:Sans-16"
--- >                , ts_node         = (0xff000000, 0xff50d0db)
--- >                , ts_nodealt      = (0xff000000, 0xff10b8d6)
+-- >                , ts_node         = (0xff000000, 0xff50dbd0)
+-- >                , ts_nodealt      = (0xff000000, 0xff10d6b8)
 -- >                , ts_highlight    = (0xffffffff, 0xffff0000)
 -- >                , ts_extra        = 0xff000000
 -- >                , ts_node_width   = 200
@@ -220,8 +220,8 @@ instance Default (TSConfig a) where
     def = TSConfig { ts_hidechildren = True
                    , ts_background   = 0xc0c0c0c0
                    , ts_font         = "xft:Sans-16"
-                   , ts_node         = (0xff000000, 0xff50d0db)
-                   , ts_nodealt      = (0xff000000, 0xff10b8d6)
+                   , ts_node         = (0xff000000, 0xff50dbd0)
+                   , ts_nodealt      = (0xff000000, 0xff10d6b8)
                    , ts_highlight    = (0xffffffff, 0xffff0000)
                    , ts_extra        = 0xff000000
                    , ts_node_width   = 200

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -161,8 +161,8 @@ import Graphics.X11.Xrender
 -- white       = 0xffffffff
 -- black       = 0xff000000
 -- red         = 0xffff0000
--- blue        = 0xff00ff00
 -- green       = 0xff0000ff
+-- blue        = 0xff00ff00
 -- transparent = 0x00000000
 -- @
 

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -137,8 +137,8 @@ import Graphics.X11.Xrender
 -- > def = TSConfig { ts_hidechildren = True
 -- >                , ts_background   = 0xc0c0c0c0
 -- >                , ts_font         = "xft:Sans-16"
--- >                , ts_node         = (0xff000000, 0xff50dbd0)
--- >                , ts_nodealt      = (0xff000000, 0xff10d6b8)
+-- >                , ts_node         = (0xff000000, 0xff50d0db)
+-- >                , ts_nodealt      = (0xff000000, 0xff10b8d6)
 -- >                , ts_highlight    = (0xffffffff, 0xffff0000)
 -- >                , ts_extra        = 0xff000000
 -- >                , ts_node_width   = 200
@@ -161,8 +161,8 @@ import Graphics.X11.Xrender
 -- white       = 0xffffffff
 -- black       = 0xff000000
 -- red         = 0xffff0000
--- blue        = 0xff0000ff
--- green       = 0xff00ff00
+-- blue        = 0xff00ff00
+-- green       = 0xff0000ff
 -- transparent = 0x00000000
 -- @
 
@@ -220,8 +220,8 @@ instance Default (TSConfig a) where
     def = TSConfig { ts_hidechildren = True
                    , ts_background   = 0xc0c0c0c0
                    , ts_font         = "xft:Sans-16"
-                   , ts_node         = (0xff000000, 0xff50dbd0)
-                   , ts_nodealt      = (0xff000000, 0xff10d6b8)
+                   , ts_node         = (0xff000000, 0xff50d0db)
+                   , ts_nodealt      = (0xff000000, 0xff10b8d6)
                    , ts_highlight    = (0xffffffff, 0xffff0000)
                    , ts_extra        = 0xff000000
                    , ts_node_width   = 200

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -656,7 +656,7 @@ drawStringXMF display window visual colormap gc font col x y text = case font of
 -- Note that it uses short to represent its components
 fromARGB :: Pixel -> XRenderColor
 fromARGB x = XRenderColor (fromIntegral $ 0xff00 .&. shiftR x 8)  -- red
-                          (fromIntegral $ 0xff00 .&. x)           -- green
-                          (fromIntegral $ 0xff00 .&. shiftL x 8)  -- blue
+                          (fromIntegral $ 0xff00 .&. shiftL x 8)  -- green
+                          (fromIntegral $ 0xff00 .&. x)           -- blue
                           (fromIntegral $ 0xff00 .&. shiftR x 16) -- alpha
 #endif

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -654,6 +654,8 @@ drawStringXMF display window visual colormap gc font col x y text = case font of
 -- | Convert 'Pixel' to 'XRenderColor'
 --
 -- Note that it uses short to represent its components
+--
+-- This fixes a bug with font rendering, caused by the haskell bindings for xorg-xft.
 fromARGB :: Pixel -> XRenderColor
 fromARGB x = XRenderColor (fromIntegral $ 0xff00 .&. shiftR x 8)  -- red
                           (fromIntegral $ 0xff00 .&. shiftL x 8)  -- green

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -161,8 +161,8 @@ import Graphics.X11.Xrender
 -- white       = 0xffffffff
 -- black       = 0xff000000
 -- red         = 0xffff0000
--- blue        = 0xff00ff00
--- green       = 0xff0000ff
+-- blue        = 0xff0000ff
+-- green       = 0xff00ff00
 -- transparent = 0x00000000
 -- @
 


### PR DESCRIPTION
### Description

Green and blue were swapped.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
