### PR TITLE
Add XMonad.Layout.CenteredIfSingle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -157,6 +157,11 @@
 
 ### New Modules
 
+  * `XMonad.Layout.CenteredIfSingle`
+
+    Layout modifier that, if only a single window is on screen, places that window
+    in the middle of the screen.
+
   * `XMonad.Layout.FixedAspectRatio`
 
     Layout modifier for user provided per-window aspect ratios.

--- a/XMonad/Layout/CenteredIfSingle.hs
+++ b/XMonad/Layout/CenteredIfSingle.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Layout.CenteredIfSingle
+-- Description :  If only a single window is shown, center it on screen
+-- Copyright   :  (c) 2021 Leon Kowarschick
+-- License     :  BSD-style (see xmonad/LICENSE)
+--
+-- Maintainer  :  Leon Kowarschick. <TheElkOfWar@gmail.com>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- A layout modifier that, if there is only a single window on screen, places
+-- that window in the center of the screen.
+-- This is especially useful on wide screen setups, where the window would otherwise
+-- be unnecessarily far away from the center of your field of vision.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Layout.CenteredIfSingle
+  ( -- * Usage
+    -- $usage
+    centeredIfSingle, CenteredIfSingle
+  ) where
+
+import XMonad
+import XMonad.Prelude (fi)
+import XMonad.Layout.LayoutModifier
+
+-- $usage
+-- You can use this module by including  the following in your @~\/.xmonad/xmonad.hs@:
+--
+-- > import XMonad.Layout.CenteredIfSingle
+--
+-- and adding the 'centeredIfSingle' layoutmodifier to your layouts.
+--
+-- > myLayoutHook = centeredIfSingle 0.7 Grid ||| ...  
+--
+-- For more information on configuring your layouts see "XMonad.Doc.Extending".
+
+
+-- | Layout Modifier that places a window in the center of the screen, 
+-- leaving room on the left and right if there is only a single window
+newtype CenteredIfSingle a = CenteredIfSingle Double deriving (Show, Read)
+
+instance LayoutModifier CenteredIfSingle Window where
+  pureModifier (CenteredIfSingle ratio) r _ [(onlyWindow, _)] = ([(onlyWindow, rectangleCenterPiece ratio r)], Nothing)
+  pureModifier _ _ _ winRects = (winRects, Nothing)
+
+-- | Layout Modifier that places a window in the center of the screen, 
+-- leaving room on the left and right if there is only a single window
+centeredIfSingle :: Double -- ^ Ratio of the screen the centered window should take up. Should be a value between 0.0 and 1.0
+                 -> l a    -- ^ The layout that will be used if more than one window is open
+                 -> ModifiedLayout CenteredIfSingle l a
+centeredIfSingle ratio = ModifiedLayout (CenteredIfSingle ratio)
+
+-- | Calculate the center piece of a rectangle given the percentage of the outer rectangle it should occupy.
+rectangleCenterPiece :: Double -> Rectangle -> Rectangle
+rectangleCenterPiece ratio (Rectangle rx ry rw rh) = Rectangle start ry width rh
+  where
+    sides = floor $ fi rw * (1.0 - ratio) / 2
+    start = fi rx + sides
+    width = fi $ fi rw - sides * 2

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -214,6 +214,7 @@ library
                         XMonad.Layout.BorderResize
                         XMonad.Layout.BoringWindows
                         XMonad.Layout.ButtonDecoration
+                        XMonad.Layout.CenteredIfSingle
                         XMonad.Layout.CenteredMaster
                         XMonad.Layout.Circle
                         XMonad.Layout.Column


### PR DESCRIPTION
### Description

XMonad.Layout.CenteredIfSingle centers windows on screen as long as there is only a single window.
As soon as there are more than one windows, the modified layout is used as normal.

Small demonstration:

https://user-images.githubusercontent.com/5300871/139041003-a2ceb6ae-07d1-405d-9056-4001d14e8538.mp4



### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Manual testing is sufficient, I've been using this for months

  - [x] I updated the `CHANGES.md` file

  - [x] I updated the `XMonad.Doc.Extending` file (if appropriate)
