### PR TITLE
X.L.Magnifier: Expose types

### DIFF
--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -42,7 +42,8 @@ module XMonad.Layout.Magnifier
       -- * Messages and Types
       MagnifyMsg (..),
       MagnifyThis(..),
-      Magnifier,
+      Magnifier(..),
+      Toggle(..)
     ) where
 
 import Numeric.Natural (Natural)


### PR DESCRIPTION
### Description

It is important for these types to be exposed to access the underlying LayoutModifier. It is not possible to interact with it without these.

In particular I needed these changes for compatibility with this PR https://github.com/xmonad/xmonad-contrib/pull/582

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
