### PR TITLE
fix compilation warning in DebugEvents.hs

### DIFF
--- a/XMonad/Hooks/DebugEvents.hs
+++ b/XMonad/Hooks/DebugEvents.hs
@@ -32,7 +32,9 @@ import           XMonad.Util.DebugWindow                     (debugWindow)
 -- import           Graphics.X11.Xlib.Extras.GetAtomName        (getAtomName)
 
 import           Control.Exception                    as E
+#if __GLASGOW_HASKELL__ <= 806
 import           Control.Monad.Fail
+#endif
 import           Control.Monad.State
 import           Control.Monad.Reader
 import           Codec.Binary.UTF8.String


### PR DESCRIPTION
### Description

This fixes the compilation warning:

```
XMonad/Hooks/DebugEvents.hs:35:1: warning: [-Wunused-imports]
    The import of ‘Control.Monad.Fail’ is redundant
      except perhaps to import instances from ‘Control.Monad.Fail’
    To import instances alone, use: import Control.Monad.Fail()
   |
35 | import           Control.Monad.Fail
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Context for the warning: https://wiki.haskell.org/MonadFail_Proposal

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit, manually, ...) and concluded: best to test this manually. We could enable `-Werror`, but that's too big of a change.

  - [x] I **didn't** update the `CHANGES.md` file because it's a very small internal change.

  - [x] I **didn't** update the `XMonad.Doc.Extending` file.
