### PR TITLE
Remove codesearch, isount and openstreetmap engines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,6 +128,15 @@
       so colors of inactive window tiles will be different (but still inside
       the provided color range).
 
+  * `XMonad.Actions.Search`
+
+    - Removed outdated `isohunt` search engine.
+
+    - Updated URLs for `codesearch`, `openstreetmap`, and `thesaurus`
+      search engines.
+
+    - Added `github` search engine.
+
 ### New Modules
 
   * `XMonad.Layout.FixedAspectRatio`

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -250,7 +250,7 @@ search browser site query = safeSpawn browser [site query]
    appends it to the base. You can easily define a new engine locally using
    exported functions without needing to modify "XMonad.Actions.Search":
 
-> myNewEngine = searchEngine "site" "http://site.com/search="
+> myNewEngine = searchEngine "site" "https://site.com/search="
 
    The important thing is that the site has a interface which accepts the escaped query
    string as part of the URL. Alas, the exact URL to feed searchEngine varies
@@ -266,14 +266,14 @@ searchEngine name site = searchEngineF name (\s -> site ++ escape s)
    inside of a URL instead of in the end) you can use the alternative 'searchEngineF' function.
 
 > searchFunc :: String -> String
-> searchFunc s | "wiki:"   `isPrefixOf` s = "http://en.wikipedia.org/wiki/" ++ (escape $ tail $ snd $ break (==':') s)
->              | "http://" `isPrefixOf` s = s
->              | otherwise               = (use google) s
+> searchFunc s | "wiki:"    `isPrefixOf` s = "https://en.wikipedia.org/wiki/" ++ (escape $ tail $ snd $ break (==':') s)
+>              | "https://" `isPrefixOf` s = s
+>              | otherwise                 = (use google) s
 > myNewEngine = searchEngineF "mymulti" searchFunc
 
    @searchFunc@ here searches for a word in wikipedia if it has a prefix
    of \"wiki:\" (you can use the 'escape' function to escape any forbidden characters), opens an address
-   directly if it starts with \"http:\/\/\" and otherwise uses the provided google search engine.
+   directly if it starts with \"https:\/\/\" and otherwise uses the provided google search engine.
    You can use other engines inside of your own through the 'use' function as shown above to make
    complex searches.
 
@@ -286,32 +286,32 @@ searchEngineF = SearchEngine
 amazon, alpha, codesearch, deb, debbts, debpts, dictionary, ebay, github, google, hackage, hoogle,
   images, imdb, lucky, maps, mathworld, openstreetmap, scholar, stackage, thesaurus, vocabulary, wayback, wikipedia, wiktionary,
   youtube, duckduckgo :: SearchEngine
-amazon        = searchEngine "amazon"        "http://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords="
-alpha         = searchEngine "alpha"         "http://www.wolframalpha.com/input/?i="
-codesearch    = searchEngine "codesearch"    "http://developers.google.com/s/results/code-search?q="
-deb           = searchEngine "deb"           "http://packages.debian.org/"
-debbts        = searchEngine "debbts"        "http://bugs.debian.org/"
-debpts        = searchEngine "debpts"        "http://packages.qa.debian.org/"
-dictionary    = searchEngine "dict"          "http://dictionary.reference.com/browse/"
-ebay          = searchEngine "ebay"          "http://www.ebay.com/sch/i.html?_nkw="
+amazon        = searchEngine "amazon"        "https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords="
+alpha         = searchEngine "alpha"         "https://www.wolframalpha.com/input/?i="
+codesearch    = searchEngine "codesearch"    "https://developers.google.com/s/results/code-search?q="
+deb           = searchEngine "deb"           "https://packages.debian.org/"
+debbts        = searchEngine "debbts"        "https://bugs.debian.org/"
+debpts        = searchEngine "debpts"        "https://packages.qa.debian.org/"
+dictionary    = searchEngine "dict"          "https://dictionary.reference.com/browse/"
+ebay          = searchEngine "ebay"          "https://www.ebay.com/sch/i.html?_nkw="
 github        = searchEngine "github"        "https://github.com/search?q="
