### PR TITLE
X.H.ManageDocks: React to strut updates of override_redirect docks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -343,7 +343,16 @@
     - Export `AvoidStruts` constructor
 
     - Restored compatibility with pre-0.13 configs by making the startup hook
-      unnecessary for correct functioning.
+      unnecessary for correct functioning (strut cache is initialized on-demand).
+
+    - Fixed ignoring of strut updates from override-redirect windows, which is
+      default for xmobar.
+
+      Previously, if one wanted xmobar to reposition itself after xrandr
+      changes and have xmonad handle that repositioning, one would need to
+      configure xmobar with `overrideRedirect = False`, which would disable
+      lowering on start and thus cause other problems. This is no longer
+      necessary.
 
   * `XMonad.Hooks.ManageHelpers`
 

--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -128,8 +128,8 @@ updateStrutCache w strut = do
     ch2 <- XS.modified $ StrutCache . fmap (M.insert w strut) . fromStrutCache
     return $ ch1 || ch2
 
-deleteFromStructCache :: Window -> X Bool
-deleteFromStructCache w = do
+deleteFromStrutCache :: Window -> X Bool
+deleteFromStrutCache w = do
     ch1 <- fst <$> getStrutCache
     ch2 <- XS.modified $ StrutCache . fmap (M.delete w) . fromStrutCache
     return $ ch1 || ch2
@@ -170,7 +170,7 @@ docksEventHook (PropertyEvent { ev_window = w
         whenX (updateStrutCache w strut) refreshDocks
     return (All True)
 docksEventHook (DestroyWindowEvent {ev_window = w}) = do
-    whenX (deleteFromStructCache w) refreshDocks
+    whenX (deleteFromStrutCache w) refreshDocks
     return (All True)
 docksEventHook _ = return (All True)
 

--- a/XMonad/Util/ExtensibleState.hs
+++ b/XMonad/Util/ExtensibleState.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternGuards #-}
 -----------------------------------------------------------------------------
 -- |
@@ -22,6 +23,7 @@ module XMonad.Util.ExtensibleState (
                               , get
                               , gets
                               , modified
+                              , modifiedM
                               ) where
 
 import Data.Typeable (typeOf,cast)
@@ -121,8 +123,11 @@ remove :: (ExtensionClass a, XLike m) => a -> m ()
 remove wit = modifyStateExts $ M.delete (show . typeOf $ wit)
 
 modified :: (ExtensionClass a, Eq a, XLike m) => (a -> a) -> m Bool
-modified f = do
+modified = modifiedM . (pure .)
+
+modifiedM :: (ExtensionClass a, Eq a, XLike m) => (a -> m a) -> m Bool
+modifiedM f = do
     v <- get
-    case f v of
+    f v >>= \case
         v' | v' == v   -> return False
            | otherwise -> put v' >> return True


### PR DESCRIPTION
### Description

We only requested PropertyChange events from docks in the `manageDocks` manageHook, but that only gets called for normal windows, not override_redirect ones. Therefore, xmobar in its default configuration wouldn't get its struts refreshed on changes. This resulted in gaps not updating after xmobar repositions itself on xrandr changes.

If one wanted to handle that repositioning in xmonad, it was possible to configure xmobar with `overrideRedirect = False`, which is meant for window managers with [proper EWMH stacking order support][1], so in xmonad it resulted in xmobar covering fullscreen windows. That can be worked around by adding `checkDock --> doLower` to manageHook, but it starts to smell of too many workarounds.

[1]: https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#STACKINGORDER

The fix is to request PropertyChange events for all windows that we treat as docks.

Related: https://github.com/xmonad/xmonad-contrib/pull/406
Related: https://github.com/xmonad/xmonad-contrib/pull/490

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)