### PR TITLE
X.A.CycleWS: Fix missing type names in documentation

### DIFF
--- a/XMonad/Actions/CycleWS.hs
+++ b/XMonad/Actions/CycleWS.hs
@@ -303,7 +303,7 @@ anyWS = WSIs . return $ const True
 --   example, be used for skipping the workspace reserved for
 --   "XMonad.Util.NamedScratchpad":
 --
--- >  moveTo Next $ hidden :&: Not empty :&: ignoringWSs [scratchpadWorkspaceTag]
+-- >  moveTo Next $ hiddenWS :&: Not emptyWS :&: ignoringWSs [scratchpadWorkspaceTag]
 --
 ignoringWSs :: [WorkspaceId] -> WSType
 ignoringWSs ts = WSIs . return $ (`notElem` ts) . tag


### PR DESCRIPTION
### Description

Documentation string doesn't contain full names of the types which might be misleading for someone trying to use its advice.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file

  - [ ] I updated the `XMonad.Doc.Extending` file (if appropriate)
