### PR TITLE
X.H.ManageDocks: Deprecate individual hooks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -495,6 +495,10 @@
     - Restored compatibility with pre-0.13 configs by making the startup hook
       unnecessary for correct functioning (strut cache is initialized on-demand).
 
+      This is a temporary measure, however. The individual hooks are now
+      deprecated in favor of the `docks` combinator, `xmonad --recompile` now
+      reports deprecation warnings, and the hooks will be removed soon.
+
     - Fixed ignoring of strut updates from override-redirect windows, which is
       default for xmobar.
 

--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -17,7 +17,6 @@ module XMonad.Hooks.ManageDocks (
     -- * Usage
     -- $usage
     docks, manageDocks, checkDock, AvoidStruts(..), avoidStruts, avoidStrutsOn,
-    docksEventHook, docksStartupHook,
     ToggleStruts(..),
     SetStruts(..),
     module XMonad.Util.Types,
@@ -28,8 +27,11 @@ module XMonad.Hooks.ManageDocks (
     RectC(..),
 #endif
 
-    -- for XMonad.Actions.FloatSnap
-    calcGap
+    -- * For developers of other modules ("XMonad.Actions.FloatSnap")
+    calcGap,
+
+    -- * Standalone hooks (deprecated)
+    docksEventHook, docksStartupHook,
     ) where
 
 
@@ -157,6 +159,7 @@ checkDock = ask >>= \w -> liftX $ do
 
 -- | Whenever a new dock appears, refresh the layout immediately to avoid the
 -- new dock.
+{-# DEPRECATED docksEventHook "Use docks instead." #-}
 docksEventHook :: Event -> X All
 docksEventHook MapNotifyEvent{ ev_window = w } = do
     whenX (runQuery checkDock w <&&> (not <$> isClient w)) $
@@ -174,6 +177,7 @@ docksEventHook DestroyWindowEvent{ ev_window = w } = do
     return (All True)
 docksEventHook _ = return (All True)
 
+{-# DEPRECATED docksStartupHook "Use docks instead." #-}
 docksStartupHook :: X ()
 docksStartupHook = void getStrutCache
 


### PR DESCRIPTION
### Description

This will make it easier to transition to an implementation of EWMH that doesn't expose the individual hooks: X.H.ManageDocks would become a deprecated compatibility reexport of X.H.EWMH.Struts for a release or two, but the individual hooks need to be removed before that.

Note that individual hooks in X.H.EwmhDesktops were deprecated earlier and individual hooks in XMonad.Hooks.UrgencyHook aren't exported any more (or perhaps never been), so this only leaves X.H.SetWMName, which unfortunately does not have a combinator interface at this point.

Related: https://github.com/xmonad/xmonad-contrib/pull/625

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - n/a I've considered how to best test these changes (property, unit, manually, ...) and concluded: XXX

  - [X] I updated the `CHANGES.md` file