### PR TITLE
X.L.NoBorders: Add OnlyFloat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -573,6 +573,9 @@
 
     - Fixed handling of floating window borders in multihead setups that was
       broken since 0.14.
+      
+    - Added `OnlyFloat` constructor to `Ambiguity` to unconditionally
+      remove all borders on floating windows.
 
   * `XMonad.Hooks.UrgencyHook`
 

--- a/XMonad/Layout/NoBorders.hs
+++ b/XMonad/Layout/NoBorders.hs
@@ -279,6 +279,8 @@ instance SetsAmbiguous Ambiguity where
                         in lr == wr1 && (not . or) vu
                     OnlyLayoutFloat ->
                         lr == wr1
+                    OnlyFloat ->
+                        True
                     _ ->
                         wr1 `R.supersetOf` sr
                 return w1
@@ -288,6 +290,7 @@ instance SetsAmbiguous Ambiguity where
               | Screen <- amb = [w]
               | OnlyScreenFloat <- amb = []
               | OnlyLayoutFloat <- amb = []
+              | OnlyFloat <- amb = []
               | OnlyLayoutFloatBelow <- amb = []
               | OtherIndicated <- amb
               , let nonF = map integrate $ W.current wset : W.visible wset
@@ -326,6 +329,9 @@ data Ambiguity
         -- ^ Focus in an empty screen does not count as ambiguous.
     | OtherIndicated
         -- ^ No borders on full when all other screens have borders.
+    | OnlyFloat
+        -- ^ Remove borders on all floating windows; tiling windows of
+        -- any kinds are not affected.
     | Screen
         -- ^ Borders are never drawn on singleton screens.  With this one you
         -- really need another way such as a statusbar to detect focus.

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -122,6 +122,10 @@ instance Arbitrary RectC where
 instance Arbitrary Rectangle where
   arbitrary = Rectangle <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
+instance Arbitrary RationalRect where
+  arbitrary = RationalRect <$> dim <*> dim <*> dim <*> dim
+   where
+    dim = arbitrary `suchThat` liftM2 (&&) (>= 0) (<= 1)
 
 newtype SizedPositive = SizedPositive Int
     deriving (Eq, Ord, Show, Read)


### PR DESCRIPTION
### Description

This adds an `OnlyFloat` data constructor to `Ambiguity`; I've found this curiously missing with the current setup of things. 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: A property test is included; we sadly can't test for arbitrary `WindowSet`s because there's no arbitrary instance for this.  However, the hand-crafted dual-head setup seems decent enough for this purpose.

  - [x] I updated the `CHANGES.md` file

  - [n/a] I updated the `XMonad.Doc.Extending` file (if appropriate)
