### PR TITLE
X.Prompt: Add transposeChars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Prompt`
+
+    - Added `transposeChars` to interchange the characters around the
+      point and bound it to `C-t` in the Emacs XPKeymaps.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

This is an analogue to Emacs's `transpose-chars` function (expect that
it does not take a universal argument), bound to its default keybinding.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Manually, for now.  The transposing logic isn't that complicated, but the whole prompt machinery makes this kind of hard to unit/property test.

  - [x] I updated the `CHANGES.md` file