-google        = searchEngine "google"        "http://www.google.com/search?num=100&q="
-hackage       = searchEngine "hackage"       "http://hackage.haskell.org/package/"
-hoogle        = searchEngine "hoogle"        "http://hoogle.haskell.org/?hoogle="
-images        = searchEngine "images"        "http://images.google.fr/images?q="
-imdb          = searchEngine "imdb"          "http://www.imdb.com/find?s=all&q="
-lucky         = searchEngine "lucky"         "http://www.google.com/search?btnI&q="
-maps          = searchEngine "maps"          "http://maps.google.com/maps?q="
-mathworld     = searchEngine "mathworld"     "http://mathworld.wolfram.com/search/?query="
+google        = searchEngine "google"        "https://www.google.com/search?num=100&q="
+hackage       = searchEngine "hackage"       "https://hackage.haskell.org/package/"
+hoogle        = searchEngine "hoogle"        "https://hoogle.haskell.org/?hoogle="
+images        = searchEngine "images"        "https://images.google.fr/images?q="
+imdb          = searchEngine "imdb"          "https://www.imdb.com/find?s=all&q="
+lucky         = searchEngine "lucky"         "https://www.google.com/search?btnI&q="
+maps          = searchEngine "maps"          "https://maps.google.com/maps?q="
+mathworld     = searchEngine "mathworld"     "https://mathworld.wolfram.com/search/?query="
 openstreetmap = searchEngine "openstreetmap" "https://www.openstreetmap.org/search?query="
-scholar       = searchEngine "scholar"       "http://scholar.google.com/scholar?q="
-stackage      = searchEngine "stackage"      "www.stackage.org/lts/hoogle?q="
-wikipedia     = searchEngine "wiki"          "http://en.wikipedia.org/wiki/Special:Search?go=Go&search="
-wiktionary    = searchEngine "wikt"          "http://en.wiktionary.org/wiki/Special:Search?go=Go&search="
-youtube       = searchEngine "youtube"       "http://www.youtube.com/results?search_type=search_videos&search_query="
-wayback       = searchEngineF "wayback"      ("http://web.archive.org/web/*/"++)
-vocabulary    = searchEngine "vocabulary"    "http://www.vocabulary.com/search?q="
+scholar       = searchEngine "scholar"       "https://scholar.google.com/scholar?q="
+stackage      = searchEngine "stackage"      "https://www.stackage.org/lts/hoogle?q="
 thesaurus     = searchEngine "thesaurus"     "https://thesaurus.com/browse/"
+wikipedia     = searchEngine "wiki"          "https://en.wikipedia.org/wiki/Special:Search?go=Go&search="
+wiktionary    = searchEngine "wikt"          "https://en.wiktionary.org/wiki/Special:Search?go=Go&search="
+youtube       = searchEngine "youtube"       "https://www.youtube.com/results?search_type=search_videos&search_query="
+wayback       = searchEngineF "wayback"      ("https://web.archive.org/web/*/"++)
+vocabulary    = searchEngine "vocabulary"    "https://www.vocabulary.com/search?q="
 duckduckgo    = searchEngine "duckduckgo"    "https://duckduckgo.com/?t=lm&q="
 
 multi :: SearchEngine
