### PR TITLE
`X.H.StatusBar`: Removed unnecessary IO

### DIFF
--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -198,7 +198,7 @@ statusBar :: LayoutClass l Window
           -> IO (XConfig (ModifiedLayout AvoidStruts l))
 statusBar cmd pp k conf= do
   sb <- statusBarPipe cmd (pure pp)
-  withEasySB sb k conf
+  return $ withEasySB sb k conf
 
 -- |
 -- Helper function which provides ToggleStruts keybinding
@@ -260,7 +260,6 @@ dynamicLogXinerama = withWindowSet $ io . putStrLn . pprWindowSetXinerama
 -- the menu bar.
 xmobarProp :: LayoutClass l Window
            => XConfig l  -- ^ The base config
-           -> IO (XConfig (ModifiedLayout AvoidStruts l))
-xmobarProp conf = do
-    xmobarPropConfig <- statusBarProp "xmobar" (pure xmobarPP)
-    withEasySB xmobarPropConfig toggleStrutsKey conf
+           -> XConfig (ModifiedLayout AvoidStruts l)
+xmobarProp =
+  withEasySB (statusBarProp "xmobar" (pure xmobarPP)) toggleStrutsKey


### PR DESCRIPTION
### Description

This is a follow-up on the IRC [discussion](https://ircbrowse.tomsmeding.com/browse/xmonad?id=28392#trid28392)

This applies for `withSB` and `withEasySB`, as well as `statusBarProp` and
`statusBarPropTo`, making composability better. `statusBarPipe` is more
awkward to use now, but that's fine

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
