### PR TITLE
Add `MINIMAL` pragmas to `HasName` and `XPrompt`

### DIFF
--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -222,17 +222,23 @@ instance XPrompt XPType where
     completionFunction  (XPT t) = completionFunction  t
     modeAction          (XPT t) = modeAction          t
 
--- | The class prompt types must be an instance of. In order to
--- create a prompt you need to create a data type, without parameters,
--- and make it an instance of this class, by implementing a simple
--- method, 'showXPrompt', which will be used to print the string to be
--- displayed in the command line window.
+-- | A class for an abstract prompt. In order for your data type to be a
+-- valid prompt you _must_ make it an instance of this class.
 --
--- This is an example of a XPrompt instance definition:
+-- The minimal complete definition is just 'showXPrompt', i.e. the name
+-- of the prompt. This string will be displayed in the command line
+-- window (before the cursor).
 --
+-- As an example of a complete 'XPrompt' instance definition, we can
+-- look at the 'XMonad.Prompt.Shell.Shell' prompt from
+-- "XMonad.Prompt.Shell":
+--
+-- >     data Shell = Shell
+-- >
 -- >     instance XPrompt Shell where
 -- >          showXPrompt Shell = "Run: "
 class XPrompt t where
+    {-# MINIMAL showXPrompt #-}
 
     -- | This method is used to print the string to be
     -- displayed in the command line window.

--- a/XMonad/Util/NamedActions.hs
+++ b/XMonad/Util/NamedActions.hs
@@ -119,6 +119,7 @@ spawn' :: String -> NamedAction
 spawn' x = addName x $ spawn x
 
 class HasName a where
+    {-# MINIMAL getAction #-}
     showName :: a -> [String]
     showName = const [""]
     getAction :: a -> X ()


### PR DESCRIPTION
### Description

This adds a `MINIMAL` pragma to the classes that should have one, i.e. the classes that have at least one function with a default implementation and at least one without. 

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
