### PR TITLE
X.U.Loggers: Add `logTitlesOnScreen`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -501,7 +501,9 @@
     - Added `logConst` to log a constant `String`, and `logDefault` (infix: `.|`)
       to combine loggers.
 
-    - Added `logTitles` to log all window titles (focused and unfocused ones).
+    - Added `logTitles` to log all window titles (focused and unfocused
+      ones) on the focused workspace, as well as `logTitlesOnScreen` as
+      a screen-specific variant thereof.
 
   * `XMonad.Layout.Minimize`
 


### PR DESCRIPTION
### Description

This works like `logTitles`, but gets an explicit screen to log the window
titles on.  This may be useful when having status bars for each screen
that show all windows on their respective visible workspaces.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: It's a trivial extension of `logTitles` and I've confirmed manually that this work for me.  It might be conceivable to property test this, as we are only accessing internal state, but I did not deem this necessary in this case.

  - [x] I updated the `CHANGES.md` file

  - [n/a] I updated the `XMonad.Doc.Extending` file (if appropriate)
