### PR TITLE
X.A.DynamicWorkspaceOrder: Export swapOrder and swapWithCurrent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -659,6 +659,9 @@
     - Added `ingoringWSs` as a `WSType` predicate to skip workspaces having a
       tag in a given list.
 
+  - `XMonad.Actions.DynamicWorkspaceOrder`
+
+    - Added `swapWithCurrent` and `swapOrder` to the list of exported names.
 
 ## 0.16
 

--- a/XMonad/Actions/DynamicWorkspaceOrder.hs
+++ b/XMonad/Actions/DynamicWorkspaceOrder.hs
@@ -21,6 +21,8 @@ module XMonad.Actions.DynamicWorkspaceOrder
       getWsCompareByOrder
     , getSortByOrder
     , swapWith
+    , swapWithCurrent
+    , swapOrder
     , updateName
     , removeName
 


### PR DESCRIPTION
### Description

The `swapWithCurrent` and `swapOrder` actions have been added to the list of exported names by the `X.A.DynamicWorkspaceOrder` module. They're very convenient for quickly changing the workspace order in ways that would normally take multiple calls to `swapWith`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested manually.

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
