### PR TITLE
X.H.DynamicIcons: Cleanups, docs improvements, composability with other *PPs

### DIFF
--- a/XMonad/Doc/Extending.hs
+++ b/XMonad/Doc/Extending.hs
@@ -477,7 +477,8 @@ Here is a list of the modules found in @XMonad.Hooks@:
     One-shot and permanent ManageHooks that can be updated at runtime.
 
 * "XMonad.Hooks.DynamicIcons":
-    Dynamic Icons based on Windows in Workspaces
+    Dynamically augment workspace names logged to a status bar via DynamicLog
+    based on the contents (windows) of the workspace.
 
 * "XMonad.Hooks.DynamicLog": for use with 'XMonad.Core.logHook'; send
   information about xmonad's state to standard output, suitable for


### PR DESCRIPTION
### Description

Followup to https://github.com/xmonad/xmonad-contrib/pull/450 and https://github.com/xmonad/xmonad-contrib/pull/481.

#### [X.H.DynamicIcons: Improve configuration of output formatting](../commit/84aa50de6240d0749e6aba88b7d113b033de2ac5)

Make it possible to keep workspace id in the output (iconsFmtAppend) and to wrap icons even if there's just one, or zero.

Also, change the default to use curly brackets to avoid confict with brackets/parentheses used by default PPs in DynamicLog.

Related: https://github.com/xmonad/xmonad-contrib/pull/450

#### [X.H.DynamicIcons: Refactor dynamicLogIconsConvert a bit](../commit/7a6d33e065bf64cc3692a32227058de85a7f8d83)

Rename to dynamicIconsPP and change the type to something similar to workspaceNamesPP and marshallPP.

Related: https://github.com/xmonad/xmonad-contrib/pull/450

#### [X.H.DynamicIcons: Refactor dynamicIconsPP, getIcons a bit](../commit/6d025ebf013596a527d5eed76b863303d01996ed)

Move all the workspaces and icon generation logic into getWorkspaceIcons and drop the Maybe which is no longer necessary since we made the formatting logic configurable.

Related: https://github.com/xmonad/xmonad-contrib/pull/450

#### [X.H.DynamicIcons: Use ppRename - simpler, better interop with other modules](../commit/7154cae69eea33a946033f39791a5d5e1e780fa4)

This ports DynamicIcons to the recently introduced ppRename mechanism, which means DynamicIcons can now safely be combined with clickablePP, workspaceNamesPP and marshallPP.

This also fixes DynamicIcons not working properly with urgent workspaces due to forgotten ppUrgent counterpart in data Icon. Also, ppVisibleNoWindows wouldn't work properly.

The code is now considerably simpler, but we lost the ability to use different icons depending on whether the workspace is visible/hidden/urgent/etc. If anyone needs that, it can be worked around by using some markup that is later interpreted in ppVisible/ppHidden/ppUrgent/etc.

Related: https://github.com/xmonad/xmonad-contrib/pull/481

#### [X.H.DynamicIcons: Move stuff around a bit (similar order to export list)](../commit/b9e23d0ab348dea98e01b9d6a4e7457fda8914e7)

Makes the other commits easier to review.

#### [X.H.DynamicIcons: Update docs](../commit/cbf16a66bb6c29216637774fae4c373b7ec43ce0)

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)