### PR TITLE
Bring XMonad.Actions.GridSelect.makeXEventhandler closer core keypress handler

### DIFF
--- a/XMonad/Actions/GridSelect.hs
+++ b/XMonad/Actions/GridSelect.hs
@@ -409,7 +409,7 @@ makeXEventhandler keyhandler = fix $ \me -> join $ liftX $ withDisplay $ \d -> l
                              maskEvent d (exposureMask .|. keyPressMask .|. buttonReleaseMask) e
                              ev <- getEvent e
                              case ev of
-                               KeyEvent {ev_state = km, ev_keycode = kc} -> do
+                               KeyEvent {ev_state = km, ev_keycode = kc} | ev_event_type ev == keyPress -> do
                                   (_, s) <- lookupString $ asKeyEvent e
                                   ks <- keycodeToKeysym d kc 0
                                   return $ do

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -651,7 +651,7 @@ eventLoop handle stopAction = do
                     maskEvent d (exposureMask .|. keyPressMask .|. buttonPressMask) e
                     ev <- getEvent e
                     (ks,s) <- case ev of
-                      KeyEvent {ev_state = km, ev_keycode = kc} | ev_event_type ev == keyPress -> do
+                      KeyEvent {ev_keycode = kc} | ev_event_type ev == keyPress -> do
                         ks <- keycodeToKeysym d kc 0
                         (_, s) <- lookupString $ asKeyEvent e
                         return (ks, s)


### PR DESCRIPTION
### Description

This changes `makeXEventhandler` to behave much closer to how xmonad itself handles keypresses. The primary difference lies in that xmonad reads raw keycode and then converts it to unmodified keysym, while `makeXEventhandler` was reading actual keysyms. As a consequence, key definitions like `(shiftMap, xK_Tab)` didn't work with `makeXEventhandler` on many layouts because an actual keysym for 'Shift+Tab' is commonly `ISO_LEFT_TAB`, and not `Tab`.

Additionally, the mask is stripped of its high bits, because apparently X likes to encode current layout group information in bits 13 and up, and we don't really want our control keys to depend on the current layout group. Please let me know if there is a better way to handle this.

Not updating the changelog just yet, awaiting feedback.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    There were no automated tests for this; I don't know how to make them, either. The code has been tested manually with my xmonad config.

  - [ ] I updated the `CHANGES.md` file

  - [ ] ~~I updated the `XMonad.Doc.Extending` file (if appropriate)~~ N/A
