### PR TITLE
X.A.Search: Fix missing export

### DIFF
--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -39,6 +39,7 @@ module XMonad.Actions.Search (   -- * Usage
                                  debpts,
                                  dictionary,
                                  ebay,
+                                 github,
                                  google,
                                  hackage,
                                  hoogle,


### PR DESCRIPTION
### Description

This is a small fix to PR with ID #606 - even though GitHub search engine was added, it was not exported.  

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
