### PR TITLE
add custom title to xmonad prompts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -302,6 +302,11 @@
 
   * Add support for GHC 9.0.1.
 
+  * `XMonad.Prompt.XMonad`
+
+    - Added `xmonadPromptCT`, which allows you to create an XMonad
+      prompt with a custom title.
+
   * `XMonad.Actions.DynamicWorkspaceGroups`
 
     - Add support for `XMonad.Actions.TopicSpace` through `viewTopicGroup` and

--- a/XMonad/Prompt/XMonad.hs
+++ b/XMonad/Prompt/XMonad.hs
@@ -17,6 +17,7 @@ module XMonad.Prompt.XMonad (
                              -- $usage
                              xmonadPrompt,
                              xmonadPromptC,
+                             xmonadPromptCT,
                              XMonad,
                               ) where
 
@@ -38,10 +39,10 @@ import XMonad.Prelude (fromMaybe)
 -- For detailed instruction on editing the key binding see
 -- "XMonad.Doc.Extending#Editing_key_bindings".
 
-data XMonad = XMonad
+newtype XMonad = XMonad String
 
 instance XPrompt XMonad where
-    showXPrompt XMonad = "XMonad: "
+    showXPrompt (XMonad str) = str <> ": "
 
 xmonadPrompt :: XPConfig -> X ()
 xmonadPrompt c = do
@@ -50,6 +51,10 @@ xmonadPrompt c = do
 
 -- | An xmonad prompt with a custom command list
 xmonadPromptC :: [(String, X ())] -> XPConfig -> X ()
-xmonadPromptC commands c =
-    mkXPrompt XMonad c (mkComplFunFromList' c (map fst commands)) $
+xmonadPromptC = xmonadPromptCT "XMonad"
+
+-- | An xmonad prompt with a custom command list and a custom title
+xmonadPromptCT :: String -> [(String, X ())] -> XPConfig -> X ()
+xmonadPromptCT title' commands c =
+    mkXPrompt (XMonad title') c (mkComplFunFromList' c (map fst commands)) $
         fromMaybe (return ()) . (`lookup` commands)


### PR DESCRIPTION
### Description

Currently when creating an XMonad Prompt you are stuck with `XMonad:` as the title for the prompt.  Its nice to be able to create a prompt with custom commands that has a particular title. adds the `xmonadPromptCT` function which allows you to do this.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded The `XMonad.Prompt.XMonad` currently has no unit or property tests. If you have any suggestions for strategies to add test coverage I would be happy to implement something.

  - [X] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
