### PR TITLE
xmonad-contrib part of "Make extensibleState primarily keyed by TypeRep instead of type names"

### DIFF
--- a/stack-master.yaml
+++ b/stack-master.yaml
@@ -9,8 +9,8 @@ packages:
 extra-deps:
 - github: xmonad/X11
   commit: master@{today}
-- github: xmonad/xmonad
-  commit: master@{today}
+- github: liskin/xmonad
+  commit: ext-state-unique@{today}
 
 nix:
   packages:

--- a/tests/ExtensibleState.hs
+++ b/tests/ExtensibleState.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wall #-}
+module ExtensibleState where
+
+import Test.Hspec
+
+import XMonad
+import Data.Typeable
+import qualified XMonad.Util.ExtensibleState as XS
+import qualified Data.Map as M
+
+data TestState = TestState Int deriving (Show, Read, Eq)
+instance ExtensionClass TestState where
+    initialValue = TestState 0
+
+data TestPersistent = TestPersistent Int deriving (Show, Read, Eq)
+instance ExtensionClass TestPersistent where
+    initialValue = TestPersistent 0
+    extensionType = PersistentExtension
+
+spec :: Spec
+spec = do
+    describe "upgrade of non-persistent" $
+        it "noop" $
+            M.keys (XS.upgrade (undefined :: TestState) mempty) `shouldBe` mempty
+    describe "upgrade of persistent" $ do
+        describe "inserts initial value if not found" $ do
+            let k = Right (typeOf (undefined :: TestPersistent))
+            let m = XS.upgrade (undefined :: TestPersistent) mempty
+            specify "keys" $ M.keys m `shouldBe` [k]
+            specify "value" $ assertRightPersistent k m (TestPersistent 0)
+        describe "noop if Right found" $ do
+            let k = Right (typeOf (undefined :: TestPersistent))
+            let m0 = M.singleton k (Right (PersistentExtension (TestPersistent 1)))
+            let m = XS.upgrade (undefined :: TestPersistent) m0
+            specify "keys" $ M.keys m `shouldBe` [k]
+            specify "value" $ assertRightPersistent k m (TestPersistent 1)
+        describe "deserialize" $ do
+            let k0 = Left "ExtensibleState.TestPersistent"
+            let m0 = M.singleton k0 (Left "TestPersistent 1")
+            let k = Right (typeOf (undefined :: TestPersistent))
+            let m = XS.upgrade (undefined :: TestPersistent) m0
+            specify "keys" $ M.keys m `shouldBe` [k]
+            specify "value" $ assertRightPersistent k m (TestPersistent 1)
+        describe "upgrade from old representation and deserialize" $ do
+            let k0 = Left "TestPersistent"
+            let m0 = M.singleton k0 (Left "TestPersistent 1")
+            let k = Right (typeOf (undefined :: TestPersistent))
+            let m = XS.upgrade (undefined :: TestPersistent) m0
+            specify "keys" $ M.keys m `shouldBe` [k]
+            specify "value" $ assertRightPersistent k m (TestPersistent 1)
+
+assertRightPersistent :: (Ord k, Typeable v, Show v, Eq v)
+                      => k -> M.Map k (Either String StateExtension) -> v -> Expectation
+assertRightPersistent k m v = case k `M.lookup` m of
+    Just (Right (PersistentExtension (cast -> Just x))) -> x `shouldBe` v
+    _ -> expectationFailure "unexpected"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -4,6 +4,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
 
 import qualified ExtensibleConf
+import qualified ExtensibleState
 import qualified ManageDocks
 import qualified NoBorders
 import qualified RotateSome
@@ -48,6 +49,7 @@ main = hspec $ do
         prop "prop_skipGetLastWord"  XPrompt.prop_skipGetLastWord
     context "NoBorders"      NoBorders.spec
     context "ExtensibleConf" ExtensibleConf.spec
+    context "ExtensibleState" ExtensibleState.spec
     context "CycleRecentWS"  CycleRecentWS.spec
     context "OrgMode"        OrgMode.spec
     context "GridSelect"     GridSelect.spec

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -58,7 +58,7 @@ library
                    mtl >= 1 && < 3,
                    unix,
                    X11 >= 1.10 && < 1.11,
-                   xmonad >= 0.16.99999 && < 0.18,
+                   xmonad >= 0.16.999999 && < 0.18,
                    utf8-string
 
     ghc-options:   -Wall -Wno-unused-do-bind
@@ -378,6 +378,7 @@ test-suite tests
   main-is:        Main.hs
   other-modules:  CycleRecentWS
                   ExtensibleConf
+                  ExtensibleState
                   GridSelect
                   Instances
                   ManageDocks


### PR DESCRIPTION
### Description

We've been using the String we get out of `show . typeOf` as key in `extensibleState`, but that has a somewhat serious bug: it shows unqualified type names, so if two modules use the same type name, their extensible states will be stored in one place and get overwritten all the time.

To fix this, the `extensibleState` map is now primarily keyed by the TypeRep themselves, with fallback to String for not yet deserialized data. XMonad.Core now exports `showExtType` which serializes type names qualified, and this is used in `writeStateToFile`.

A simpler fix would be to just change the serialization of type names in `XMonad.Util.ExtensibleState`, but I'm afraid that might slows things down: Most types used here will start with "XMonad.", and that's a lot of useless linked-list pointer jumping.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/94
Related: https://github.com/xmonad/xmonad/pull/326

---

I must admit I don't really like the code, especially the xmonad-contrib part. There's the assumption that a Right key maps to a Right value, and Left key to Left value, but enforcing that in the types probably means adding a another field to the XState.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    (TODO)

  - n/a I updated the `CHANGES.md` file

  - n/a I updated the `XMonad.Doc.Extending` file (if appropriate)