### PR TITLE
Fallback fonts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,12 @@
     - Added `transposeChars` to interchange the characters around the
       point and bound it to `C-t` in the Emacs XPKeymaps.
 
+    - Added xft-based font fallback support.  This may be used by
+      appending other fonts to the given string:
+      `xft:iosevka-11,FontAwesome-9`.  Note that this requires
+      `xmonad-contrib` to be compiled with `X11-xft` version 0.3.4 or
+      higher.
+
   * `XMonad.Hooks.WindowSwallowing`
 
     - Fixed windows getting lost when used in conjunction with
@@ -52,6 +58,14 @@
     - The focused window will always be at the master area in the stack being
       passed onto the modified layout, even when focus leaves the workspace
       using the modified layout.
+
+  * `XMonad.Actions.TreeSelect`
+
+    - Added xft-based font fallback support.  This may be used by
+      appending other fonts to the given string:
+      `xft:iosevka-11,FontAwesome-9`.  Note that this requires
+      `xmonad-contrib` to be compiled with `X11-xft` version 0.3.4 or
+      higher.
 
 ## 0.17.0 (October 27, 2021)
 

--- a/XMonad/Actions/TreeSelect.hs
+++ b/XMonad/Actions/TreeSelect.hs
@@ -79,8 +79,9 @@ import XMonad.Hooks.WorkspaceHistory
 import qualified Data.Map as M
 
 #ifdef XFT
-import Graphics.X11.Xft
+import qualified Data.List.NonEmpty as NE
 import Graphics.X11.Xrender
+import Graphics.X11.Xft
 #endif
 
 -- $usage
@@ -648,10 +649,14 @@ drawStringXMF display window visual colormap gc font col x y text = case font of
         setForeground display gc col
         wcDrawImageString display window fnt gc x y text
 #ifdef XFT
-    Xft fnt -> do
+    Xft fnts -> do
         withXftDraw display window visual colormap $
             \ft_draw -> withXftColorValue display visual colormap (fromARGB col) $
-            \ft_color -> xftDrawString ft_draw ft_color fnt x y text
+#if MIN_VERSION_X11_xft(0, 3, 4)
+            \ft_color -> xftDrawStringFallback ft_draw ft_color (NE.toList fnts) (fi x) (fi y) text
+#else
+            \ft_color -> xftDrawString ft_draw ft_color (NE.head fnts) x y text
+#endif
 
 -- | Convert 'Pixel' to 'XRenderColor'
 --


### PR DESCRIPTION
### Description

Related to #208. Moving [MinXft](https://github.com/jaor/xmobar/blob/master/src/Xmobar/X11/MinXft.hsc) library and [xmobar's fallback fonts logic](https://github.com/jaor/xmobar/blob/master/src/Xmobar/X11/Text.hs) to XMonad prompts, tabs labels, etc. So now, for example, prompts are able to display text and emoji. You can specify fonts to use through comma-separated list.  It also requires manual bindings from the Xft library, because https://hackage.haskell.org/package/X11-xft doesn't have binding for vital `XftCharExists` function.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
