### PR TITLE
X.H.ManageDocks: Fix button events on decoration windows

### DIFF
--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -142,7 +142,8 @@ manageDocks = checkDock --> (doIgnore <+> doRequestDockEvents)
 -- (Only if not already a client to avoid overriding 'clientMask')
 requestDockEvents :: Window -> X ()
 requestDockEvents w = whenX (not <$> isClient w) $ withDisplay $ \dpy ->
-    io $ selectInput dpy w (propertyChangeMask .|. structureNotifyMask)
+    withWindowAttributes dpy w $ \attrs -> io $ selectInput dpy w $
+        wa_your_event_mask attrs .|. propertyChangeMask .|. structureNotifyMask
 
 -- | Checks if a window is a DOCK or DESKTOP window
 checkDock :: Query Bool


### PR DESCRIPTION
### Description

Decoration windows are created using XMonad.Util.XUtils.createNewWindow
which happens to set _NET_WM_WINDOW_TYPE to _NET_WM_WINDOW_TYPE_DESKTOP,
and ManageDocks considers such windows candidates for struts and
therefore requests property events, thus overriding the original event
mask requested by decorations.

The fix is to first obtain the current event mask, set the required bits
in it only then reset the mask.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/517
Fixes: ec146171238b ("X.H.ManageDocks: React to strut updates of override_redirect docks")
Related: https://github.com/xmonad/X11/pull/77

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    I tested this manually and I've verified that dragging works now and
    that https://github.com/xmonad/xmonad-contrib/pull/492 isn't
    regressed either. We do not and will not have the infrastructure to
    write an automated test for this, unfortunately.

  - n/a I updated the `CHANGES.md` file

    This is a recent regression of git master, no need to clutter the
    CHANGES.

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)