### PR TITLE
Move `ppTitleUnfocused` to X.U.Loggers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,9 +107,6 @@
     - Added `filterOutWsPP` for filtering out certain workspaces from being
       displayed.
 
-    - Added `ppTitleUnfocused` to `PP` for showing unfocused windows on
-      the current workspace in the status bar.
-
     - Added `xmobarBorder` function to create borders around strings.
 
     - Added `ppRename` to `PP`, which makes it possible for extensions like
@@ -416,6 +413,8 @@
 
     - Added `logConst` to log a constant `String`, and `logDefault` (infix: `.|`)
       to combine loggers.
+
+    - Added `logTitles` to log all window titles (focused and unfocused ones).
 
   * `XMonad.Layout.Minimize`
 


### PR DESCRIPTION
### Description

This replaces `ppTitleUnfocused` from commit
a3e0668 with a more extensible version,
containing more information about the window and being able to operate
on the focused window as well.

The functionality provided is a strict superset of `ppTitle`, though
that function is kept for backwards compatibility.

This plays nicely with #463 for lazy people like me who want their bars to read from the same property, as showing windows only if they're on the current screen is now easily possible (see the example). 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)

  - [x] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
