### PR TITLE
X.A.TreeSelect: Only swap green/blue for X11-xft < 0.3.3

### DIFF
--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -655,8 +655,16 @@ drawStringXMF display window visual colormap gc font col x y text = case font of
 --
 -- Note that it uses short to represent its components
 fromARGB :: Pixel -> XRenderColor
-fromARGB x = XRenderColor (fromIntegral $ 0xff00 .&. shiftR x 8)  -- red
-                          (fromIntegral $ 0xff00 .&. shiftL x 8)  -- blue   (swapped with green as a workaround for the
-                          (fromIntegral $ 0xff00 .&. x)           -- green   faulty Storable instance in X11-xft <= 0.3.1)
-                          (fromIntegral $ 0xff00 .&. shiftR x 16) -- alpha
+fromARGB x =
+#if MIN_VERSION_X11_xft(0, 3, 3)
+    XRenderColor r g b a
+#else
+    -- swapped green/blue as a workaround for the faulty Storable instance in X11-xft < 0.3.3
+    XRenderColor r b g a
+#endif
+  where
+    r = fromIntegral $ 0xff00 .&. shiftR x 8
+    g = fromIntegral $ 0xff00 .&. x
+    b = fromIntegral $ 0xff00 .&. shiftL x 8
+    a = fromIntegral $ 0xff00 .&. shiftR x 16
 #endif


### PR DESCRIPTION
### Description

The issue was fixed upstream in 0.3.3:
https://github.com/clefru/X11-xft/commit/24f6275791f2212215047f7af898750b7846810e
https://github.com/clefru/X11-xft/commit/24f6275791f2212215047f7af898750b7846810e^
(it is yet to be uploaded to Hackage, Clemens lost his Hackage credentials :-))

Related: https://github.com/xmonad/xmonad-contrib/pull/486
Related: 46f24bb27ec4 ("X.A.TreeSelect: Fix swapped green/blue in foreground when using Xft")

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

     I tested it manually in ghci.

  - n/a I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)