### PR TITLE
Provide a mechanism by which users can customize the nix devShell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tags
 
 stack.yaml.lock
 
+flake.lock

--- a/NIX.md
+++ b/NIX.md
@@ -1,0 +1,17 @@
+# `nix` integration for XMonad
+
+## Customizing the `nix-shell`
+
+It's possible to use a file `develop.nix` to customize the `devShell`
+provided by the flake.  This is useful if e.g. you want to have the
+`haskell-language-server` or other developer tools in the shell properly
+configured (correct GHC versions, and the like).
+
+Here is an example `develop.nix` for `haskell-language-server`:
+
+``` nix
+pkgs: devInputs: devInputs // {
+  nativeBuildInputs = with pkgs.haskellPackages;
+    [ cabal-install hlint ghcid ormolu implicit-hie haskell-language-server ];
+}
+```

--- a/flake.nix
+++ b/flake.nix
@@ -18,13 +18,18 @@
     };
     overlays = xmonad.overlays ++ [ overlay ];
   in flake-utils.lib.eachDefaultSystem (system:
-  let pkgs = import nixpkgs { inherit system overlays; };
+  let
+    pkgs = import nixpkgs { inherit system overlays; };
+    modifyDevShell =
+      if builtins.pathExists ./develop.nix
+      then import ./develop.nix
+      else _: x: x;
   in
   rec {
-    devShell = pkgs.haskellPackages.shellFor {
+    devShell = pkgs.haskellPackages.shellFor (modifyDevShell pkgs {
       packages = p: [ p.xmonad-contrib ];
       nativeBuildInputs = [ pkgs.cabal-install ];
-    };
+    });
     defaultPackage = pkgs.haskellPackages.xmonad-contrib;
   }) // { inherit overlay overlays; } ;
 }

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -23,7 +23,7 @@ license:            BSD3
 license-file:       LICENSE
 author:             Spencer Janssen & others
 maintainer:         xmonad@haskell.org
-extra-source-files: README.md CHANGES.md scripts/generate-configs scripts/run-xmonad.sh
+extra-source-files: README.md CHANGES.md NIX.md scripts/generate-configs scripts/run-xmonad.sh
                     scripts/window-properties.sh
                     scripts/xinitrc scripts/xmonad-acpi.c
                     scripts/xmonad-clock.c


### PR DESCRIPTION
This allows users to use a file develop.nix to customize the devShell provided by the flake. This is useful if e.g. the user wants to have the haskell-language-server or other developer tools in the shell properly configured (correct ghc versions etc).

Here is an example develop.nix for haskell-language-server:
```
pkgs: devInputs: devInputs // {
  nativeBuildInputs = with pkgs.haskellPackages;
    [ cabal-install hlint ghcid ormolu implicit-hie haskell-language-server ];
}
```