### PR TITLE
Fix bug #420, add some functions to IndependentScreens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -609,6 +609,22 @@
     - The decoration window now sets a `WM_CLASS` property.  This allows
       other applications, like compositors, to properly match on it.
 
+  * `XMonad.Layout.IndependentScreens`
+
+    - Fixed a bug where `marshallPP` always sorted workspace names
+      lexically.  This changes the default behaviour of `marshallPP`—the
+      given `ppSort` now operates in the _physical_ workspace names.
+      The documentation of `marshallSort` contains an example of how to
+      get the old behaviour, where `ppSort` operates in virtual names,
+      back.
+
+    - Added `workspacesOn` for filtering workspaces on the current screen.
+
+    - Added `withScreen` to specify names for a given single screen.
+
+    - Added new aliases `PhysicalWindowSpace` and `VirtualWindowSpace`
+      for a `WindowSpace` for easier to read function signatures.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Actions/CopyWindow.hs
+++ b/XMonad/Actions/CopyWindow.hs
@@ -18,7 +18,7 @@ module XMonad.Actions.CopyWindow (
                                  -- * Usage
                                  -- $usage
                                  copy, copyToAll, copyWindow, runOrCopy
-                                 , killAllOtherCopies, kill1
+                                 , killAllOtherCopies, kill1, taggedWindows, copiesOfOn
                                  -- * Highlight workspaces containing copies in logHook
                                  -- $logHook
                                  , wsContainingCopies

--- a/XMonad/Config/Dmwit.hs
+++ b/XMonad/Config/Dmwit.hs
@@ -25,7 +25,7 @@ import XMonad.Hooks.DynamicLog
 import XMonad.Hooks.ManageDocks
 import XMonad.Hooks.ManageHelpers
 import XMonad.Layout.Grid
-import XMonad.Layout.IndependentScreens
+import XMonad.Layout.IndependentScreens hiding (withScreen)
 import XMonad.Layout.Magnifier
 import XMonad.Layout.NoBorders
 import XMonad.Prelude


### PR DESCRIPTION
### Description
So basically I add:
1. `withNthWorkspaceScreen` to make it work with dynamicWorkspces
2. `copyWindowTo` to make it work with CopyWindow
3. `marshallSort'` (minor changes) to let it work properly with getSortByIndex
4. `wsContainingCopies` to let it detect copied windows properly (with CopyWindow)
5. `withScreen` (minor changes) to allow for different workspace names for each monitor

I am not sure if some function should be put in XMonad.Layout.IndependentScreens or other places.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
