### PR TITLE
X.Prompt: Document, simplify completion window implementation

### DIFF
--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -1499,20 +1499,20 @@ printPrompt drw = do
   -- flip back to the original colors and print the rest of the string
   draw (fgNormal color) (bgNormal color) (x + fi (pcFont + cFont)) y postCursor
 
--- get the current completion function depending on the active mode
-getCompletionFunction :: XPState -> ComplFunction
-getCompletionFunction st = case operationMode st of
-  XPSingleMode compl _ -> compl
-  XPMultipleModes modes -> completionFunction $ W.focus modes
-
--- Completions
+-- | Get all available completions for the current input.
 getCompletions :: XP [String]
 getCompletions = do
-  s <- get
-  let q     = commandToComplete (currentXPMode s) (command s)
-      compl = getCompletionFunction s
-      srt   = sorter (config s)
-  io $ (srt q <$> compl q) `E.catch` \(SomeException _) -> return []
+  st@XPS{ config } <- get
+  let cmd   = commandToComplete (currentXPMode st) (command st)
+      compl = getCompletionFunction st
+      srt   = sorter config
+  io $ (srt cmd <$> compl cmd) `E.catch` \(SomeException _) -> return []
+ where
+  -- | Get the current completion function depending on the active mode.
+  getCompletionFunction :: XPState -> ComplFunction
+  getCompletionFunction st = case operationMode st of
+    XPSingleMode compl _ -> compl
+    XPMultipleModes modes -> completionFunction $ W.focus modes
 
 destroyComplWin :: XP ()
 destroyComplWin = do

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -1579,29 +1579,24 @@ getComplWinDim compl = do
 
   pure $ ComplWindowDim x y winWidth rowHeight xCols yRows
 
+-- | Draw the completion window.
 drawComplWin :: Window -> [String] -> XP ()
 drawComplWin w compl = do
-  st <- get
-  let c   = config st
-      cr  = color st
-      d   = dpy st
-      scr = defaultScreenOfDisplay d
-      bw  = promptBorderWidth c
-      gc  = gcon st
-  Just bgcolor <- io $ initColor d (bgNormal cr)
-  Just borderC <- io $ initColor d (border cr)
+  XPS{ config, color, dpy, gcon } <- get
+  let scr = defaultScreenOfDisplay dpy
+      bw  = promptBorderWidth config
+  Just bgcolor <- io $ initColor dpy (bgNormal color)
+  Just borderC <- io $ initColor dpy (border color)
+  ComplWindowDim{ cwWidth, cwRowHeight, cwCols, cwRows } <- getComplWinDim compl
 
-  ComplWindowDim{cwWidth,cwRowHeight,cwCols,cwRows} <- getComplWinDim compl
-
-  p <- io $ createPixmap d w cwWidth cwRowHeight
-                         (defaultDepthOfScreen scr)
-  io $ fillDrawable d p gc borderC bgcolor (fi bw) cwWidth cwRowHeight
+  p <- io $ createPixmap dpy w cwWidth cwRowHeight (defaultDepthOfScreen scr)
+  io $ fillDrawable dpy p gcon borderC bgcolor (fi bw) cwWidth cwRowHeight
   let ac = chunksOf (length cwRows) (take (length cwCols * length cwRows) compl)
 
-  printComplList d p gc (fgNormal cr) (bgNormal cr) cwCols cwRows ac
+  printComplList dpy p gcon (fgNormal color) (bgNormal color) cwCols cwRows ac
   --lift $ spawn $ "xmessage " ++ " ac: " ++ show ac  ++ " xx: " ++ show xx ++ " length xx: " ++ show (length xx) ++ " yy: " ++ show (length yy)
-  io $ copyArea d p w gc 0 0 cwWidth cwRowHeight 0 0
-  io $ freePixmap d p
+  io $ copyArea dpy p w gcon 0 0 cwWidth cwRowHeight 0 0
+  io $ freePixmap dpy p
 
 -- Finds the column and row indexes in which a string appears.
 -- if the string is not in the matrix, the indexes default to (0,0)

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -1385,20 +1385,25 @@ data ComplWindowDim = ComplWindowDim
   }
   deriving (Eq)
 
+-- | Create the prompt window.
 createPromptWin :: Display -> Window -> XPConfig -> Rectangle -> IO Window
