### PR TITLE
X.U.EZConfig: Simplify removeKeys, removeMouseBindings

### DIFF
--- a/XMonad/Util/EZConfig.hs
+++ b/XMonad/Util/EZConfig.hs
@@ -109,7 +109,7 @@ additionalKeysP conf keyList =
 -- >                 `removeKeys` [(mod1Mask .|. shiftMask, n) | n <- [xK_1 .. xK_9]]
 removeKeys :: XConfig a -> [(KeyMask, KeySym)] -> XConfig a
 removeKeys conf keyList =
-    conf { keys = \cnf -> keys conf cnf `M.difference` M.fromList (zip keyList $ repeat ()) }
+    conf { keys = \cnf -> foldr M.delete (keys conf cnf) keyList }
 
 -- | Like 'removeKeys', except using short @String@ key descriptors
 --   like @\"M-m\"@ instead of @(modMask, xK_m)@, as described in the
@@ -130,8 +130,7 @@ additionalMouseBindings conf mouseBindingsList =
 -- | Like 'removeKeys', but for mouse bindings.
 removeMouseBindings :: XConfig a -> [(ButtonMask, Button)] -> XConfig a
 removeMouseBindings conf mouseBindingList =
-    conf { mouseBindings = \cnf -> mouseBindings conf cnf `M.difference`
-                                   M.fromList (zip mouseBindingList $ repeat ()) }
+    conf { mouseBindings = \cnf -> foldr M.delete (mouseBindings conf cnf) mouseBindingList }
 
 
 --------------------------------------------------------------


### PR DESCRIPTION
### Description

This is a small one, but everything that brings down our global LOC is good, I guess :)

We're not parsing anything (as opposed to the respective `P` functions)
and so there's no need to create a dummy map with units as values and
then take the difference; we can simply remove the relevant keys from
the map.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  ~~- [ ] I updated the `CHANGES.md` file~~

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
