### PR TITLE
add support for multiple formats for X.H.Wallpapersetter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -537,6 +537,14 @@
     - Added `KeepWordsLeft` and `KeepWordsRight` for keeping certain number of
       words in left or right direction in layout description.
 
+  * `XMonad.Hooks.WallpaperSetter`
+
+    - Added `defWPNamesPng`, which works like `defWPNames` but maps
+      `ws-name` to `ws-name.png` instead of `ws-name.jpg`.
+
+    - Added `defWPNamesJpg` as an alias to `defWPNames` and deprecated
+      the latter.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Hooks/WallpaperSetter.hs
+++ b/XMonad/Hooks/WallpaperSetter.hs
@@ -19,7 +19,7 @@ module XMonad.Hooks.WallpaperSetter (
 , Wallpaper(..)
 , WallpaperList(..)
 , defWallpaperConf
-, defWPNames
+, defWPNamesJpg, defWPNamesPng, defWPNames
   -- *TODO
   -- $todo
 ) where
@@ -34,7 +34,7 @@ import System.FilePath ((</>))
 import System.Random (randomRIO)
 
 import qualified Data.Map as M
-import Data.List (intersperse, sortBy)
+import Data.List (sortBy)
 import Data.Char (isAlphaNum)
 import Data.Ord (comparing)
 
@@ -82,7 +82,7 @@ newtype WallpaperList = WallpaperList [(WorkspaceId, Wallpaper)]
 instance Monoid WallpaperList where
   mempty = WallpaperList []
   mappend (WallpaperList w1) (WallpaperList w2) =
-    WallpaperList $ M.toList $ (M.fromList w2) `M.union` (M.fromList w1)
+    WallpaperList $ M.toList $ M.fromList w2 `M.union` M.fromList w1
 
 instance Semigroup WallpaperList where
   (<>) = mappend
@@ -100,9 +100,17 @@ defWallpaperConf = WallpaperConf "" $ WallpaperList []
 instance Default WallpaperConf where
     def = defWallpaperConf
 
--- |returns the default association list (maps name to name.jpg, non-alphanumeric characters are omitted)
+{-# DEPRECATED defWPNames "Use defWPNamesJpg instead" #-}
 defWPNames :: [WorkspaceId] -> WallpaperList
-defWPNames xs = WallpaperList $ map (\x -> (x,WallpaperFix (filter isAlphaNum x++".jpg"))) xs
+defWPNames = defWPNamesJpg
+
+-- | Return the default association list (maps @name@ to @name.jpg@, non-alphanumeric characters are omitted)
+defWPNamesJpg :: [WorkspaceId] -> WallpaperList
+defWPNamesJpg xs = WallpaperList $ map (\x -> (x, WallpaperFix (filter isAlphaNum x ++ ".jpg"))) xs
+
+-- | Like 'defWPNamesJpg', but map @name@ to @name.png@ instead.
+defWPNamesPng :: [WorkspaceId] -> WallpaperList
+defWPNamesPng xs = WallpaperList $ map (\x -> (x, WallpaperFix (filter isAlphaNum x ++ ".png"))) xs
 
 -- | Add this to your log hook with the workspace configuration as argument.
 wallpaperSetter :: WallpaperConf -> X ()
@@ -158,7 +166,6 @@ getPicRes picpath = do
     [[(w,"")],[(h,"")]] -> Just (w,h)
     _ -> Nothing
 
-
 -- |complete unset fields to default values (wallpaper directory = ~/.wallpapers,
 --  expects a file "NAME.jpg" for each workspace named NAME)
 completeWPConf :: WallpaperConf -> X WallpaperConf
@@ -196,20 +203,20 @@ applyWallpaper parts = do
   winset <- gets windowset
   let (vx,vy) = getVScreenDim winset
   layers <- liftIO $ mapM layerCommand parts
-  let basepart ="convert -size "++show vx++"x"++show vy++" xc:black "
+  let basepart ="convert -size " ++ show vx ++ "x" ++ show vy ++ " xc:black"
       endpart =" jpg:- | feh --no-xinerama --bg-tile --no-fehbg -"
-      cmd = basepart ++ (concat $ intersperse " " layers) ++ endpart
+      cmd = basepart ++ unwords layers ++ endpart
   liftIO $ runCommand cmd
 
 
 getVScreenDim :: S.StackSet i l a sid ScreenDetail -> (Integer, Integer)
-getVScreenDim = foldr maxXY (0,0) . map (screenRect . S.screenDetail) . S.screens
-  where maxXY (Rectangle x y w h) (mx,my) = ( fromIntegral ((fromIntegral x)+w) `max` mx
-                                            , fromIntegral ((fromIntegral y)+h) `max` my )
+getVScreenDim = foldr (maxXY . screenRect . S.screenDetail) (0,0) . S.screens
+  where maxXY (Rectangle x y w h) (mx,my) = ( fromIntegral (fromIntegral x+w) `max` mx
+                                            , fromIntegral (fromIntegral y+h) `max` my )
 
 needsRotation :: Rectangle -> (Int,Int) -> Bool
 needsRotation rect (px,py) = let wratio, pratio :: Double
-                                 wratio = (fromIntegral $ rect_width rect) / (fromIntegral $ rect_height rect)
+                                 wratio = fromIntegral (rect_width rect) / fromIntegral (rect_height rect)
                                  pratio = fromIntegral px / fromIntegral py
                              in wratio > 1 && pratio < 1 || wratio < 1 && pratio > 1
 
@@ -221,4 +228,4 @@ layerCommand (rect, path) = do
     Just rotate -> let size = show (rect_width rect) ++ "x" ++ show (rect_height rect) in
                      " \\( '"++path++"' "++(if rotate then "-rotate 90 " else "")
                       ++ " -scale "++size++"^ -gravity center -extent "++size++" +gravity \\)"
-                      ++ " -geometry +"++(show$rect_x rect)++"+"++(show$rect_y rect)++" -composite "
+                      ++ " -geometry +" ++ (show $rect_x rect) ++ "+" ++ (show $rect_y rect) ++ " -composite "


### PR DESCRIPTION
### Description
As discussed in https://github.com/xmonad/xmonad-contrib/issues/518
I just clean a bit of the syntax and have tested the module. It is painfully slow with noticeable lagging. As I don't know how to implement a cache for the images, I can not improve the performance. The `todo` by previous author(s) also mentioned about caching.

Use `feh` without `convert` will see an small boost in performance. But that is up to the users to decide. 

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
