### PR TITLE
X.A.UpdateFocus: Add focusUnderPointer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -686,6 +686,13 @@
     - Fixed issue with keyboard/pointer staying grabbed when a blocking action
       like `runProcessWithInput` was invoked.
 
+  - `XMonad.Actions.UpdateFocus`
+
+    - Added `focusUnderPointer`, that updates the focus based on pointer
+      position, an inverse of `X.A.UpdatePointer`, which moves the mouse
+      pointer to match the focused window). Together these can be used to
+      ensure focus stays in sync with mouse.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Actions/UpdatePointer.hs
+++ b/XMonad/Actions/UpdatePointer.hs
@@ -60,6 +60,11 @@ import Control.Arrow ((&&&), (***))
 -- | Update the pointer's location to the currently focused
 -- window or empty screen unless it's already there, or unless the user was changing
 -- focus with the mouse
+--
+-- See also 'XMonad.Actions.UpdateFocus.focusUnderPointer' for an inverse
+-- operation that updates the focus instead. The two can be combined in a
+-- single config if neither goes into 'logHook' but are invoked explicitly in
+-- individual key bindings.
 updatePointer :: (Rational, Rational) -> (Rational, Rational) -> X ()
 updatePointer refPos ratio = do
   ws <- gets windowset


### PR DESCRIPTION
### Description

Some people like their mouse pointer to move when changing focus with the keyboard, other people like their pointer to stay and focus to follow. xmonad(-contrib) supports both preferences, but imperfectly: The former requires using the XMonad.Actions.UpdatePointer contrib module, the latter (focusFollowsMouse) only reacts to CrossingEvent; the focus isn't updated after changing workspaces or layouts.

This adds an inverse of XMonad.Actions.UpdatePointer.updatePointer that immediately updates the focus instead.

Fixes: https://github.com/xmonad/xmonad/issues/108

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    I tested this a bit with a minimal config file and I hope the reporter and commenters of https://github.com/xmonad/xmonad/issues/108 will test it some more. I do not intend to use this myself.

  - [X] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)