### PR TITLE
added function shiftWin to PureX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -491,6 +491,8 @@
     - Added `focusWindow` and `focusNth` which don't refresh (and thus
       possibly flicker) when they happen to be a no-op.
 
+    - Added `shiftWin` as a refresh tracking version of `W.shiftWin`.
+
   * Several `LayoutClass` instances now have an additional `Typeable`
     constraint which may break some advanced configs. The upside is that we
     can now add `Typeable` to `LayoutClass` in `XMonad.Core` and make it

--- a/XMonad/Util/PureX.hs
+++ b/XMonad/Util/PureX.hs
@@ -46,7 +46,7 @@ module XMonad.Util.PureX (
   getStack, putStack, peek,
   focusWindow, focusNth,
   view, greedyView, invisiView,
-  shift, curScreen, curWorkspace,
+  shift, shiftWin, curScreen, curWorkspace,
   curTag, curScreenId,
 ) where
 
@@ -270,6 +270,16 @@ shift tag = withFocii $ \ctag fw ->
     modifyWindowSet' (W.shiftWin tag fw)
     mfw' <- peek
     return (Any $ Just fw /= mfw')
+
+-- | A refresh tracking version of @W.shiftWin@.
+shiftWin :: XLike m => WorkspaceId -> Window -> m Any
+shiftWin tag w = do
+  mtag <- gets $ W.findTag w . windowset
+  whenJust' mtag $ \wtag ->
+    when' (tag /= wtag) $ do
+      modifyWindowSet' $ W.shiftWin tag w
+      ntag <- gets $ W.findTag w . windowset
+      return (Any $ mtag /= ntag)
 
 -- | Internal. Refresh-tracking logic of focus operations.
 focusWith :: XLike m => (WindowSet -> WindowSet) -> m Any


### PR DESCRIPTION
### Description

Added the function `shiftWin` to `Xmonad.Util.PureX` as a refresh-tracking version of `W.shiftWin`.
This was a gap in the currently privded interface that I needed. 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

This PR only adds the function `shiftWin`, so unit tests on this function would suffice. For example, if the target tag or target window don't exist, then it should return `Any False`, if the window is already on the target tag, it should return `Any False`, in all other cases it should return `Any True`.

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
