### PR TITLE
Set `WM_CLASS` for some windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@
       constraint (was: `IO`), due to changes in how the xmonad core handles XDG
       directories.
 
+    - The prompt window now sets a `WM_CLASS` property.  This allows
+      other applications, like compositors, to properly match on it.
+
   * `XMonad.Hooks.EwmhDesktops`
 
     - It is no longer recommended to use `fullscreenEventHook` directly.
@@ -250,6 +253,10 @@
   * `XMonad.Actions.TreeSelect`
 
     - Fix swapped green/blue in foreground when using Xft.
+
+    - The spawned tree-select window now sets a `WM_CLASS` property.
+      This allows other applications, like compositors, to properly
+      match on it.
 
   * `XMonad.Layout.Fullscreen`
 
@@ -571,6 +578,11 @@
 
     - Add the ability to increase/decrease the window size by a custom
       rational number. E.g: `sendMessage $ ExpandTowardsBy L 0.02`
+
+  * `XMonad.Layout.Decoration`
+
+    - The decoration window now sets a `WM_CLASS` property.  This allows
+      other applications, like compositors, to properly match on it.
 
 ## 0.16
 

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -317,7 +317,9 @@ treeselectAt conf@TSConfig{..} zipper hist = withDisplay $ \display -> do
         set_colormap attributes colormap
         set_background_pixel attributes ts_background
         set_border_pixel attributes 0
-        createWindow display rootw rect_x rect_y rect_width rect_height 0 (visualInfo_depth vinfo) inputOutput (visualInfo_visual vinfo) (cWColormap .|. cWBorderPixel .|. cWBackPixel) attributes
+        w <- createWindow display rootw rect_x rect_y rect_width rect_height 0 (visualInfo_depth vinfo) inputOutput (visualInfo_visual vinfo) (cWColormap .|. cWBorderPixel .|. cWBackPixel) attributes
+        setClassHint display w (ClassHint "xmonad-tree_select" "xmonad")
+        pure w
 
     liftIO $ do
         -- TODO: move below?

--- a/XMonad/Layout/Decoration.hs
+++ b/XMonad/Layout/Decoration.hs
@@ -377,8 +377,12 @@ createDecos t ds sc s wrs ((w,r):xs) = do
 createDecos _ _ _ _ _ [] = return []
 
 createDecoWindow :: Theme -> Rectangle -> X Window
-createDecoWindow t r = let mask = Just (exposureMask .|. buttonPressMask) in
-                       createNewWindow r mask (inactiveColor t) True
+createDecoWindow t r = do
+  let mask = Just (exposureMask .|. buttonPressMask)
+  w <- createNewWindow r mask (inactiveColor t) True
+  d <- asks display
+  io $ setClassHint d w (ClassHint "xmonad-decoration" "xmonad")
+  pure w
 
 showDecos :: [DecoWin] -> X ()
 showDecos = showWindows . catMaybes . map fst . filter (isJust . snd)

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -558,7 +558,7 @@ mkXPromptImplementation historyKey conf om = do
   fs <- initXMF (font conf)
   st' <- io $
     bracket
-      (createWin d rw conf s)
+      (createPromptWin d rw conf s)
       (destroyWindow d)
       (\w ->
         bracket
@@ -1395,8 +1395,8 @@ redrawWindows c = do
     l  -> redrawComplWin l
   io $ sync d False
 
-createWin :: Display -> Window -> XPConfig -> Rectangle -> IO Window
-createWin d rw c s = do
+createPromptWin :: Display -> Window -> XPConfig -> Rectangle -> IO Window
+createPromptWin d rw c s = do
   let (x,y) = case position c of
                 Top -> (0,0)
                 Bottom -> (0, rect_height s - height c)
@@ -1406,6 +1406,7 @@ createWin d rw c s = do
                 _              -> rect_width s
   w <- mkUnmanagedWindow d (defaultScreenOfDisplay d) rw
                       (rect_x s + x) (rect_y s + fi y) width (height c)
+  setClassHint d w (ClassHint "xmonad-prompt" "xmonad")
   mapWindow d w
   return w
 


### PR DESCRIPTION
### Description

Fixes:
  - https://github.com/xmonad/xmonad-contrib/issues/526
  - https://github.com/xmonad/xmonad-contrib/issues/369

Set the WM_CLASS property for long-living windows that need it.  This
helps users to properly match on these windows for certain tasks.

This needs a new X11 release, hence it's a draft for now.  I also didn't change the bounds in the cabal file, as #545 has already done this and I expect this will get merged sooner. 

I was a bit conservative with what to set properties for.  Things like X.U.EZConfig also create windows that may very well have such a property, but I didn't think they were long-lived enough to warrant it really.  Feel free to point me to more modules that need it and I'll add them.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: 

    I tested this by hand and it works.  I don't think we can really tests these kinds of interaction with the X server.

  - [x] I updated the `CHANGES.md` file

  ~~- [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)~~
