### PR TITLE
X.P.Shell: add `safeDirPrompt`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -289,6 +289,9 @@
     - Added `compgenDirectories` and `compgenFiles` to get the directory/filename completion
       matches returned by the compgen shell builtin.
 
+    - Added `safeDirPrompt`, which is like `safePrompt`, but optimized
+      for the use-case of a program that needs a file as an argument.
+
   * `XMonad.Prompt.Unicode`
 
     - Reworked internally to call `spawnPipe` (asynchronous) instead of


### PR DESCRIPTION
### Description

A new prompt that works like `safePrompt`, but is optimized for the
use-case of a program that needs a file as an argument.

This is necessarily a new function and can't just be achieved by using
the old `safePrompt`, as `getShellCompl'` does not at all filter the
files (compgen already does that based on the input), but only the
available commands.  If we start the prompt with a single command then
the chosen `searchPredicate` becomes quite useless and we can't take
advantage of fuzzy matching for file finding.  This, however, is quite
useful when having a program that explicitly expects a file as one of
its arguments, e.g. dragon [1].

What we have to do instead of to generate all available files with
compgen and _then_ filter this down to what we want via a given
function.  In order to make this change backwards compatible we have to
introduce the rather ugly `shellComplImpl`, which takes a laundry list
of all of the different parameters that we need.  Since the function is
not exported, this ugliness does perhaps not matter too much.

[1]: https://github.com/mwh/dragon

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [X] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
