### PR TITLE
X.H.StatusBar: Simplify the fix for `def` as `k`

### DIFF
--- a/XMonad/Hooks/DynamicLog.hs
+++ b/XMonad/Hooks/DynamicLog.hs
@@ -156,8 +156,7 @@ import XMonad.Hooks.StatusBar
 -- You should use this function only when the default 'dzen' function does not
 -- serve your purpose.
 --
-dzenWithFlags :: (LayoutClass l Window
-                 ,Read (l Window))
+dzenWithFlags :: LayoutClass l Window
               => String     -- ^ Flags to give to @dzen@
               -> XConfig l  -- ^ The base config
               -> IO (XConfig (ModifiedLayout AvoidStruts l))
@@ -171,8 +170,7 @@ dzenWithFlags flags = statusBar ("dzen2 " ++ flags) dzenPP toggleStrutsKey
 --
 -- This works pretty much the same as the 'xmobar' function.
 --
-dzen :: (LayoutClass l Window
-        ,Read (l Window))
+dzen :: LayoutClass l Window
      => XConfig l  -- ^ The base config
      -> IO (XConfig (ModifiedLayout AvoidStruts l))
 dzen = dzenWithFlags flags
@@ -183,8 +181,7 @@ dzen = dzenWithFlags flags
 
 -- | This function works like 'xmobarProp', but uses pipes instead of
 -- property-based logging.
-xmobar :: (LayoutClass l Window
-          ,Read (l Window))
+xmobar :: LayoutClass l Window
        => XConfig l  -- ^ The base config
        -> IO (XConfig (ModifiedLayout AvoidStruts l))
 xmobar = statusBar "xmobar" xmobarPP toggleStrutsKey
@@ -192,8 +189,7 @@ xmobar = statusBar "xmobar" xmobarPP toggleStrutsKey
 -- | Like 'statusBarProp', but uses pipes instead of property-based logging.
 -- Only use this function if your status bar does not support reading from a
 -- property of the root window.
-statusBar :: (LayoutClass l Window
-             ,Read (l Window))
+statusBar :: LayoutClass l Window
           => String    -- ^ The command line to launch the status bar
           -> PP        -- ^ The pretty printing options
           -> (XConfig Layout -> (KeyMask, KeySym))
@@ -262,8 +258,7 @@ dynamicLogXinerama = withWindowSet $ io . putStrLn . pprWindowSetXinerama
 -- The binding uses the "XMonad.Hooks.ManageDocks" module to automatically
 -- handle screen placement for xmobar, and enables 'mod-b' for toggling
 -- the menu bar.
-xmobarProp :: (LayoutClass l Window
-              ,Read (l Window))
+xmobarProp :: LayoutClass l Window
            => XConfig l  -- ^ The base config
            -> XConfig (ModifiedLayout AvoidStruts l)
 xmobarProp =

--- a/XMonad/Hooks/StatusBar.hs
+++ b/XMonad/Hooks/StatusBar.hs
@@ -275,8 +275,7 @@ withSB (StatusBarConfig lh sh ch) conf = conf
 -- Using this function multiple times to combine status bars may result in
 -- only one status bar working properly. See the section on using multiple
 -- status bars for more details.
-withEasySB :: (LayoutClass l Window
-              ,Read (l Window))
+withEasySB :: LayoutClass l Window
            => StatusBarConfig -- ^ The status bar config
            -> (XConfig Layout -> (KeyMask, KeySym))
                               -- ^ The key binding
@@ -287,16 +286,18 @@ withEasySB sb k conf = docks . withSB sb $ conf
     , keys       = (<>) <$> keys' <*> keys conf
     }
   where
-    -- This usually means the user passed 'def' for the keybinding
-    -- function, and is otherwise meaningless to harmful depending on
-    -- whether 383ffb7 has been applied to xmonad or not. So do what
-    -- they probably intend.
-    --
-    -- A user who wants no keybinding function should probably use
-    -- 'withSB' instead, especially since NoSymbol didn't do anything
-    -- sane before 383ffb7. ++bsa
-    k' | k conf {layoutHook = Layout (layoutHook conf)} == (0,0) = defToggleStrutsKey
-       | otherwise = k
+    k' conf' = case k conf' of
+        (0, 0) ->
+            -- This usually means the user passed 'def' for the keybinding
+            -- function, and is otherwise meaningless to harmful depending on
+            -- whether 383ffb7 has been applied to xmonad or not. So do what
+            -- they probably intend.
+            --
+            -- A user who wants no keybinding function should probably use
+            -- 'withSB' instead, especially since NoSymbol didn't do anything
+            -- sane before 383ffb7. ++bsa
+            defToggleStrutsKey conf'
+        key -> key
     keys' = (`M.singleton` sendMessage ToggleStruts) . k'
 
 -- | Default @mod-b@ key binding for 'withEasySB'


### PR DESCRIPTION
Would this also work?

Fixes: 58e2b803a478 ("fix: handle `const (0,0)` from passing `def` as keybinding action")