### PR TITLE
Minor documentation fixes to `XMonad.Hooks.FadeWindows`

### DIFF
--- a/XMonad/Hooks/FadeWindows.hs
+++ b/XMonad/Hooks/FadeWindows.hs
@@ -176,7 +176,7 @@ fadeTo, translucence, fadeBy :: Rational -> FadeHook
 fadeTo       = transparency
 -- | An alias for 'transparency'.
 translucence = transparency
--- | An alias for 'transparency'.
+-- | An alias for 'opacity'.
 fadeBy       = opacity
 
 invisible, solid :: FadeHook


### PR DESCRIPTION
### Description

Some corrections to the documentation of `XMonad.Hooks.FadeWindows`. Some comments were for the wrong declaration (`^` instead of `|`), and one comment didn't match the definition.

I'm not sure if updating the CHANGES.md is necessary, since it's such a small change, only to the documentation.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: regenerated the docs

  - [ ] I updated the `CHANGES.md` file
