### PR TITLE
ClickableWorkspace Improvement for X.A.DynamicWorkspaces

### DIFF
--- a/XMonad/Util/ClickableWorkspaces.hs
+++ b/XMonad/Util/ClickableWorkspaces.hs
@@ -26,8 +26,9 @@ import Data.Functor ((<&>))
 
 import XMonad
 import XMonad.Hooks.StatusBar.PP (xmobarAction, PP(..))
-import XMonad.Util.WorkspaceCompare (getWsIndex)
+import XMonad.Util.WorkspaceCompare (getSortByIndex)
 import qualified XMonad.StackSet as W
+import Data.List (elemIndex)
 
 -- $usage
 -- If you're using the "XMonad.Hooks.StatusBar" interface, apply 'clickablePP'
@@ -54,6 +55,19 @@ import qualified XMonad.StackSet as W
 -- workspace @i@.
 clickableWrap :: Int -> String -> String
 clickableWrap i ws = xmobarAction ("xdotool set_desktop " ++ show i) "1" ws
+
+-- Note that 'getWsIndex' from "XMonad.Util.WorkspaceCompare" only works for
+-- predefined workspaces. When used together with "XMonad.Action.DynamicWorkspaces",
+-- 'getWsIndex' needs to be rewritten to get the correct index of a workspace.
+-- The workspace order perceived by @xdotool@ is the same as that by 'getSortByIndex'.
+-- So 'getSortByIndex' is used in such case.
+
+-- | Return the index of a workspace if it exists.
+getWsIndex :: X (WorkspaceId -> Maybe Int)
+getWsIndex = do
+    wSort <- getSortByIndex
+    spaces <- gets (map W.tag . wSort . W.workspaces . windowset)
+    return $ flip elemIndex spaces
 
 -- | Return a function that wraps workspace names in an xmobar action that
 -- switches to that workspace.


### PR DESCRIPTION
### Description
To solve https://github.com/xmonad/xmonad-contrib/issues/510, I add a `getWsIndex` in it. `getWsIndex` will call `getSortByIndex`.
The reason are as follows: 
1. Using X.A.DynamicWorkspaces, by adding and deleting workspaces, the total number of workspaces varies.
2. I have tried to use a more general form, that is, use `[Windowspace]->[Windowspace]` and let ClickablePP receive a `X WorkspaceSort'`. However, I discovered that when using `getSortByTag`, the order of workspaces in `xdotool` is still similar to `getSortByIndex`. In other words, `getSortByTag` is useless here or we need to modify the workspace order received by `xdotool`. I don't know how to solve it.

Solution to address problem from `reason 2`: 
      User use `withNthworkspaces` and `getSortByTag`. Which means user needs to define such keybinding themselves and then we                  have function such as
```
"<action=xdotool key super+"++show key++">"++" "++ws++" "++"</action>"
         where key = keypad'' !! num
```
### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
