### PR TITLE
Documentation tweaks for `X.H.StatusBar(.PP)`

### DIFF
--- a/XMonad/Hooks/StatusBar.hs
+++ b/XMonad/Hooks/StatusBar.hs
@@ -339,6 +339,9 @@ statusBarPipe cmd xpp  = do
 -- property, their content will be the same. If you want to use property-based
 -- logging with multiple bars, they should read from different properties.
 --
+-- "XMonad.Util.Loggers" includes loggers that can be bound to specific screens,
+-- like 'logCurrentOnScreen', that might be useful with multiple screens.
+--
 -- Long-time xmonad users will note that the above config is equivalent to
 -- the following less robust and more verbose configuration that they might
 -- find in their old configs:

--- a/XMonad/Hooks/StatusBar/PP.hs
+++ b/XMonad/Hooks/StatusBar/PP.hs
@@ -100,7 +100,9 @@ data PP = PP { ppCurrent :: WorkspaceId -> String
              , ppWsSep :: String
                -- ^ separator to use between workspace tags
              , ppTitle :: String -> String
-               -- ^ window title format for the focused window
+               -- ^ window title format for the focused window. To display
+               -- the titles of all windows—even unfocused ones—check
+               -- 'XMonad.Util.Loggers.logTitles'.
              , ppTitleSanitize :: String -> String
               -- ^ escape / sanitizes input to 'ppTitle'
              , ppLayout :: String -> String

--- a/XMonad/Hooks/StatusBar/PP.hs
+++ b/XMonad/Hooks/StatusBar/PP.hs
@@ -68,9 +68,8 @@ import XMonad.Hooks.UrgencyHook
 -- > import XMonad.Hooks.StatusBar.PP
 -- >
 -- > myPP = def { ppCurrent = xmobarColor "black" "white" }
--- > main = do
--- >   mySB <- statusBarProp "xmobar" (pure myPP)
--- >   xmonad =<< withEasySB mySB defToggleStrutsKey myConfig
+-- > mySB = statusBarProp "xmobar" (pure myPP)
+-- > main = xmonad . withEasySB mySB defToggleStrutsKey $ myConfig
 --
 -- Check "XMonad.Hooks.StatusBar" for more examples and an in depth
 -- explanation.


### PR DESCRIPTION
### Description

The example in `X.H.StatusBar.PP` wasn't updated when we removed the `X` from `statusBarProp`, and #535 shows that the loggers weren't really discoverable.

@slotThe do you think this is better?

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  ~- [ ] I tested my changes with [xmonad-testing](https://github.com/xmonad/xmonad-testing)~

  ~- [ ] I updated the `CHANGES.md` file~

  ~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~
