### PR TITLE
Update X.L.Spacing documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -708,6 +708,11 @@
     - Added `isToggleActive` for querying the toggle state of transformers.
       Useful to show the state in a status bar.
 
+  * `XMonad.Layout.Spacing`
+
+    - Removed deprecations for `spacing`, `spacingWithEdge`,
+      `smartSpacing`, and `smartSpacingWithEdge`.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -34,14 +34,13 @@ module XMonad.Layout.Spacing
     , decWindowSpacing, decScreenSpacing
     , incScreenWindowSpacing, decScreenWindowSpacing
     , borderMap, borderIncrementBy
-      -- * Backwards Compatibility
-      -- $backwardsCompatibility
-    , SpacingWithEdge
-    , SmartSpacing, SmartSpacingWithEdge
-    , ModifySpacing (..)
     , spacing, spacingWithEdge
     , smartSpacing, smartSpacingWithEdge
     , setSpacing, incSpacing
+      -- * Backwards Compatibility
+    , SpacingWithEdge
+    , SmartSpacing, SmartSpacingWithEdge
+    , ModifySpacing (..)
     ) where
 
 import           XMonad

--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -19,10 +19,13 @@
 module XMonad.Layout.Spacing
     ( -- * Usage
       -- $usage
-      Border (..)
-    , Spacing (..)
-    , SpacingModifier (..)
+      Spacing (..)
     , spacingRaw
+    , spacing, spacingWithEdge
+    , smartSpacing, smartSpacingWithEdge
+
+      -- * Modify Spacing
+    , SpacingModifier (..)
     , setSmartSpacing
     , setScreenSpacing, setScreenSpacingEnabled
     , setWindowSpacing, setWindowSpacingEnabled
@@ -33,14 +36,16 @@ module XMonad.Layout.Spacing
     , incWindowSpacing, incScreenSpacing
     , decWindowSpacing, decScreenSpacing
     , incScreenWindowSpacing, decScreenWindowSpacing
+
+      -- * Modify Borders
+    , Border (..)
     , borderMap, borderIncrementBy
-    , spacing, spacingWithEdge
-    , smartSpacing, smartSpacingWithEdge
-    , setSpacing, incSpacing
+
       -- * Backwards Compatibility
     , SpacingWithEdge
     , SmartSpacing, SmartSpacingWithEdge
     , ModifySpacing (..)
+    , setSpacing, incSpacing
     ) where
 
 import           XMonad

--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -61,10 +61,40 @@ import           XMonad.Actions.MessageFeedback
 --
 -- > import XMonad.Layout.Spacing
 --
--- and modifying your layoutHook as follows (for example):
+-- and, for example, modifying your @layoutHook@ as follows:
 --
--- > layoutHook = spacingRaw True (Border 0 10 10 10) True (Border 10 10 10 10) True $
--- >              layoutHook def
+-- > main :: IO ()
+-- > main = xmonad $ def
+-- >   { layoutHook = spacingWithEdge 10 $ myLayoutHook
+-- >   }
+-- >
+-- > myLayoutHook = Full ||| ...
+--
+-- The above would add a 10 pixel gap around windows on all sides, as
+-- well as add the same amount of spacing around the edges of the
+-- screen.  If you only want to add spacing around windows, you can use
+-- 'spacing' instead.
+--
+-- There is also the 'spacingRaw' command, for more fine-grained
+-- control.  For example:
+--
+-- > layoutHook = spacingRaw True (Border 0 10 10 10) True (Border 10 10 10 10) True
+-- >            $ myLayoutHook
+--
+-- Breaking this down, the above would do the following:
+--
+--   - @True@: Enable the 'smartBorder' to not apply borders when there
+--     is only one window.
+--
+--   - @(Border 0 10 10 10)@: Add a 'screenBorder' of 10 pixels in every
+--     direction but the top.
+--
+--   - @True@: Enable the 'screenBorder'.
+--
+--   - @(Border 10 10 10 10)@: Add a 'windowBorder' of 10 pixels in
+--     every direction.
+--
+--   - @True@: Enable the 'windowBorder'.
 
 -- | Represent the borders of a rectangle.
 data Border = Border


### PR DESCRIPTION
Update the X.L.Spacing docs, as a lot of people seem to have trouble
using that module.

- X.L.Spacing: Remove link to backwards compatibility section

  This has been removed already, so remove the link and move the
  undeprecated functions out of there.

- CHANGES.md: Mention X.L.Spacing undeprecations

- X.L.Spacing: Reorder export list

- X.L.Spacing: Extend documentation

  Users are having trouble with this module all the time.  Now that
  certain helper functions are undeprecated, we should tell users how they
  may use them.  It is also worth explaining the scary-looking
  `spacingRaw` command a bit further.

Related: https://github.com/xmonad/xmonad-contrib/pull/597 (cadb178819fa70b7fc83c69399c11030491de8b9)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Doc changes; nothing necessary

  - [x] I updated the `CHANGES.md` file

  - [n/a] I updated the `XMonad.Doc.Extending` file (if appropriate)