### PR TITLE
X.U.Hacks: Add "Stacking trays (trayer) above panels (xmobar)"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,11 +74,16 @@
 
   * `XMonad.Util.Hacks`
 
-    Serves as a collection of hacks and fixes that should be easily acessible to users.
-    The first element of this module is windowedFullscreenFix, which fixes fullscreen behaviour
-    of chromium based applications when using windowed fullscreen.
-    A second entry is `javaHack`, which helps when dealing with Java applications that might
-    not work well with xmonad.
+    A collection of hacks and fixes that should be easily acessible to users:
+
+    - `windowedFullscreenFix` fixes fullscreen behaviour of chromium based
+      applications when using windowed fullscreen.
+
+    - `javaHack` helps when dealing with Java applications that might not work
+      well with xmonad.
+
+    - `trayerAboveXmobarEventHook` reliably stacks trayer on top of xmobar and
+      below other windows
 
   * `XMonad.Util.ActionCycle`
 

--- a/XMonad/Doc/Extending.hs
+++ b/XMonad/Doc/Extending.hs
@@ -1160,7 +1160,8 @@ A non complete list with a brief description:
     Core fonts and Xft.
 
 * "XMonad.Util.Hacks":
-    A collection of small fixes and utilities with possibly hacky implementations.
+    A collection of small fixes and utilities with possibly hacky
+    implementations and/or not deserving own modules.
 
 * "XMonad.Util.Image":
     Utilities for manipulating [[Bool]] as images.

--- a/XMonad/Util/Hacks.hs
+++ b/XMonad/Util/Hacks.hs
@@ -19,13 +19,14 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Util.Hacks
-  ( -- * Windowed fullscreen
-    -- $windowedFullscreenFix
-    windowedFullscreenFixEventHook
-    -- * Java Hack
-    -- $java
-  , javaHack
+module XMonad.Util.Hacks (
+  -- * Windowed fullscreen
+  -- $windowedFullscreenFix
+  windowedFullscreenFixEventHook,
+
+  -- * Java Hack
+  -- $java
+  javaHack,
   ) where
 
 
@@ -79,7 +80,7 @@ windowedFullscreenFixEventHook _ = return $ All True
 
 
 -- $java
--- | Some java Applications might not work with xmonad. A common workaround would be to set the environment
+-- Some java Applications might not work with xmonad. A common workaround would be to set the environment
 -- variable @_JAVA_AWT_WM_NONREPARENTING@ to 1. The function 'javaHack' does exactly that.
 -- Example usage:
 --

--- a/XMonad/Util/Hacks.hs
+++ b/XMonad/Util/Hacks.hs
@@ -9,7 +9,8 @@
 -- Portability :  unportable
 --
 -- This module is a collection of random fixes, workarounds and other functions
--- that rely on somewhat hacky implementations which may have unwanted side effects.
+-- that rely on somewhat hacky implementations which may have unwanted side effects
+-- and/or are small enough to not warrant a separate module.
 --
 -- Import this module as qualified like so:
 --


### PR DESCRIPTION
### Description

Placing `trayer` on top of `xmobar` is somewhat tricky:

- they both should be lowered to the bottom of the stacking order to avoid overlapping fullscreen windows

- the tray needs to be stacked on top of the panel regardless of which happens to start first

`trayerAboveXmobarEventHook` (and the more generic `trayAbovePanelEventHook`) is an event hook that ensures the latter: whenever the tray lowers itself to the bottom of the stack, it checks whether there are any panels above it and lowers these again.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)