### PR TITLE
X.L.Magnifier: Add `magnifierczOff` and `magnifierczOff'`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -487,6 +487,11 @@
 
     - Fixed a bug that prevented changing focus on inactive workspaces.
 
+  * `XMonad.Layout.Magnifier`
+
+    - Added `magnifierczOff` and `magnifierczOff'` for custom-size
+      magnifiers that start out with magnifying disabled.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -84,7 +84,7 @@ import XMonad.Util.XUtils
 
 -- | Increase the size of the window that has focus
 magnifier :: l a -> ModifiedLayout Magnifier l a
-magnifier = ModifiedLayout (Mag 1 (1.5,1.5) On All)
+magnifier = magnifiercz 1.5
 
 -- | Change the size of the window that has focus by a custom zoom
 magnifiercz :: Rational -> l a -> ModifiedLayout Magnifier l a
@@ -93,7 +93,12 @@ magnifiercz cz = ModifiedLayout (Mag 1 (fromRational cz, fromRational cz) On All
 -- | Increase the size of the window that has focus, unless if it is one of the
 -- master windows.
 magnifier' :: l a -> ModifiedLayout Magnifier l a
-magnifier' = ModifiedLayout (Mag 1 (1.5,1.5) On NoMaster)
+magnifier' = magnifiercz' 1.5
+
+-- | Increase the size of the window that has focus by a custom zoom,
+-- unless if it is one of the the master windows.
+magnifiercz' :: Rational -> l a -> ModifiedLayout Magnifier l a
+magnifiercz' cz = ModifiedLayout (Mag 1 (fromRational cz, fromRational cz) On NoMaster)
 
 -- | Magnifier that defaults to Off
 magnifierOff :: l a -> ModifiedLayout Magnifier l a
@@ -102,11 +107,6 @@ magnifierOff = ModifiedLayout (Mag 1 (1.5,1.5) Off All)
 -- | A magnifier that greatly magnifies with defaults to Off
 maxMagnifierOff :: l a -> ModifiedLayout Magnifier l a
 maxMagnifierOff = ModifiedLayout (Mag 1 (1000,1000) Off All)
-
--- | Increase the size of the window that has focus by a custom zoom,
--- unless if it is one of the the master windows.
-magnifiercz' :: Rational -> l a -> ModifiedLayout Magnifier l a
-magnifiercz' cz = ModifiedLayout (Mag 1 (fromRational cz, fromRational cz) On NoMaster)
 
 -- | A magnifier that greatly magnifies just the vertical direction
 maximizeVertical :: l a -> ModifiedLayout Magnifier l a
@@ -123,7 +123,7 @@ data MagnifyMaster = All | NoMaster deriving  (Read, Show)
 instance LayoutModifier Magnifier Window where
     redoLayout  (Mag _ z On All     ) r (Just s) wrs = applyMagnifier z r s wrs
     redoLayout  (Mag n z On NoMaster) r (Just s) wrs = unlessMaster n (applyMagnifier z) r s wrs
-    redoLayout  _                   _ _        wrs = return (wrs, Nothing)
+    redoLayout  _                     _ _        wrs = return (wrs, Nothing)
 
     handleMess (Mag n z On  t) m
                     | Just MagnifyMore    <- fromMessage m = return . Just $ Mag n             (z `addto`   0.1 ) On  t
@@ -164,7 +164,7 @@ magnify (zoomx,zoomy) (Rectangle x y w h) = Rectangle x' y' w' h'
 
 fit :: Rectangle -> Rectangle -> Rectangle
 fit (Rectangle sx sy sw sh) (Rectangle x y w h) = Rectangle x' y' w' h'
-    where x' = max sx (x - (max 0 (x + fi w - sx - fi sw)))
-          y' = max sy (y - (max 0 (y + fi h - sy - fi sh)))
+    where x' = max sx (x - max 0 (x + fi w - sx - fi sw))
+          y' = max sy (y - max 0 (y + fi h - sy - fi sh))
           w' = min sw w
           h' = min sh h

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -20,13 +20,21 @@
 module XMonad.Layout.Magnifier
     ( -- * Usage
       -- $usage
+
+      -- * Magnify Everything
       magnifier,
-      magnifier',
       magnifierOff,
-      maxMagnifierOff,
       magnifiercz,
-      magnifiercz',
+      magnifierczOff,
+      maxMagnifierOff,
       maximizeVertical,
+
+      -- * Don't Magnify the Master Window
+      magnifier',
+      magnifiercz',
+      magnifierczOff',
+
+      -- * Messages and Types
       MagnifyMsg (..),
       Magnifier,
     ) where
@@ -102,11 +110,20 @@ magnifiercz' cz = ModifiedLayout (Mag 1 (fromRational cz, fromRational cz) On No
 
 -- | Magnifier that defaults to Off
 magnifierOff :: l a -> ModifiedLayout Magnifier l a
-magnifierOff = ModifiedLayout (Mag 1 (1.5,1.5) Off All)
+magnifierOff = magnifierczOff 1.5
 
--- | A magnifier that greatly magnifies with defaults to Off
+-- | A magnifier that greatly magnifies the focused window; defaults to
+-- @Off@.
 maxMagnifierOff :: l a -> ModifiedLayout Magnifier l a
-maxMagnifierOff = ModifiedLayout (Mag 1 (1000,1000) Off All)
+maxMagnifierOff = magnifierczOff 1000
+
+-- | Like 'magnifiercz', but default to @Off@.
+magnifierczOff :: Rational -> l a -> ModifiedLayout Magnifier l a
+magnifierczOff cz = ModifiedLayout (Mag 1 (fromRational cz, fromRational cz) Off All)
+
+-- | Like 'magnifiercz'', but default to @Off@.
+magnifierczOff' :: Rational -> l a -> ModifiedLayout Magnifier l a
+magnifierczOff' cz = ModifiedLayout (Mag 1 (fromRational cz, fromRational cz) Off NoMaster)
 
 -- | A magnifier that greatly magnifies just the vertical direction
 maximizeVertical :: l a -> ModifiedLayout Magnifier l a

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -132,7 +132,21 @@ maximizeVertical = ModifiedLayout (Mag 1 (1,1000) Off All)
 data MagnifyMsg = MagnifyMore | MagnifyLess | ToggleOn | ToggleOff | Toggle deriving ( Typeable )
 instance Message MagnifyMsg
 
-data Magnifier a = Mag !Int (Double,Double) Toggle MagnifyMaster deriving (Read, Show)
+-- | The type for magnifying a given type; do note that the given type
+-- @a@ is a phantom type.
+data Magnifier a = Mag !Int !(Double, Double) !Toggle !MagnifyMaster
+    deriving (Read, Show)
+-- The constructors are documented here due to a bug in haddock with GHC
+-- 8.4.x (TODO: Change this when we bump the GHC version lower bound).
+-- Since they are an implementation detail and are thus subject to
+-- change, this is not top-level documentation.
+--
+-- - Int:  How many windows there are in the master pane.
+-- - (Double, Double): Zoom-factor in the @x@ and @y@ direction; the
+--   window's width and height will be multiplied by these amounts when
+--   magnifying.
+-- - Toggle: Whether to magnify windows at all.
+-- - MagnifyMaster: Magnify only the master, or all windows.
 
 data Toggle        = On  | Off      deriving  (Read, Show)
 data MagnifyMaster = All | NoMaster deriving  (Read, Show)


### PR DESCRIPTION
### Description

Closes #168

Add the `magnifierczOff` and `magnifierczOff'` functions for custom-size magnification, with it being off by default.  This seems preferrable to exporting the internal constructor, so we can change that if necessary.  

There is also a bit of cleanup in there, like strictifying the `Magnifier` type and implementing functions in terms of each other for easier maitnenance, that I didn't think were worth their own pr. 

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
