### PR TITLE
Add xmobarFont

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,6 +117,8 @@
       `workspaceNamesPP`, `marshallPP` and/or `clickablePP` to compose
       intuitively.
 
+    - Added `xmobarFont` for selecting an xmobar font index
+
 
   * `XMonad.Hooks.StatusBar`
 

--- a/XMonad/Hooks/StatusBar/PP.hs
+++ b/XMonad/Hooks/StatusBar/PP.hs
@@ -36,7 +36,7 @@ module XMonad.Hooks.StatusBar.PP (
 
     -- * Formatting utilities
     wrap, pad, trim, shorten, shorten', shortenLeft, shortenLeft',
-    xmobarColor, xmobarAction, xmobarBorder,
+    xmobarColor, xmobarFont, xmobarAction, xmobarBorder,
     xmobarRaw, xmobarStrip, xmobarStripTags,
     dzenColor, dzenEscape, dzenStrip, filterOutWsPP,
 
@@ -285,6 +285,12 @@ dzenStrip = strip [] where
       | '^' == head x       = strip keep (drop 1 . dropWhile (/= ')') $ x)
       | otherwise           = let (good,x') = span (/= '^') x
                               in strip (keep ++ good) x'
+
+-- | Use xmobar escape codes to output a string with the font at the given index
+xmobarFont :: Int     -- ^ index: index of the font to use (0: standard font)
+           -> String  -- ^ output string
+           -> String
+xmobarFont index = wrap ("<fn=" ++ show index ++ ">") "</fn>"
 
 -- | Use xmobar escape codes to output a string with given foreground
 --   and background colors.


### PR DESCRIPTION
### Description

xmobar allows you to define a list of additional fonts (`additionalFonts`) and to use the fn tag to choose between them (by passing in the index of the font to use). `xmobarFont` is essentially the same as the existing `xmobarColor` function, but for fonts.

Specifically, I use this to use an icon font for my workspaces, but I imagine this can be useful for other situations as well.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit, manually, ...) and concluded: manually - this is a very small change that rests almost entirely on the `wrap` function.

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate) - N/A
