### PR TITLE
EwmhDesktops: Advertise _NET_WM_STATE_DEMANDS_ATTENTION.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,11 @@
       was changed to be closer to the spec. From now these two lists will have
       differently sorted windows.
 
+    - `_NET_WM_STATE_DEMANDS_ATTENTION` was added to the list of supported
+      hints (as per `_NET_SUPPORTED`). This hint has long been understood by
+      `UrgencyHook`. This enables certain applications (e.g. kitty terminal
+      emulator) that check whether the hint is supported to use it.
+
   * All modules still exporting a `defaultFoo` constructor
 
     - All of these were now removed. You can use the re-exported `def` from

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -390,6 +390,7 @@ setSupported = withDisplay $ \dpy -> do
     r <- asks theRoot
     a <- getAtom "_NET_SUPPORTED"
     supp <- mapM getAtom ["_NET_WM_STATE_HIDDEN"
+                         ,"_NET_WM_STATE_DEMANDS_ATTENTION"
                          ,"_NET_NUMBER_OF_DESKTOPS"
                          ,"_NET_CLIENT_LIST"
                          ,"_NET_CLIENT_LIST_STACKING"


### PR DESCRIPTION
### Description

XMonad.Hooks.UrgencyHook knows how to understand this hint, but it's
not advertised as supported via _NET_SUPPORTED. This prevents certain
applications (e.g. kitty terminal emulator) from using it.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I ran `stack test` in xmonad-contrib and verified that with the change kitty terminal emulator sets the hint on bell character.

  - [x] I updated the `CHANGES.md` file