### PR TITLE
Adds killOthers function to Xmonad.Actions.WithAll

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -302,6 +302,11 @@
 
   * Add support for GHC 9.0.1.
 
+  * `XMonad.Actions.WithAll`
+
+    - Added `killOthers`, which kills all unfocused windows on the
+      current workspace.
+
   * `XMonad.Prompt.XMonad`
 
     - Added `xmonadPromptCT`, which allows you to create an XMonad

--- a/XMonad/Actions/WithAll.hs
+++ b/XMonad/Actions/WithAll.hs
@@ -5,15 +5,16 @@
 -- Stability    : unstable
 -- Portability  : unportable
 --
--- Provides functions for performing a given action on all windows of
--- the current workspace.
+-- Provides functions for performing a given action on all or certain
+-- groups of windows on the current workspace.
 -----------------------------------------------------------------------------
 
 module XMonad.Actions.WithAll (
     -- * Usage
     -- $usage
     sinkAll, withAll,
-    withAll', killAll) where
+    withAll', killAll,
+    killOthers) where
 
 import XMonad.Prelude hiding (foldr)
 
@@ -50,3 +51,7 @@ withAll f = withWindowSet $ \ws -> let all' = integrate' . stack . workspace . c
 -- | Kill all the windows on the current workspace.
 killAll :: X()
 killAll = withAll killWindow
+
+-- | Kill all the unfocused windows on the current workspace.
+killOthers :: X ()
+killOthers = withUnfocused killWindow

--- a/XMonad/Doc/Extending.hs
+++ b/XMonad/Doc/Extending.hs
@@ -336,8 +336,8 @@ edit your key bindings.
     Experimental rewrite of "XMonad.Layout.WindowNavigation".
 
 * "XMonad.Actions.WithAll":
-    Provides functions for performing a given action on all windows of
-    the current workspace.
+    Provides functions for performing a given action on all or certain
+    groups of windows on the current workspace.
 
 * "XMonad.Actions.Workscreen":
     A workscreen permits to display a set of workspaces on several screens. In


### PR DESCRIPTION
### Description

Resolves https://github.com/xmonad/xmonad-contrib/issues/527

Adds `killOthers` function to `XMonad.Actions.WithAll`. Depends on https://github.com/xmonad/xmonad/pull/327

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
