### PR TITLE
Add Sponsor button to GitHub

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github:
+  - liskin


### PR DESCRIPTION
### Description

These past months I've spent a lot of time working on xmonad and I feel like I've done a lot. This is, however, not sustainable long term. :-(

I'd like to try making my GitHub Sponsors profile a bit more visible, hoping that would allow me to continue dedicating time to xmonad.

I know that the correct approach probably is for the xmonad project to find a fiscal sponsor like the Software Freedom Conservancy or Open Collective or something and accept donations as a project, and then redistribute that to people, but I don't think the project has enough momentum to do something as complicated as that. :-/

---

@xmonad/core @slotThe @TheMC47 Are you folks okay with me doing this? Can I put that on https://github.com/xmonad/xmonad as well? Would you like to add your profile as well (I checked all of your profiles and none of you have a Sponsors profile yet, though)?