### PR TITLE
X.Prompt: Special handling of one highlighted item

### DIFF
--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -410,9 +410,10 @@ highlightedItem st' completions = case complWinDim st' of
       (_,_,_,_,xx,yy) = winDim
       complMatrix = splitInSubListsAt (length yy) (take (length xx * length yy) completions)
       (col_index,row_index) = complIndex st'
-    in case completions of
-      [] -> Nothing
-      _  -> complMatrix !? col_index >>= (!? row_index)
+    in case length completions of
+      0 -> Nothing
+      1 -> Just $ complMatrix !! col_index !! row_index
+      _ -> complMatrix !? col_index >>= (!? row_index)
  where
   -- | Safe version of '(!!)'.
   (!?) :: [a] -> Int -> Maybe a


### PR DESCRIPTION
### Description

Fixes a bug introduced in f2cfaa33980061f4fb39b689403701d36babe33f.

The changes there allowed the prompt to cycle through its input; it now
becomes necessary to single out the case of only having a single
suggestion that's also highlighted.  Otherwise, `hlComplete` (condition:
`alwaysHighlight` is enabled) will loop forever.  This case can't be
handled from within hlComplete, as we are giving it incomplete
information to start with (by only calling it with the last word of the
current completion in `handleCompletion`), which is necessary for things
like completing arguments.

Sigh.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~
  I don't think this is really necessary.

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
