### PR TITLE
Add X.U.ActionQueue And X.H.BorderPerWindow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
     Layout modifier that, if only a single window is on screen, places that window
     in the middle of the screen.
 
+  * `XMonad.Util.ActionQueue`
+
+    Put XMonad actions in the queue to be executed every time the
+    `logHook` (or, alternatively, a hook of your choice) runs.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Prompt`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,11 @@
     Put XMonad actions in the queue to be executed every time the
     `logHook` (or, alternatively, a hook of your choice) runs.
 
+  * `XMonad.Hooks.BorderPerWindow`
+
+    While XMonad provides config to set all window borders at the same
+    width, this extension defines and sets border width for each window.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Prompt`

--- a/XMonad/Hooks/BorderPerWindow.hs
+++ b/XMonad/Hooks/BorderPerWindow.hs
@@ -1,0 +1,78 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Hooks.BorderPerWindow
+-- Description :  Set border width for each window in all layouts.
+-- Copyright   :  (c) 2021 Xiaokui Shu
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  subbyte@gmail.com
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Want to customize border width, for each window on all layouts? Want
+-- specific window have no border on all layouts? Try this.
+-----------------------------------------------------------------------------
+
+module XMonad.Hooks.BorderPerWindow ( -- * Usage
+                                      -- $usage
+                                      defineBorderWidth
+                                    , actionQueue
+
+                                      -- * Design Considerations
+                                      -- $design
+                                    ) where
+
+
+import Graphics.X11.Xlib (Dimension)
+import XMonad
+import XMonad.Util.ActionQueue (enqueue, actionQueue)
+
+-- $usage
+--
+-- To use this module, first import it
+--
+-- > import XMonad.Hooks.BorderPerWindow (defineBorderWidth, actionQueue)
+--
+-- Then specify which window to customize the border of in your
+-- @manageHook@:
+--
+-- > myManageHook :: ManageHook
+-- > myManageHook = composeAll
+-- >     [ className =? "firefox"  --> defineWindowWidth 0
+-- >     , className =? "Chromium" --> defineWindowWidth 0
+-- >     , isDialog                --> defineWindowWidth 8
+-- >     ]
+--
+-- Finally, add the 'actionQueue' combinator and @myManageHook@ to your
+-- config:
+--
+-- > main = xmonad $ actionQueue $ def
+-- >     { ...
+-- >     , manageHook = myManageHook
+-- >     , ...
+-- >     }
+--
+-- Note that this module is incompatible with other ways of changing
+-- borders, like "XMonad.Layout.NoBorders".  This is because we are
+-- changing the border exactly /once/ (when the window first appears)
+-- and not every time some condition is satisfied.
+
+-- $design
+--
+-- 1. Keep it simple. Since the extension does not aim to change border setting
+--    when layout changes, only execute the border setting function once to
+--    avoid potential window flashing/jumping/scaling.
+--
+-- 2. The 'ManageHook' eDSL is a nice language for specifying windows. Let's
+--    build on top of it and use it to specify window to define border.
+
+defineBorderWidth :: Dimension -> ManageHook
+defineBorderWidth bw = do
+    w <- ask
+    liftX . enqueue $ updateBorderWidth w bw
+    idHook
+
+updateBorderWidth :: Window -> Dimension -> X ()
+updateBorderWidth w bw = do
+    withDisplay $ \d -> io $ setWindowBorderWidth d w bw
+    refresh

