### PR TITLE
Added iconFilterFunction to XMonad.Hooks.DynamicIcons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -190,6 +190,7 @@
   * `XMonad.Hooks.DynamicIcons`
 
     Added Dynamic Strings as `dynamicLogIconWithPP` based on a Workspaces Windows
+    Added ability to change to only show focused window
 
   * `XMonad.Hooks.WindowSwallowing`
 


### PR DESCRIPTION
### Description

Added iconFilterFunction to IconConfig so you can change the way of determining which icon to bring to focus.
e.g getMasterIcon to only show focused window as icon

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
