### PR TITLE
X.H.EwmhDesktops: Ignore _NET_WM_STATE_FULLSCREEN from unmanaged windows

### DIFF
--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -307,6 +307,7 @@ fullscreenStartup = setFullscreenSupported
 -- Note this is not included in 'ewmh'.
 fullscreenEventHook :: Event -> X All
 fullscreenEventHook (ClientMessageEvent _ _ _ dpy win typ (action:dats)) = do
+  managed <- isClient win
   wmstate <- getAtom "_NET_WM_STATE"
   fullsc <- getAtom "_NET_WM_STATE_FULLSCREEN"
   wstate <- fromMaybe [] <$> getProp32 wmstate win
@@ -319,7 +320,7 @@ fullscreenEventHook (ClientMessageEvent _ _ _ dpy win typ (action:dats)) = do
       toggle = 2
       chWstate f = io $ changeProperty32 dpy win wmstate aTOM propModeReplace (f wstate)
 
-  when (typ == wmstate && fi fullsc `elem` dats) $ do
+  when (managed && typ == wmstate && fi fullsc `elem` dats) $ do
     when (action == add || (action == toggle && not isFull)) $ do
       chWstate (fi fullsc:)
       windows $ W.float win $ W.RationalRect 0 0 1 1


### PR DESCRIPTION
### Description

This prevents an unnecessary refresh.

That refresh would normally be harmless but it does reset the input focus, which happens to upset some non-conforming clients such as https://github.com/flameshot-org/flameshot. Flameshot is an interactive screenshot tool that creates an override-redirect fullscreen window to let the user select a rectangle to capture and then allows drawing and adding text and so on, but it unfortunately doesn't follow ICCCM recommendations:

> If it is necessary for a client to receive keystrokes on an override-redirect window, either the client must grab the keyboard, or the client must have another top-level window that is not override-redirect and that has selected the Locally Active or Globally Active focus model.

Instead, it just takes input focus and hopes for the best. And it also sends an entirely useless `_NET_WM_STATE_FULLSCREEN` request, which would trigger a refresh and take that focus away.

This commit works around that by not handling that useless `_NET_WM_STATE_FULLSCREEN` for unmanaged windows and thus preventing that refresh. It's just a workaround, however: if a legitimate refresh is necessary at any point, the focus _will_ be taken away.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/550
Fixes: https://github.com/flameshot-org/flameshot/issues/773

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    I tested this manually.

  - [ ] I updated the `CHANGES.md` file

    Not sure if this is worth a changelog entry, as fullscreen handling
    was refactored a bit since 0.16 and will be refactored even more
    before 0.17.

  - [X] I updated the `XMonad.Doc.Extending` file (if appropriate)
