### PR TITLE
`X.A.CycleWS`: deprecate `WSType` constructors, add `ignoringWSs` predicate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,7 +116,7 @@
   - `XMonad.Actions.CycleWS`
 
     - Deprecated `EmptyWS`, `HiddenWS`, `NonEmptyWS`, `HiddenNonEmptyWS`,
-      `HiddenEmptyWS`, `AnyWS` and `WSTagGroup`
+      `HiddenEmptyWS`, `AnyWS` and `WSTagGroup`.
 
 ### New Modules
 
@@ -642,6 +642,10 @@
 
     - Added `hiddenWS`, `emptyWS` and `anyWS` to replace deprecated
       constructors.
+
+    - Added `ingoringWSs` as a `WSType` predicate to skip workspaces having a
+      tag in a given list.
+
 
 ## 0.16
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,11 @@
 
     - Removed the `Wrap` and `NextLayoutNoWrap` data constructors.
 
+  - `XMonad.Actions.CycleWS`
+
+    - Deprecated `EmptyWS`, `HiddenWS`, `NonEmptyWS`, `HiddenNonEmptyWS`,
+      `HiddenEmptyWS`, `AnyWS` and `WSTagGroup`
+
 ### New Modules
 
   * `XMonad.Hooks.StatusBar.PP`
@@ -629,6 +634,14 @@
 
     - Added `copiesPP` to make a `PP` aware of copies of the focused
       window.
+
+  - `XMonad.Actions.CycleWS`
+
+    - Added `:&:`, `:|:` and `Not` data constructors to `WSType` to logically
+      combine predicates.
+
+    - Added `hiddenWS`, `emptyWS` and `anyWS` to replace deprecated
+      constructors.
 
 ## 0.16
 

--- a/XMonad/Actions/CycleWS.hs
+++ b/XMonad/Actions/CycleWS.hs
@@ -67,6 +67,7 @@ module XMonad.Actions.CycleWS (
                               , hiddenWS
                               , anyWS
                               , wsTagGroup
+                              , ignoringWSs
 
                               , shiftTo
                               , moveTo
@@ -296,6 +297,15 @@ hiddenWS = WSIs $ do
 -- | Cycle through all workspaces
 anyWS :: WSType
 anyWS = WSIs . return $ const True
+
+-- | Cycle through workspaces that are not in the given list. This could, for
+--   example, be used for skipping the workspace reserved for
+--   "XMonad.Util.NamedScratchpad":
+--
+-- >  moveTo Next $ hidden :&: Not empty :&: ignoringWSs [scratchpadWorkspaceTag]
+--
+ignoringWSs :: [WorkspaceId] -> WSType
+ignoringWSs ts = WSIs . return $ (`notElem` ts) . tag
 
 -- | Cycle through workspaces in the same group, the
 --   group name is all characters up to the first

--- a/XMonad/Actions/SwapWorkspaces.hs
+++ b/XMonad/Actions/SwapWorkspaces.hs
@@ -53,7 +53,7 @@ swapWithCurrent t s = swapWorkspaces t (currentTag s) s
 -- | Say @swapTo Next@ or @swapTo Prev@ to move your current workspace.
 -- This is an @X ()@ so can be hooked up to your keybindings directly.
 swapTo :: Direction1D -> X ()
-swapTo dir = findWorkspace getSortByIndex dir AnyWS 1 >>= windows . swapWithCurrent
+swapTo dir = findWorkspace getSortByIndex dir anyWS 1 >>= windows . swapWithCurrent
 
 -- | Takes two workspace tags and an existing XMonad.StackSet and returns a new
 --   one with the two corresponding workspaces' tags swapped.

--- a/XMonad/Actions/WorkspaceNames.hs
+++ b/XMonad/Actions/WorkspaceNames.hs
@@ -48,7 +48,7 @@ import XMonad.Prelude (fromMaybe, isInfixOf, (<&>), (>=>))
 import qualified XMonad.StackSet as W
 import qualified XMonad.Util.ExtensibleState as XS
 
-import XMonad.Actions.CycleWS (findWorkspace, WSType(..), Direction1D(..))
+import XMonad.Actions.CycleWS (findWorkspace, WSType(..), Direction1D(..), anyWS)
 import qualified XMonad.Actions.SwapWorkspaces as Swap
 import XMonad.Hooks.DynamicLog (PP(..))
 import XMonad.Prompt (mkXPrompt, XPConfig)
@@ -141,7 +141,7 @@ workspaceNamesPP pp = getWorkspaceNames ":" <&> \ren -> pp{ ppRename = ppRename 
 
 -- | See 'XMonad.Actions.SwapWorkspaces.swapTo'. This is the same with names.
 swapTo :: Direction1D -> X ()
-swapTo dir = swapTo' dir AnyWS
+swapTo dir = swapTo' dir anyWS
 
 -- | Swap with the previous or next workspace of the given type.
 swapTo' :: Direction1D -> WSType -> X ()

--- a/XMonad/Config/Droundy.hs
+++ b/XMonad/Config/Droundy.hs
@@ -39,8 +39,8 @@ import XMonad.Prompt.Shell ( shellPrompt )
 import XMonad.Actions.CopyWindow ( kill1, copy )
 import XMonad.Actions.DynamicWorkspaces ( withNthWorkspace, withWorkspace,
                                           selectWorkspace, renameWorkspace, removeWorkspace )
-import XMonad.Actions.CycleWS ( moveTo, WSType( HiddenNonEmptyWS ),
-                                Direction1D( Prev, Next) )
+import XMonad.Actions.CycleWS ( moveTo, hiddenWS, emptyWS,
+                                Direction1D( Prev, Next), WSType ((:&:), Not) )
 
 import XMonad.Hooks.ManageDocks ( avoidStruts, docks )
 import XMonad.Hooks.EwmhDesktops ( ewmh )
@@ -80,8 +80,8 @@ keys x = M.fromList $
     , ((modMask x .|. shiftMask, xK_Escape), io exitSuccess) -- %! Quit xmonad
     , ((modMask x              , xK_Escape), restart "xmonad" True) -- %! Restart xmonad
 
-    , ((modMask x .|. shiftMask, xK_Right), moveTo Next HiddenNonEmptyWS)
-    , ((modMask x .|. shiftMask, xK_Left), moveTo Prev HiddenNonEmptyWS)
+    , ((modMask x .|. shiftMask, xK_Right), moveTo Next $ hiddenWS :&: Not emptyWS)
+    , ((modMask x .|. shiftMask, xK_Left), moveTo Prev $ hiddenWS :&: Not emptyWS)
     , ((modMask x, xK_Right), sendMessage $ Go R)
     , ((modMask x, xK_Left), sendMessage $ Go L)
     , ((modMask x, xK_Up), sendMessage $ Go U)


### PR DESCRIPTION
### Description

### X.A.CycleWS: Deprecated WSType Data Constructors 
By deprecating everything except `WSIs` and adding constructors to
logically combine `WSType` values, we can have a more flexible interface.
Adding anything to the old interface would mean going through `WSIs`, and
all old constructors can be implemented in terms of `WSIs`.

### X.A.CycleWS: Added ignoringWSs
`ignoringWSs` is useful in combination with `X.U.NamedScratchpad` to
skip a list of tags


I went the extreme way of deprecating the constructors, but if you don't
think this is an improvement we could drop that commit and re-write
`ignoringWSs` as `WSType -> [WorkspaceId] -> WSType`. I don't see
the usefulness of the old constructors though.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes: manual testing

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
