### PR TITLE
Redefined `ComplCaseSensitivity` as a proper sum type. (#509)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -491,6 +491,8 @@
     - Added `maxComplColumns` field to `XPConfig`, to limit the number of
       columns in the completion window.
 
+    - Redefine `ComplCaseSensitivity` to a proper sum type as opposed to a newtype wrapped around Bool.
+
   * `XMonad.Actions.TreeSelect`
 
     - Fixed a crash when focusing a new window while the tree select

--- a/XMonad/Layout/WorkspaceDir.hs
+++ b/XMonad/Layout/WorkspaceDir.hs
@@ -62,7 +62,7 @@ import XMonad.StackSet ( tag, currentTag )
 -- If you prefer a prompt with case-insensitive completion:
 --
 -- >  , ((modm .|. shiftMask, xK_x     ),
---       changeDir def {complCaseSensitivity = ComplCaseSensitive False})
+--       changeDir def {complCaseSensitivity = CaseInSensitive})
 --
 -- For detailed instruction on editing the key binding see:
 --

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -208,7 +208,7 @@ type ComplFunction = String -> IO [String]
 type XPMode = XPType
 data XPOperationMode = XPSingleMode ComplFunction XPType | XPMultipleModes (W.Stack XPType)
 
-newtype ComplCaseSensitivity = ComplCaseSensitive Bool
+data ComplCaseSensitivity = CaseSensitive | CaseInSensitive
 
 instance Show XPType where
     show (XPT p) = showXPrompt p
@@ -341,7 +341,7 @@ instance Default XPConfig where
         , defaultText           = []
         , autoComplete          = Nothing
         , showCompletionOnTab   = False
-        , complCaseSensitivity  = ComplCaseSensitive True
+        , complCaseSensitivity  = CaseSensitive
         , searchPredicate       = isPrefixOf
         , alwaysHighlight       = False
         , defaultPrompter       = id

--- a/XMonad/Prompt/Directory.hs
+++ b/XMonad/Prompt/Directory.hs
@@ -47,7 +47,7 @@ directoryPrompt c prom f = mkXPrompt (Dir prom csn f) c (getDirCompl csn) f
 directoryMultipleModes :: String            -- ^ Prompt.
                        -> (String -> X ())  -- ^ Action.
                        -> XPType
-directoryMultipleModes = directoryMultipleModes' (ComplCaseSensitive True)
+directoryMultipleModes = directoryMultipleModes' CaseSensitive
 
 -- | Like @directoryMultipleModes@ with a parameter for completion case-sensitivity.
 directoryMultipleModes' :: ComplCaseSensitivity -- ^ Completion case sensitivity.

--- a/XMonad/Prompt/Shell.hs
+++ b/XMonad/Prompt/Shell.hs
@@ -98,7 +98,7 @@ unsafePrompt c config = mkXPrompt Shell config (getShellCompl [c] $ searchPredic
     where run a = unsafeSpawn $ c ++ " " ++ a
 
 getShellCompl :: [String] -> Predicate -> String -> IO [String]
-getShellCompl = getShellCompl' (ComplCaseSensitive True)
+getShellCompl = getShellCompl' CaseSensitive
 
 getShellCompl' :: ComplCaseSensitivity -> [String] -> Predicate -> String -> IO [String]
 getShellCompl' csn cmds p s | s == "" || last s == ' ' = return []
@@ -128,8 +128,10 @@ compgen csn actionOpt s = runProcessWithInput "bash" [] $
     complCaseSensitivityCmd csn ++ " ; " ++ compgenCmd actionOpt s
 
 complCaseSensitivityCmd :: ComplCaseSensitivity -> String
-complCaseSensitivityCmd (ComplCaseSensitive b) =
-    "bind 'set completion-ignore-case " ++ (if b then "off" else "on") ++ "'"
+complCaseSensitivityCmd CaseSensitive =
+    "bind 'set completion-ignore-case off'"
+complCaseSensitivityCmd CaseInSensitive =
+    "bind 'set completion-ignore-case on'"
 
 compgenCmd :: String -> String -> String
 compgenCmd actionOpt s = "compgen -A " ++ actionOpt ++ " -- " ++ s ++ "\n"


### PR DESCRIPTION
### Description

This is my first time submitting a pull request of any kind, so please tell me if I've done anything incorrectly.

This PR is an implementation of the suggestion in issue #509, with all relevant functions changed so as to expect the rewritten datatype. 

### Checklist

  - [✔️] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [✔️] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [✔️] I updated the `CHANGES.md` file

  - [✔️] I updated the `XMonad.Doc.Extending` file (if appropriate)