--- a/XMonad/Util/ActionQueue.hs
+++ b/XMonad/Util/ActionQueue.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Util.ActionQueue
+-- Description :  Queue of XMonad actions
+-- Copyright   :  (c) 2021 Xiaokui Shu
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  subbyte@gmail.com
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Put XMonad actions in the queue to be executed in either the
+-- @logHook@ or another hook of your choice.
+-----------------------------------------------------------------------------
+
+module XMonad.Util.ActionQueue ( -- * Usage
+                                 -- $usage
+                                 ActionQueue
+                               , actionQueue
+                               , enqueue
+                               , exequeue
+                               ) where
+
+import XMonad
+import qualified XMonad.Util.ExtensibleConf  as XC
+import qualified XMonad.Util.ExtensibleState as XS
+
+import Data.Sequence (Seq (..), ViewL (..), viewl, (|>))
+
+-- $usage
+--
+-- This module provides a queue that, by default, gets executed every
+-- time the @logHook@ runs.  To use this module
+--
+-- 1. Enqueue `X ()` actions at the place you need; e.g.:
+--
+-- > enqueue myAction
+--
+-- 2. Add the 'actionQueue' combinator to your configuration:
+--
+-- > main = xmonad $ actionQueue $ def
+-- >     { ... }
+--
+-- This will execute all of the actions in the queue (if any) every time
+-- the @logHook@ runs.  Developers of other extensions using this module
+-- should re-export 'actionQueue'.
+--
+-- Alternatively, you can directly add 'exequeue' to a hook of your choice.
+-- This is discouraged when writing user-facing modules, as (accidentally)
+-- adding 'exequeue' to two different hooks might lead to undesirable
+-- behaviour.  'actionQueue' uses the "XMonad.Util.ExtensibleConf" interface to
+-- circumvent this.
+--
+
+newtype ActionQueue = ActionQueue (Seq (X ()))
+  deriving newtype (Semigroup)
+
+-- NOTE: The 'Semigroup' instance is technically wrong for a queue
+-- (simply appending two queues together).  However, since these are
+-- only needed for essentially the unit element and multiplication with
+-- the unit, this does not seem like a big deal.
+--
+-- Indeed, since 'ActionQueue' is exported as an abstract type, there is
+-- no way to build up a queue outside os using 'enqueue', meaning users
+-- can't abuse these.
+
+instance ExtensionClass ActionQueue where
+    initialValue = emptyQueue
+
+emptyQueue :: ActionQueue
+emptyQueue = ActionQueue mempty
+
+-- | Every time the @logHook@ runs, execute all actions in the queue.
+actionQueue :: XConfig l -> XConfig l
+actionQueue = XC.once (\cfg -> cfg{ logHook = logHook cfg <> exequeue })
+                      emptyQueue
+
+-- | Enqueue an action.
+enqueue :: X () -> X ()
+enqueue = XS.modify . go
+  where
+    go :: X () -> ActionQueue -> ActionQueue
+    go a (ActionQueue as) = ActionQueue $ as |> a
+
+-- | Execute every action in the queue.
+exequeue :: X ()
+exequeue = do
+    -- Note that we are executing all actions one by one.  Otherwise, we may
+    -- not execute the actions in the right order.  Any of them may call
+    -- 'refresh' or 'windows', which triggers the logHook, which may trigger
+    -- 'exequeue' again if it is used in the logHook.
+    ActionQueue aas <- XS.get
+    case viewl aas of
+      EmptyL  -> pure ()
+      a :< as -> do XS.put (ActionQueue as)
+                    a `catchX` pure ()
+                    exequeue

--- a/XMonad/Util/ExtensibleConf.hs
+++ b/XMonad/Util/ExtensibleConf.hs
@@ -62,7 +62,7 @@ import qualified Data.Map as M
 -- > newtype MyConf = MyConf{ fromMyConf :: [Int] } deriving Semigroup
 -- >
 -- > customLogger :: Int -> XConfig l -> XConfig l
--- > customLogger i = XC.once (MyConf [i]) $ \c -> c{ logHook = logHook c <> lh }
+-- > customLogger i = XC.once (\c -> c{ logHook = logHook c <> lh }) (MyConf [i])
 -- >   where
 -- >     lh :: X ()
 -- >     lh = XC.with $ io . print . fromMyConf

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -335,6 +335,7 @@ library
                         XMonad.Prompt.XMonad
                         XMonad.Prompt.Zsh
                         XMonad.Util.ActionCycle
+                        XMonad.Util.ActionQueue
                         XMonad.Util.ClickableWorkspaces
                         XMonad.Util.Cursor
                         XMonad.Util.CustomKeys

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -168,6 +168,7 @@ library
                         XMonad.Doc.Configuring
                         XMonad.Doc.Developing
                         XMonad.Doc.Extending
+                        XMonad.Hooks.BorderPerWindow
                         XMonad.Hooks.CurrentWorkspaceOnTop
                         XMonad.Hooks.DebugEvents
                         XMonad.Hooks.DebugKeyEvents


### PR DESCRIPTION
### Description

Here's a functionality that no existing extension covers: default border width is 4; a user wants `firefox` and `chromium` to have 0 border and `feh` to have border width 16. The border width is permanent and no need to change when switching between layouts. And the user wants to avoid any unnecessary visual effects, e.g., [window jumping](https://github.com/xmonad/xmonad-contrib/issues/316).

12 years ago, users first discussed this need [here](https://xmonad.haskell.narkive.com/130DKJDZ/how-to-make-a-window-floating-above-all-the-other-windows-and-border-less). Unfortunately, no working solution was provided. At the end of the discussion, _Magicloud_ said "the toggleBorder part does not work".

Recently I developed the same need, and asked the question in stackoverflow [Config No Border For Specific Windows in Xmonad](https://stackoverflow.com/questions/69725874/config-no-border-for-specific-windows-in-xmonad). After a few days, I figured out why _Magicloud_ said `ManageHook` does not work (detailed in [my answer](https://stackoverflow.com/a/69774944/8418198)) and wrote this PR to help others solve the same problem.

I put _why I think this is the best way to realize the functionality_ and _why there is no existing extension that implements exactly this_ in the docstring of the source code---the `$design` and `$options` sections.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I tested the new module manually to verify its behaviors.

  - [x] I updated the `CHANGES.md` file
