### PR TITLE
add KeepWordsLeft and KeepWordsRight for X.L.Renamed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -522,6 +522,11 @@
       ability to postpone magnifying until there are a certain number of
       windows on the workspace.
 
+  * `XMonad.Layout.Renamed`
+
+    - Added `KeepWordsLeft` and `KeepWordsRight` for keeping certain number of 
+      words in left or right direction in layout description.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/Renamed.hs
+++ b/XMonad/Layout/Renamed.hs
@@ -46,6 +46,8 @@ data Rename a = CutLeft Int -- ^ Remove a number of characters from the left
               | Prepend String -- ^ Add a string on the left
               | CutWordsLeft Int -- ^ Remove a number of words from the left
               | CutWordsRight Int -- ^ Remove a number of words from the right
+              | KeepWordsLeft Int -- ^ Keep a number of words from the left
+              | KeepWordsRight Int -- ^ Keep a number of words from the right
               | AppendWords String -- ^ Add a string to the right, prepending a space to it
                                    -- if necessary
               | PrependWords String -- ^ Add a string to the left, appending a space to it if
@@ -59,7 +61,10 @@ apply (CutLeft i) s = drop i s
 apply (CutRight i) s = take (length s - i) s
 apply (CutWordsLeft i) s = unwords $ drop i $ words s
 apply (CutWordsRight i) s = let ws = words s
-                           in unwords $ take (length ws - i) ws
+                           in unwords $ take (length ws - i) ws                        
+apply (KeepWordsLeft i) s = unwords $ take i $ words s
+apply (KeepWordsRight i) s = let ws = words s
+                           in unwords $ drop (length ws - i) ws
 apply (Replace s) _ = s
 apply (Append s') s = s ++ s'
 apply (Prepend s') s = s' ++ s


### PR DESCRIPTION
### Description

Add `KeepWordsLeft` and `KeepWordsRight` as stated in https://github.com/xmonad/xmonad-contrib/issues/482
I think these are only minor changes.
@TheMC47 I am not sure if I have done it right.
The only problem I encountered is that the layout information shown in xmobar does not change over restart. So I have to exit and start xmonad multiple times for testing. 

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