@@ -323,7 +323,7 @@ multi = namedEngine "multi" $ foldr1 (!>) [amazon, alpha, codesearch, deb, debbt
 
 > myIntelligentGoogleEngine = intelligent google
 
-   Now if you search for http:\/\/xmonad.org it will directly open in your browser-}
+   Now if you search for https:\/\/xmonad.org it will directly open in your browser-}
 intelligent :: SearchEngine -> SearchEngine
 intelligent (SearchEngine name site) = searchEngineF name (\s -> if takeWhile (/= ':') s `elem` ["http", "https", "ftp"] then s else site s)
 

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -42,7 +42,6 @@ module XMonad.Actions.Search (   -- * Usage
                                  hoogle,
                                  images,
                                  imdb,
-                                 isohunt,
                                  lucky,
                                  maps,
                                  mathworld,
@@ -116,6 +115,8 @@ import           XMonad.Util.XSelection   (getSelection)
 
 * 'ebay' -- Ebay keyword search.
 
+* 'github' -- GitHub keyword search.
+
 * 'google' -- basic Google search.
 
 * 'hackage' -- Hackage, the Haskell package database.
@@ -128,8 +129,6 @@ import           XMonad.Util.XSelection   (getSelection)
 
 * 'imdb'   -- the Internet Movie Database.
 
-* 'isohunt' -- isoHunt search.
-
 * 'lucky' -- Google "I'm feeling lucky" search.
 
 * 'maps'   -- Google maps.
@@ -140,7 +139,7 @@ import           XMonad.Util.XSelection   (getSelection)
 
 * 'scholar' -- Google scholar academic search.
 
-* 'thesaurus' -- thesaurus.reference.com search.
+* 'thesaurus' -- thesaurus.com search.
 
 * 'wayback' -- the Wayback Machine.
 
@@ -284,39 +283,39 @@ searchEngineF :: Name -> Site -> SearchEngine
 searchEngineF = SearchEngine
 
 -- The engines.
-amazon, alpha, codesearch, deb, debbts, debpts, dictionary, ebay, google, hackage, hoogle,
-  images, imdb, isohunt, lucky, maps, mathworld, openstreetmap, scholar, stackage, thesaurus, vocabulary, wayback, wikipedia, wiktionary,
+amazon, alpha, codesearch, deb, debbts, debpts, dictionary, ebay, github, google, hackage, hoogle,
+  images, imdb, lucky, maps, mathworld, openstreetmap, scholar, stackage, thesaurus, vocabulary, wayback, wikipedia, wiktionary,
   youtube, duckduckgo :: SearchEngine
 amazon        = searchEngine "amazon"        "http://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords="
 alpha         = searchEngine "alpha"         "http://www.wolframalpha.com/input/?i="
-codesearch    = searchEngine "codesearch"    "http://www.google.com/codesearch?q="
+codesearch    = searchEngine "codesearch"    "http://developers.google.com/s/results/code-search?q="
 deb           = searchEngine "deb"           "http://packages.debian.org/"
 debbts        = searchEngine "debbts"        "http://bugs.debian.org/"
 debpts        = searchEngine "debpts"        "http://packages.qa.debian.org/"
 dictionary    = searchEngine "dict"          "http://dictionary.reference.com/browse/"
 ebay          = searchEngine "ebay"          "http://www.ebay.com/sch/i.html?_nkw="
+github        = searchEngine "github"        "https://github.com/search?q="
 google        = searchEngine "google"        "http://www.google.com/search?num=100&q="
 hackage       = searchEngine "hackage"       "http://hackage.haskell.org/package/"
 hoogle        = searchEngine "hoogle"        "http://hoogle.haskell.org/?hoogle="
 images        = searchEngine "images"        "http://images.google.fr/images?q="
 imdb          = searchEngine "imdb"          "http://www.imdb.com/find?s=all&q="
-isohunt       = searchEngine "isohunt"       "http://isohunt.com/torrents/?ihq="
 lucky         = searchEngine "lucky"         "http://www.google.com/search?btnI&q="
 maps          = searchEngine "maps"          "http://maps.google.com/maps?q="
 mathworld     = searchEngine "mathworld"     "http://mathworld.wolfram.com/search/?query="
-openstreetmap = searchEngine "openstreetmap" "http://gazetteer.openstreetmap.org/namefinder/?find="
+openstreetmap = searchEngine "openstreetmap" "https://www.openstreetmap.org/search?query="
 scholar       = searchEngine "scholar"       "http://scholar.google.com/scholar?q="
 stackage      = searchEngine "stackage"      "www.stackage.org/lts/hoogle?q="
-thesaurus     = searchEngine "thesaurus"     "http://thesaurus.reference.com/search?q="
 wikipedia     = searchEngine "wiki"          "http://en.wikipedia.org/wiki/Special:Search?go=Go&search="
 wiktionary    = searchEngine "wikt"          "http://en.wiktionary.org/wiki/Special:Search?go=Go&search="
 youtube       = searchEngine "youtube"       "http://www.youtube.com/results?search_type=search_videos&search_query="
 wayback       = searchEngineF "wayback"      ("http://web.archive.org/web/*/"++)
 vocabulary    = searchEngine "vocabulary"    "http://www.vocabulary.com/search?q="
+thesaurus     = searchEngine "thesaurus"     "https://thesaurus.com/browse/"
 duckduckgo    = searchEngine "duckduckgo"    "https://duckduckgo.com/?t=lm&q="
 
 multi :: SearchEngine
-multi = namedEngine "multi" $ foldr1 (!>) [amazon, alpha, codesearch, deb, debbts, debpts, dictionary, ebay, google, hackage, hoogle, images, imdb, isohunt, lucky, maps, mathworld, openstreetmap, scholar, thesaurus, wayback, wikipedia, wiktionary, duckduckgo, prefixAware google]
+multi = namedEngine "multi" $ foldr1 (!>) [amazon, alpha, codesearch, deb, debbts, debpts, dictionary, ebay, github, google, hackage, hoogle, images, imdb, lucky, maps, mathworld, openstreetmap, scholar, thesaurus, wayback, wikipedia, wiktionary, duckduckgo, prefixAware google]
 
 {- | This function wraps up a search engine and creates a new one, which works
    like the argument, but goes directly to a URL if one is given rather than


### PR DESCRIPTION
### Description

This is mostly a cosmetic change. Removed search engines point to sites that do not exist anymore or their functionality has changed. 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