-createPromptWin d rw c s = do
-  let (x,y) = case position c of
-                Top -> (0,0)
-                Bottom -> (0, rect_height s - height c)
-                CenteredAt py w -> (floor $ fi (rect_width s) * ((1 - w) / 2), floor $ py * fi (rect_height s) - (fi (height c) / 2))
-      width = case position c of
-                CenteredAt _ w -> floor $ fi (rect_width s) * w
-                _              -> rect_width s
-  w <- mkUnmanagedWindow d (defaultScreenOfDisplay d) rw
-                      (rect_x s + x) (rect_y s + fi y) width (height c)
-  setClassHint d w (ClassHint "xmonad-prompt" "xmonad")
-  mapWindow d w
+createPromptWin dpy rootw XPC{ position, height } scn = do
+  w <- mkUnmanagedWindow dpy (defaultScreenOfDisplay dpy) rootw
+                      (rect_x scn + x) (rect_y scn + y) width height
+  setClassHint dpy w (ClassHint "xmonad-prompt" "xmonad")
+  mapWindow dpy w
   return w
+ where
+  (x, y) :: (Position, Position) = fi <$> case position of
+    Top             -> (0, 0)
+    Bottom          -> (0, rect_height scn - height)
+    CenteredAt py w ->
+      ( floor $ fi (rect_width scn) * ((1 - w) / 2)
+      , floor $ py * fi (rect_height scn) - (fi height / 2)
+      )
+  width :: Dimension = case position of
+    CenteredAt _ w -> floor $ fi (rect_width scn) * w
+    _              -> rect_width scn
 
 --- | Update all prompt windows.
 updateWindows :: XP ()

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -1514,14 +1514,13 @@ getCompletions = do
     XPSingleMode compl _ -> compl
     XPMultipleModes modes -> completionFunction $ W.focus modes
 
+-- | Destroy the currently drawn completion window, if there is one.
 destroyComplWin :: XP ()
 destroyComplWin = do
-  d  <- gets dpy
-  cw <- gets complWin
-  wr <- gets complWinRef
-  case cw of
-    Just w -> do io $ destroyWindow d w
-                 io $ writeIORef wr Nothing
+  XPS{ dpy, complWin, complWinRef } <- get
+  case complWin of
+    Just w -> do io $ destroyWindow dpy w
+                 io $ writeIORef complWinRef Nothing
                  modify (\s -> s { complWin = Nothing, complWinDim = Nothing })
     Nothing -> return ()
 


### PR DESCRIPTION
### Description

`X.Prompt` is big.  And ugly.  I'd really like to revamp some of the internals (thankfully none of the `XPState` stuff is exported) but quite frankly I just don't understand some of the code in its current state.  This is a first effort to document some of the internal functions, so they may be more greatly simplified in the future.  I focused mostly on the X-specific part of the completion window implementation but this is still pretty long, sorry about that.

There are already a few simplifications in here that I couldn't resist making straight away:

* [X.Prompt: Make ComplWindowDim a proper type](https://github.com/xmonad/xmonad-contrib/commit/728e933848a317a5b2a31fadb37f65c8748d07a3)
  This gets rid of the horrible tuple implementation
  ``` haskell
    type ComplWindowDim = (Position,Position,Dimension,Dimension,Columns,Rows)
  ```
  and makes this a proper record type so we can a) give its fields meaningful names and b) make these fields strict.

* [X.Prompt: Simplify nextComplIndex](https://github.com/xmonad/xmonad-contrib/commit/34244f343f37a1cb58abdfa143f0368924f5b9dd)
  The logic for deciding in `nextComplIndex` was simplified and the extra argument was removed.

* [X.Prompt: Remove non-IORef complWin](https://github.com/xmonad/xmonad-contrib/commit/591d94204517d604426a90cc92be01d0efc7740b)
  We used to have two `complWin` fields, but they were always updated in tandem.  This means that we can just get rid of one of the fields. 

* [X.Prompt: Calculate prompt width once at the start](https://github.com/xmonad/xmonad-contrib/commit/ff856badf6f4849085c3eea1a27538b947d56855)
  The prompt doesn't change its size while it's open, so it suffices to calculate its width once at the start.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
