### PR TITLE
X.L.Magnifier: Add `magnify` combinator, magnification at `n` windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -516,6 +516,10 @@
     - Added `magnifierczOff` and `magnifierczOff'` for custom-size
       magnifiers that start out with magnifying disabled.
 
+    - Added `magnify` as a more general combinator, including the
+      ability to postpone magnifying until there are a certain number of
+      windows on the workspace.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE DeriveDataTypeable, MultiParamTypeClasses, TypeSynonymInstances, PatternGuards #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE PatternGuards              #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Layout.Magnifier
@@ -157,16 +160,16 @@ instance LayoutModifier Magnifier Window where
     redoLayout  _                     _ _        wrs = return (wrs, Nothing)
 
     handleMess (Mag n z On  t) m
-                    | Just MagnifyMore    <- fromMessage m = return . Just $ Mag n             (z `addto`   0.1 ) On  t
-                    | Just MagnifyLess    <- fromMessage m = return . Just $ Mag n             (z `addto` (-0.1)) On  t
-                    | Just ToggleOff      <- fromMessage m = return . Just $ Mag n             z                  Off t
-                    | Just Toggle         <- fromMessage m = return . Just $ Mag n             z                  Off t
-                    | Just (IncMasterN d) <- fromMessage m = return . Just $ Mag (max 0 (n+d)) z                  On  t
-                    where addto (x,y) i = (x+i,y+i)
+        | Just MagnifyMore    <- fromMessage m = return . Just $ Mag n             (z `addto`   0.1 ) On  t
+        | Just MagnifyLess    <- fromMessage m = return . Just $ Mag n             (z `addto` (-0.1)) On  t
+        | Just ToggleOff      <- fromMessage m = return . Just $ Mag n             z                  Off t
+        | Just Toggle         <- fromMessage m = return . Just $ Mag n             z                  Off t
+        | Just (IncMasterN d) <- fromMessage m = return . Just $ Mag (max 0 (n+d)) z                  On  t
+      where addto (x, y) i = (x + i, y + i)
     handleMess (Mag n z Off t) m
-                    | Just ToggleOn       <- fromMessage m = return . Just $ Mag n             z                  On  t
-                    | Just Toggle         <- fromMessage m = return . Just $ Mag n             z                  On  t
-                    | Just (IncMasterN d) <- fromMessage m = return . Just $ Mag (max 0 (n+d)) z                  Off t
+        | Just ToggleOn       <- fromMessage m = return . Just $ Mag n             z                  On  t
+        | Just Toggle         <- fromMessage m = return . Just $ Mag n             z                  On  t
+        | Just (IncMasterN d) <- fromMessage m = return . Just $ Mag (max 0 (n+d)) z                  Off t
     handleMess _ _ = return Nothing
 
     modifierDescription (Mag _ _ On  All     ) = "Magnifier"

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -12,8 +12,8 @@
 -- Stability   :  unstable
 -- Portability :  unportable
 --
--- This is a layout modifier that will make a layout increase the size
--- of the window that has focus.
+-- This is a layout modifier that will make a layout change the size of
+-- the window that has focus.
 --
 -- [Example screenshot using @magnifiercz' 1.3@ with one of the two stack windows focused.](https://user-images.githubusercontent.com/50166980/108524842-c5f69380-72cf-11eb-9fd6-b0bf67b13ed6.png)
 --
@@ -59,26 +59,30 @@ import XMonad.Util.XUtils
 --
 -- > import XMonad.Layout.Magnifier
 --
--- Then edit your @layoutHook@ by adding the 'magnifier' layout modifier
--- to some layout:
+-- Then edit your @layoutHook@ by e.g. adding the 'magnifier' layout
+-- modifier to some layout:
 --
 -- > myLayout = magnifier (Tall 1 (3/100) (1/2))  ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- By default magnifier increases the focused window's size by 1.5.
--- You can also use:
+-- By default 'magnifier' increases the focused window's size by @1.5@.
 --
--- > magnifiercz 1.2
+-- You can also use @'magnifiercz' 1.2@ to use a custom level of
+-- magnification.  You can even make the focused window smaller for a
+-- pop in effect.  There's also the possibility of starting out not
+-- magnifying anything at all ('magnifierOff'); see below for ways to
+-- toggle this on while in use.
 --
--- to use a custom level of magnification.  You can even make the focused
--- window smaller for a pop in effect.
+-- The most general combinator available is 'magnify'—all of the other
+-- functions in this module are essentially just creative applications
+-- of it.
 --
 -- For more detailed instructions on editing the layoutHook see:
 --
 -- "XMonad.Doc.Extending#Editing_the_layout_hook"
 --
--- Magnifier supports some commands. To use them add something like
--- this to your key bindings:
+-- Magnifier supports some commands, see 'MagnifyMsg'.  To use them add
+-- something like this to your key bindings:
 --
 -- >    , ((modm .|. controlMask              , xK_plus ), sendMessage MagnifyMore)
 -- >    , ((modm .|. controlMask              , xK_minus), sendMessage MagnifyLess)
@@ -102,7 +106,7 @@ import XMonad.Util.XUtils
 
 -- | Add magnification capabilities to a certain layout.
 --
--- For example, to re-create @'magnifiercz'' 1.3@, you would do
+-- For example, to re-create 'magnifiercz' 1.3', you would do
 --
 -- >>> magnify 1.3 (NoMaster 1) On
 --

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -108,7 +108,7 @@ import XMonad.Util.XUtils
 --
 -- For example, to re-create 'magnifiercz' 1.3', you would do
 --
--- >>> magnify 1.3 (NoMaster 1) On
+-- >>> magnify 1.3 (NoMaster 1) True
 --
 magnify
     :: Rational     -- ^ Amount to magnify both directions


### PR DESCRIPTION
### Description

Add the ability to only start magnifying when a certain number of windows is reached.  As a byproduct, cleans up the rather embarassing mistake made in bb205e92051de531c6c8b7eb1d692779969b6710 to not just transform everything into a record.

Also add a more general `magnify` function that subsumes (almost) all previously known combinators.  This needs exporting of some previously internal (but not crucial to the implementation) types, but the internals are still changeable easily enough. 

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
