### PR TITLE
X.A.Submap, X.U.Ungrab: Sync after ungrab (fixes issues with runProcessWithInput)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -681,6 +681,11 @@
 
     - Added `swapWithCurrent` and `swapOrder` to the list of exported names.
 
+  - `XMonad.Actions.Submap`, `XMonad.Util.Ungrab`:
+
+    - Fixed issue with keyboard/pointer staying grabbed when a blocking action
+      like `runProcessWithInput` was invoked.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Actions/Submap.hs
+++ b/XMonad/Actions/Submap.hs
@@ -92,5 +92,6 @@ submapDefaultWithKey defAction keys = do
 
     io $ ungrabPointer d currentTime
     io $ ungrabKeyboard d currentTime
+    io $ sync d False
 
     fromMaybe (defAction (m', s)) (M.lookup (m', s) keys)

--- a/XMonad/Util/Ungrab.hs
+++ b/XMonad/Util/Ungrab.hs
@@ -18,6 +18,7 @@ module XMonad.Util.Ungrab
       unGrab
     ) where
 
+import Graphics.X11.Xlib (sync)
 import Graphics.X11.Xlib.Extras (currentTime)
 import Graphics.X11.Xlib.Misc (ungrabKeyboard, ungrabPointer)
 import XMonad.Core
@@ -40,4 +41,4 @@ import XMonad.Core
 
 -- | Release xmonad's keyboard grab, so other grabbers can do their thing.
 unGrab :: X ()
-unGrab = withDisplay $ \d -> io (ungrabKeyboard d currentTime >> ungrabPointer d currentTime)
+unGrab = withDisplay $ \d -> io (ungrabKeyboard d currentTime >> ungrabPointer d currentTime >> sync d False)


### PR DESCRIPTION
### Description

When `runProcessWithInput` is invoked immediately after `ungrabPointer`/`ungrabKeyboard`, we don't actually ungrab at all because `runProcessWithInput` blocks and the ungrab requests wait in Xlib's queue for a request that needs a queue flush.

Common uses of `unGrab` (before `spawn`) aren't followed by a blocking action, so the ungrab requests are flushed by xmonad's main loop, and this is merely a timing issue—fork/exec takes a while and xmonad probably manages to get back to its main loop in time. Uses of `runProcessWithInput` in ordinary non-submap key bindings happen to work because key bindings are passive grabs—the grab is released by the user's fingers releasing the key itself, even if xmonad's ungrab requests are stuck in a blocked queue. Submap key bindings, however, take an active grab and therefore need to ungrab explicitly.

Easy fix—explicit `sync`.

Fixes: https://github.com/xmonad/xmonad/issues/313

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    Appears to have fixed the issue and I'll ask the reporter of https://github.com/xmonad/xmonad/issues/313 to verify.

  - [X] I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)