### PR TITLE
X.H.ManageHelpers: Add new operators

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,11 +67,6 @@
     - All of these were now removed. You can use the re-exported `def` from
       `Data.Default` instead.
 
-  * `XMonad.Hooks.ManageHelpers`
-
-    - Added `(^?)`, `(~?)` and `($?)` operators as infix versions of `isPrefixOf`, `isInfixOf`
-      and `isSuffixOf` working with `ManageHook`s.
-
   * `XMonad.Hooks.Script`
 
     - `execScriptHook` now has an `X` constraint (was: `MonadIO`), due to changes
@@ -524,6 +519,9 @@
       (using either the `WM_CLIENT_LEADER` or `_NET_WM_PID` property).
 
     - Added `windowTag`
+
+    - Added `(^?)`, `(~?)` and `($?)` operators as infix versions of `isPrefixOf`, `isInfixOf`
+      and `isSuffixOf` working with `ManageHook`s.
 
   * `XMonad.Util.EZConfig`
 

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -26,7 +26,7 @@
 -- >         ...
 -- >     }
 --
--- Some helpers defined here you can easily extend by yourself:
+-- Here's how you can define more helpers like the ones from this module:
 --
 -- > -- some function you want to transform into an infix operator
 -- > f :: a -> b -> Bool


### PR DESCRIPTION
### Description

Closes #628

Adds a couple of operators and a note about the way they defined.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
