### PR TITLE
X.Prompt: fix selection not entering history

### DIFF
--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -611,6 +611,10 @@ runXP st = do
     (\status ->
       execStateT
         (when (status == grabSuccess) $ do
+          ah <- gets (alwaysHighlight . config)
+          when ah $ do
+            compl <- listToMaybe <$> getCompletions
+            modify' $ \xpst -> xpst{ highlightedCompl = compl }
           updateWindows
           eventLoop handleMain evDefaultStop)
         st


### PR DESCRIPTION
### Description

When `alwaysHighlight` is enabled and one immediately presses (by
default) Return after opening the prompt (because the highlighted
completion is what one wants) then the selection will not enter the
prompt history.  Instead, an empty string will be entered because there
hasn't been any input yet and hence the `highlightedCompl` field has not
yet been filled in.

The fix is simply checking whether `alwaysHighlight` is set during
startup and, if yes, already setting the highlighted completion to the
first suggestion.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~
  The relevant entry of 

>    - Made the history respect words that were "completed" by `alwaysHighlight`
>      upon confirmation of the selection by the user.

  already covers this.

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
