### PR TITLE
X.P.OrgMode: Fix behaviour of getLast

### DIFF
--- a/tests/OrgMode.hs
+++ b/tests/OrgMode.hs
@@ -22,6 +22,14 @@ spec = do
   prop "prop_encodeLinearity" prop_encodeLinearity
   prop "prop_decodeLinearity" prop_decodeLinearity
 
+  -- Checking for regressions
+  context "+d +d f" $ do
+    it "encode" $ prop_encodeLinearity (OrgMsg "+d +d f")
+    it "decode" $ prop_decodeLinearity (Deadline "+d" (Time {date = Next Friday, tod = Nothing}))
+  context "+d f 1 +d f" $ do
+    it "encode" $ prop_encodeLinearity (OrgMsg "+d f 1 +d f")
+    it "decode" $ prop_decodeLinearity (Deadline "+d f 1" (Time {date = Next Friday, tod = Nothing}))
+
 -- | Printing omits no information from output.
 prop_encodeLinearity :: OrgMsg -> Property
 prop_encodeLinearity (OrgMsg s) = Just s === (ppNote <$> pInput s)


### PR DESCRIPTION
### Description

It's funny to notice this so late; I guess non-deterministic tests do have their drawback :)

So far, while parsing strings like "<ptn><more-letters>", the `getLast`
function immediately stopped on strings of the form "<ptn><whitespace>".
This may be a bit confusing given the functions name.  Strings of
the—perhaps artificial—form

    "a +d f 1 +d f 2"

would be cut short and parsed as

    Deadline "a" (Time { date = Next Friday, tod = Just 01:00 })

instead of the more intuitive

    Deadline "a +d f 1" (Time { date = Next Friday, tod = Just 02:00 }).

This is readily fixed by applying the `go` parser as often as possible,
only returning the longest list, and then pruning eventual leftovers at
the end of the string.  Since we were already invoking `dropWhileEnd` to
trim whitespace before, the added `reverse`s should not impact
performance at all.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/584

```
λ ⟩ pInput "a +d f 1 +d f 2"
Just (Deadline "a +d f 1" (Time {date = Next Friday, tod = Just 02:00}))
```

```
λ ⟩ quickCheck $ prop_decodeLinearity (Deadline "+d" (Time {date = XMonad.Prompt.OrgMode.Next Friday, tod = Nothing}))
+++ OK, passed 1 test.
```

```
λ ⟩ quickCheck $ prop_decodeLinearity (Deadline "+d f 1" (Time {date = XMonad.Prompt.OrgMode.Next Friday, tod = Nothing}))
+++ OK, passed 1 test.
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I added some regression tests for the cases that were mentioned in #584

  - [n/a] I updated the `CHANGES.md` file
    Unreleased module, I don't think this is necessary.

  - [n/a] I updated the `XMonad.Doc.Extending` file (if appropriate)
