### PR TITLE
Updated flake.nix for full compatibility.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       ghcWithPackages = prev.ghcWithPackages.override (fn prev);
       haskellPackages = prev.haskellPackages.override (fn prev);
     };
-    overlays = [ overlay ];
+    overlays = xmonad.overlays ++ [ overlay ];
   in flake-utils.lib.eachDefaultSystem (system:
   let pkgs = import nixpkgs { inherit system overlays; };
   in


### PR DESCRIPTION
### Description


For people using nix, the overlay provided does not work with `ghcWithPackages` & `ghcWithHoogle`.

This change fixes that.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually

  - [ ] I updated the `CHANGES.md` file

  - [ ] ~~I updated the `XMonad.Doc.Extending` file (if appropriate)~~
