### PR TITLE
Undeprecate spacing convenience functions

### DIFF
--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -329,13 +329,8 @@ orderSelect o (lt,eq,gt) = case o of
 -----------------------------------------------------------------------------
 {-# DEPRECATED SpacingWithEdge, SmartSpacing, SmartSpacingWithEdge "Use Spacing instead." #-}
 {-# DEPRECATED ModifySpacing "Use SpacingModifier instead, perhaps with sendMessages." #-}
-{-# DEPRECATED spacing, spacingWithEdge, smartSpacing, smartSpacingWithEdge "Use spacingRaw instead." #-}
 {-# DEPRECATED setSpacing "Use setScreenWindowSpacing instead." #-}
 {-# DEPRECATED incSpacing "Use incScreenWindowSpacing instead." #-}
-
--- $backwardsCompatibility
--- The following functions and types exist solely for compatibility with
--- pre-0.14 releases.
 
 -- | A type synonym for the 'Spacing' 'LayoutModifier'.
 type SpacingWithEdge = Spacing


### PR DESCRIPTION
These should be undeprecated because:
- The suggestion to use `spacingRaw` is pretty ridiculous; the interface to spacingRaw is very general and flexible, which is great, but I think that most people probably do not need all of that flexibility, and one of these convenience functions may suit their needs better.
- There is precendent for having convenience functions like these