### PR TITLE
`X.A.DynamicWorkspaceGroups`: TopicSpace support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -231,6 +231,11 @@
 
   * Add support for GHC 9.0.1.
 
+  * `XMonad.Actions.DynamicWorkspaceGroups`
+
+    - Add support for `XMonad.Actions.TopicSpace` through `viewTopicGroup` and
+      `promptTopicGroupView`.
+
   * `XMonad.Actions.TreeSelect`
 
     - Fix swapped green/blue in foreground when using Xft.

--- a/XMonad/Actions/DynamicWorkspaceGroups.hs
+++ b/XMonad/Actions/DynamicWorkspaceGroups.hs
@@ -160,12 +160,16 @@ promptWSGroupForget xp s = do
   mkXPrompt (WSGPrompt s) xp (mkComplFunFromList' xp gs) forgetWSGroup
 
 -- $topics
--- You can use this module with "XMonad.Actions.TopicSpace" - just replace
+-- You can use this module with "XMonad.Actions.TopicSpace" — just replace
 -- 'promptWSGroupView' with 'promptTopicGroupView':
 --
 -- >    , ("M-y n", promptWSGroupAdd myXPConfig "Name this group: ")
 -- >    , ("M-y g", promptTopicGroupView myTopicConfig myXPConfig "Go to group: ")
 -- >    , ("M-y d", promptWSGroupForget myXPConfig "Forget group: ")
+--
+-- It's also a good idea to replace 'spawn' with
+-- 'XMonad.Actions.SpawnOn.spawnOn' or 'XMonad.Actions.SpawnOn.spawnHere' in
+-- your topic actions, so everything is spawned where it should be.
 
 -- | Prompt for a workspace group to view, treating the workspaces as topics.
 promptTopicGroupView :: TopicConfig -> XPConfig -> String -> X ()


### PR DESCRIPTION
### Description

This adds `viewTopicGroup` and a corresponding prompt. This is similar
to `viewWSGroup`, but it calls `switchTopic` instead of `W.greedyView`,
in order to run the topic action on the workspace.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: it works

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
