### PR TITLE
X.U.NamedScratchpad: Add logHook to auto-hide named scratchpads on focus loss

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -379,6 +379,9 @@
 
      - Exported the `scratchpadWorkspaceTag`.
 
+     - Added a new logHook `nsHideOnFocusLoss` for hiding scratchpads
+       when they lose focus.
+
   * `XMonad.Prompt.Window`
 
     - Added `allApplications` function which maps application executable

--- a/XMonad/Hooks/RefocusLast.hs
+++ b/XMonad/Hooks/RefocusLast.hs
@@ -41,7 +41,9 @@ module XMonad.Hooks.RefocusLast (
   RecentWins(..),
   RecentsMap(..),
   RefocusLastLayoutHook(..),
-  RefocusLastToggle(..)
+  RefocusLastToggle(..),
+  -- * Library functions
+  withRecentsIn,
 ) where
 
 import XMonad
@@ -262,7 +264,7 @@ updateRecentsOn tag = withWindowSet $ \ws ->
 
 -- }}}
 
--- --< Private Utilities >-- {{{
+-- --< Utilities >-- {{{
 
 -- | Focuses the first window in the list it can find on the current workspace.
 tryFocus :: [Window] -> WindowSet -> WindowSet


### PR DESCRIPTION
### Description

Adds a new logHook, nsHideOnFocusLoss, that hides the given
scratchpads when they lose focus.  This is akin to the functionality
provided by a lot of dropdown terminals.

Relevant commits:

- X.H.RefocusLast: Export withRecentsIn

  This exports the `withRecentsIn` function, as it's quite useful when
  using X.H.RefocusLast in other modules as a library.

  It is already possible (RecentsMap is fully exported) to completely
  define this function outside of the module, so we are not exposing any
  more internals than we were before.

- X.U.NamedScratchpad: Add nsHideOnFocusLoss 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I don't think we have any proper setup for testing logHooks do we?  As far as I can tell, this is only using the reader/state part of `X`, so it should theoretically be possible...  

  - [x] I updated the `CHANGES.md` file

  - [n/a] I updated the `XMonad.Doc.Extending` file (if appropriate)
