### PR TITLE
rewrite GridSelect.stringToRatio to use randomR (fixes #572)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -122,6 +122,11 @@
     - Deprecated `EmptyWS`, `HiddenWS`, `NonEmptyWS`, `HiddenNonEmptyWS`,
       `HiddenEmptyWS`, `AnyWS` and `WSTagGroup`.
 
+  - `XMonad.Actions.GridSelect`
+
+    - `colorRangeFromClassName` now uses different hash function,
+      so colors of inactive window tiles will be different (but still inside
+      the provided color range).
 
 ### New Modules
 

--- a/XMonad/Actions/GridSelect.hs
+++ b/XMonad/Actions/GridSelect.hs
@@ -47,6 +47,7 @@ module XMonad.Actions.GridSelect (
     fromClassName,
     stringColorizer,
     colorRangeFromClassName,
+    stringToRatio,
 
     -- * Navigation Mode assembly
     TwoD,
@@ -93,7 +94,7 @@ import XMonad.Layout.Decoration
 import XMonad.Util.NamedWindows
 import XMonad.Actions.WindowBringer (bringWindow)
 import Text.Printf
-import System.Random (mkStdGen, genRange, next)
+import System.Random (mkStdGen, randomR)
 import Data.Word (Word8)
 
 -- $usage
@@ -628,15 +629,12 @@ mix (r1, g1, b1) (r2, g2, b2) r = (mix' r1 r2, mix' g1 g2, mix' b1 b2)
 
 -- | Generates a Double from a string, trying to
 -- achieve a random distribution.
--- We create a random seed from the sum of all characters
+-- We create a random seed from the hash of all characters
 -- in the string, and use it to generate a ratio between 0 and 1
 stringToRatio :: String -> Double
 stringToRatio "" = 0
-stringToRatio s = let gen = mkStdGen $ sum $ map fromEnum s
-                      range = (\(a, b) -> b - a) $ genRange gen
-                      randomInt = foldr1 combine $ replicate 20 next
-                      combine f1 f2 g = let (_, g') = f1 g in f2 g'
-                  in fi (fst $ randomInt gen) / fi range
+stringToRatio s = let gen = mkStdGen $ foldl' (\t c -> t * 31 + fromEnum c) 0 s
+                  in fst $ randomR (0, 1) gen
 
 -- | Brings up a 2D grid of elements in the center of the screen, and one can
 -- select an element with cursors keys. The selected element is returned.

--- a/tests/GridSelect.hs
+++ b/tests/GridSelect.hs
@@ -1,0 +1,15 @@
+module GridSelect where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+
+import XMonad.Actions.GridSelect
+
+spec :: Spec
+spec = do
+  prop "prop_stringToRatio_valuesInRange"  prop_stringToRatio_valuesInRange
+
+prop_stringToRatio_valuesInRange :: String -> Bool
+prop_stringToRatio_valuesInRange s =
+  let r = stringToRatio s
+  in r >= 0 && r <= 1

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -12,6 +12,7 @@ import qualified SwapWorkspaces
 import qualified XPrompt
 import qualified CycleRecentWS
 import qualified OrgMode
+import qualified GridSelect
 
 main :: IO ()
 main = hspec $ do
@@ -49,3 +50,4 @@ main = hspec $ do
     context "ExtensibleConf" ExtensibleConf.spec
     context "CycleRecentWS"  CycleRecentWS.spec
     context "OrgMode"        OrgMode.spec
+    context "GridSelect"     GridSelect.spec

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -375,6 +375,8 @@ test-suite tests
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   other-modules:  CycleRecentWS
+                  ExtensibleConf
+                  GridSelect
                   Instances
                   ManageDocks
                   NoBorders
@@ -383,31 +385,41 @@ test-suite tests
                   Selective
                   SwapWorkspaces
                   Utils
-                  ExtensibleConf
                   XMonad.Actions.CycleRecentWS
                   XMonad.Actions.CycleWS
                   XMonad.Actions.FocusNth
+                  XMonad.Actions.GridSelect
                   XMonad.Actions.PhysicalScreens
                   XMonad.Actions.RotateSome
                   XMonad.Actions.SwapWorkspaces
                   XMonad.Actions.TagWindows
+                  XMonad.Actions.WindowBringer
                   XMonad.Hooks.ManageDocks
+                  XMonad.Hooks.ManageHelpers
+                  XMonad.Hooks.UrgencyHook
                   XMonad.Hooks.WorkspaceHistory
+                  XMonad.Layout.Decoration
                   XMonad.Layout.LayoutModifier
                   XMonad.Layout.LimitWindows
                   XMonad.Layout.NoBorders
+                  XMonad.Layout.WindowArranger
                   XMonad.Prelude
                   XMonad.Prompt
                   XMonad.Prompt.OrgMode
                   XMonad.Prompt.Shell
+                  XMonad.Util.Dmenu
+                  XMonad.Util.Dzen
                   XMonad.Util.ExtensibleConf
                   XMonad.Util.ExtensibleState
                   XMonad.Util.Font
                   XMonad.Util.Image
+                  XMonad.Util.Invisible
+                  XMonad.Util.NamedWindows
                   XMonad.Util.PureX
                   XMonad.Util.Rectangle
                   XMonad.Util.Run
                   XMonad.Util.Stack
+                  XMonad.Util.Timer
                   XMonad.Util.Types
                   XMonad.Util.WindowProperties
                   XMonad.Util.WorkspaceCompare
@@ -423,6 +435,7 @@ test-suite tests
                , time >= 1.8 && < 1.12
                , hspec >= 2.4.0 && < 3
                , mtl
+               , random
                , process
                , unix
                , utf8-string


### PR DESCRIPTION
### Description

Due to differences between random-1.1 and random-1.2, on newer systems stringToRatio returns numbers outside [0, 1] range, which breaks colorRangeFromClassName colorizers.

This commit fixes the issue by using randomR to directly generate the random number.

Also this fixes the compilation warning (genRange and next are deprecated in random-1.2).

Instead of using sum of charactes I've elected use a simple hash - this will result in a bit less collisions (simple sums of characters collide quite often).

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit, manually, ...) and added a test for `stringToRatio` function.

  - [x] I updated the `CHANGES.md` file.

  - [x] I *didn't* update the `XMonad.Doc.Extending` file (not appropriate)
