### PR TITLE
Prefer safe alternatives to getWindowAttributes

### DIFF
--- a/XMonad/Actions/ConstrainedResize.hs
+++ b/XMonad/Actions/ConstrainedResize.hs
@@ -44,8 +44,8 @@ import XMonad
 
 -- | Resize (floating) window with optional aspect ratio constraints.
 mouseResizeWindow :: Window -> Bool -> X ()
-mouseResizeWindow w c = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+mouseResizeWindow w c = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     sh <- io $ getWMNormalHints d w
     io $ warpPointer d none w 0 0 0 0 (fromIntegral (wa_width wa)) (fromIntegral (wa_height wa))
     mouseDrag (\ex ey -> do

--- a/XMonad/Actions/FlexibleResize.hs
+++ b/XMonad/Actions/FlexibleResize.hs
@@ -50,8 +50,8 @@ mouseResizeEdgeWindow
   :: Rational -- ^ The size of the area where only one edge is resized.
   -> Window   -- ^ The window to resize.
   -> X ()
-mouseResizeEdgeWindow edge w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+mouseResizeEdgeWindow edge w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     sh <- io $ getWMNormalHints d w
     (_, _, _, _, _, ix, iy, _) <- io $ queryPointer d w
     let

--- a/XMonad/Actions/FloatKeys.hs
+++ b/XMonad/Actions/FloatKeys.hs
@@ -44,8 +44,8 @@ import XMonad.Prelude (fi)
 -- | @keysMoveWindow (dx, dy)@ moves the window by @dx@ pixels to the
 --   right and @dy@ pixels down.
 keysMoveWindow :: D -> Window -> X ()
-keysMoveWindow (dx,dy) w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+keysMoveWindow (dx,dy) w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     io $ moveWindow d w (fi (fi (wa_x wa) + dx))
                         (fi (fi (wa_y wa) + dy))
     float w
@@ -61,8 +61,8 @@ keysMoveWindow (dx,dy) w = whenX (isClient w) $ withDisplay $ \d -> do
 -- > keysMoveWindowTo (512,384) (1%2, 1%2) -- center the window on screen
 -- > keysMoveWindowTo (1024,0) (1, 0)      -- put window in the top right corner
 keysMoveWindowTo :: P -> G -> Window -> X ()
-keysMoveWindowTo (x,y) (gx, gy) w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+keysMoveWindowTo (x,y) (gx, gy) w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     io $ moveWindow d w (x - round (gx * fi (wa_width wa)))
                         (y - round (gy * fi (wa_height wa)))
     float w
@@ -113,8 +113,8 @@ keysResizeWindow' sh (x,y) (w,h) (dx,dy) (gx, gy) = ((nx, ny), (nw, nh))
         ny = round $ fi y + gy * fi h - gy * fi nh
 
 keysMoveResize :: (SizeHints -> P -> D -> a -> b -> (P,D)) -> a -> b -> Window -> X ()
-keysMoveResize f move resize w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+keysMoveResize f move resize w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     sh <- io $ getWMNormalHints d w
     let wa_dim = (fi $ wa_width wa, fi $ wa_height wa)
         wa_pos = (fi $ wa_x wa, fi $ wa_y wa)

--- a/XMonad/Actions/FloatSnap.hs
+++ b/XMonad/Actions/FloatSnap.hs
@@ -92,8 +92,8 @@ snapMagicMouseResize
     -> Maybe Int -- ^ The maximum distance to snap. Use Nothing to not impose any boundary.
     -> Window    -- ^ The window to move and resize.
     -> X ()
-snapMagicMouseResize middle collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+snapMagicMouseResize middle collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     (_, _, _, px, py, _, _, _) <- io $ queryPointer d w
     let x = (fromIntegral px - wx wa)/ww wa
         y = (fromIntegral py - wy wa)/wh wa
@@ -119,9 +119,8 @@ snapMagicResize
     -> Maybe Int   -- ^ The maximum distance to snap. Use Nothing to not impose any boundary.
     -> Window      -- ^ The window to move and resize.
     -> X ()
-snapMagicResize dir collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
-
+snapMagicResize dir collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     (xbegin,xend) <- handleAxis True d wa
     (ybegin,yend) <- handleAxis False d wa
 
@@ -168,9 +167,8 @@ snapMagicMove
     -> Maybe Int -- ^ The maximum distance to snap. Use Nothing to not impose any boundary.
     -> Window    -- ^ The window to move.
     -> X ()
-snapMagicMove collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
-
+snapMagicMove collidedist snapdist w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     nx <- handleAxis True d wa
     ny <- handleAxis False d wa
 
@@ -208,8 +206,8 @@ snapMove U = doSnapMove False True
 snapMove D = doSnapMove False False
 
 doSnapMove :: Bool -> Bool -> Maybe Int -> Window -> X ()
-doSnapMove horiz rev collidedist w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+doSnapMove horiz rev collidedist w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     ((bl,br,_),(fl,fr,_)) <- getSnap horiz collidedist d w
 
     let (mb,mf) = if rev then (bl,fl)
@@ -247,8 +245,8 @@ snapShrink
 snapShrink = snapResize False
 
 snapResize :: Bool -> Direction2D -> Maybe Int -> Window -> X ()
-snapResize grow dir collidedist w = whenX (isClient w) $ withDisplay $ \d -> do
-    wa <- io $ getWindowAttributes d w
+snapResize grow dir collidedist w = whenX (isClient w) $ withDisplay $ \d ->
+  withWindowAttributes d w $ \wa -> do
     mr <- case dir of
               L -> do ((mg,ms,_),(_,_,_)) <- getSnap True collidedist d w
                       return $ case (if grow then mg else ms) of

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -616,11 +616,8 @@ actOnScreens act wrap = withWindowSet $ \winset -> do
 
 -- | Determines whether a given window is mapped
 isMapped :: Window -> X Bool
-isMapped win  =  withDisplay
-              $  \dpy -> io
-              $  (waIsUnmapped /=)
-              .  wa_map_state
-             <$> getWindowAttributes dpy win
+isMapped = fmap (maybe False ((waIsUnmapped /=) .  wa_map_state))
+         . safeGetWindowAttributes
 
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------

--- a/XMonad/Actions/NoBorders.hs
+++ b/XMonad/Actions/NoBorders.hs
@@ -27,8 +27,7 @@ import XMonad
 toggleBorder :: Window -> X ()
 toggleBorder w = do
     bw <- asks (borderWidth . config)
-    withDisplay $ \d -> io $ do
-        cw <- wa_border_width <$> getWindowAttributes d w
-        if cw == 0
+    withDisplay $ \d -> withWindowAttributes d w $ \wa -> io $
+        if wa_border_width wa == 0
             then setWindowBorderWidth d w bw
             else setWindowBorderWidth d w 0

--- a/XMonad/Actions/TiledWindowDragging.hs
+++ b/XMonad/Actions/TiledWindowDragging.hs
@@ -48,10 +48,11 @@ import           XMonad.Layout.DraggingVisualizer
 -- | Create a mouse binding for this to be able to drag your windows around.
 -- You need "XMonad.Layout.DraggingVisualizer" for this to look good.
 dragWindow :: Window -> X ()
-dragWindow window = whenX (isClient window) $ do
+dragWindow window = whenX (isClient window) $ withDisplay $ \dpy ->
+  withWindowAttributes dpy window $ \wa -> do
     focus window
-    (offsetX, offsetY)                <- getPointerOffset window
-    (winX, winY, winWidth, winHeight) <- getWindowPlacement window
+    (offsetX, offsetY)                    <- getPointerOffset window
+    let (winX, winY, winWidth, winHeight)  = getWindowPlacement wa
 
     mouseDrag
         (\posX posY ->
@@ -71,11 +72,8 @@ getPointerOffset win = do
     return (fi oX, fi oY)
 
 -- | return a tuple of windowX, windowY, windowWidth, windowHeight
-getWindowPlacement :: Window -> X (Int, Int, Int, Int)
-getWindowPlacement window = do
-    wa <- withDisplay (\d -> io $ getWindowAttributes d window)
-    return (fi $ wa_x wa, fi $ wa_y wa, fi $ wa_width wa, fi $ wa_height wa)
-
+getWindowPlacement :: WindowAttributes -> (Int, Int, Int, Int)
+getWindowPlacement wa = (fi $ wa_x wa, fi $ wa_y wa, fi $ wa_width wa, fi $ wa_height wa)
 
 performWindowSwitching :: Window -> X ()
 performWindowSwitching win = do

--- a/XMonad/Actions/UpdatePointer.hs
+++ b/XMonad/Actions/UpdatePointer.hs
@@ -28,7 +28,6 @@ import XMonad
 import XMonad.Prelude
 import XMonad.StackSet (member, peek, screenDetail, current)
 
-import Control.Exception (SomeException, try)
 import Control.Arrow ((&&&), (***))
 
 -- $usage
@@ -73,10 +72,9 @@ updatePointer refPos ratio = do
   let defaultRect = screenRect $ screenDetail $ current ws
   rect <- case peek ws of
         Nothing -> return defaultRect
-        Just w  -> do tryAttributes <- io $ try $ getWindowAttributes dpy w
-                      return $ case tryAttributes of
-                        Left (_ :: SomeException) -> defaultRect
-                        Right attributes          -> windowAttributesToRectangle attributes
+        Just w  -> maybe defaultRect windowAttributesToRectangle
+               <$> safeGetWindowAttributes w
+
   root <- asks theRoot
   mouseIsMoving <- asks mouseFocused
   (_sameRoot,_,currentWindow,rootX,rootY,_,_,_) <- io $ queryPointer dpy root

--- a/XMonad/Actions/Warp.hs
+++ b/XMonad/Actions/Warp.hs
@@ -91,11 +91,9 @@ warp w x y = withDisplay $ \d -> io $ warpPointer d none w 0 0 0 0 x y
 -- | Warp the pointer to a given position relative to the currently
 --   focused window.  Top left = (0,0), bottom right = (1,1).
 warpToWindow :: Rational -> Rational -> X ()
-warpToWindow h v =
-    withDisplay $ \d ->
-        withFocused $ \w -> do
-            wa <- io $ getWindowAttributes d w
-            warp w (fraction h (wa_width wa)) (fraction v (wa_height wa))
+warpToWindow h v = withDisplay $ \d -> withFocused $ \w ->
+  withWindowAttributes d w $ \wa ->
+    warp w (fraction h (wa_width wa)) (fraction v (wa_height wa))
 
 -- | Warp the pointer to the given position (top left = (0,0), bottom
 --   right = (1,1)) on the given screen.

--- a/XMonad/Actions/WindowMenu.hs
+++ b/XMonad/Actions/WindowMenu.hs
@@ -51,9 +51,9 @@ colorizer _ isFg = do
                 else (nBC, fBC)
 
 windowMenu :: X ()
-windowMenu = withFocused $ \w -> do
+windowMenu = withFocused $ \w -> withDisplay $ \d -> withWindowAttributes d w $ \wa -> do
     tags <- asks (workspaces . config)
-    Rectangle x y wh ht <- getSize w
+    let Rectangle x y wh ht = getSize wa
     Rectangle sx sy swh sht <- gets $ screenRect . W.screenDetail . W.current . windowset
     let originFractX = (fi x - fi sx + fi wh / 2) / fi swh
         originFractY = (fi y - fi sy + fi ht / 2) / fi sht
@@ -69,12 +69,10 @@ windowMenu = withFocused $ \w -> do
                     | tag <- tags ]
     runSelectedAction gsConfig actions
 
-getSize :: Window -> X Rectangle
-getSize w = do
-  d  <- asks display
-  wa <- io $ getWindowAttributes d w
+getSize :: WindowAttributes -> Rectangle
+getSize wa =
   let x = fi $ wa_x wa
       y = fi $ wa_y wa
       wh = fi $ wa_width wa
       ht = fi $ wa_height wa
-  return (Rectangle x y wh ht)
+   in Rectangle x y wh ht

--- a/XMonad/Hooks/PositionStoreHooks.hs
+++ b/XMonad/Hooks/PositionStoreHooks.hs
@@ -68,10 +68,9 @@ positionStoreManageHook :: Maybe Theme -> ManageHook
 positionStoreManageHook mDecoTheme = ask >>= liftX . positionStoreInit mDecoTheme >> idHook
 
 positionStoreInit :: Maybe Theme -> Window -> X ()
-positionStoreInit mDecoTheme w  = withDisplay $ \d -> do
+positionStoreInit mDecoTheme w  = withDisplay $ \d -> withWindowAttributes d w $ \wa -> do
         let decoH = maybe 0 decoHeight mDecoTheme   -- take decoration into account, which - in its current
                                                     -- form - makes windows smaller to make room for it
-        wa <- io $ getWindowAttributes d w
         ws <- gets windowset
         arbitraryOffsetX <- randomIntOffset
         arbitraryOffsetY <- randomIntOffset

--- a/XMonad/Layout/FixedColumn.hs
+++ b/XMonad/Layout/FixedColumn.hs
@@ -23,17 +23,9 @@ module XMonad.Layout.FixedColumn (
         FixedColumn(..)
 ) where
 
-import Graphics.X11.Xlib (Window, rect_width)
-import Graphics.X11.Xlib.Extras ( getWMNormalHints
-                                , getWindowAttributes
-                                , sh_base_size
-                                , sh_resize_inc
-                                , wa_border_width)
-
-import XMonad.Prelude (fromMaybe, msum, (<&>))
-import XMonad.Core (X, LayoutClass(..), fromMessage, io, withDisplay)
-import XMonad.Layout (Resize(..), IncMasterN(..), tile)
-import XMonad.StackSet as W
+import XMonad
+import XMonad.Prelude
+import qualified XMonad.StackSet as W
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
@@ -82,9 +74,10 @@ instance LayoutClass FixedColumn Window where
 --   columns wide, using @inc@ as a resize increment for windows that
 --   don't have one
 widthCols :: Int -> Int -> Window -> X Int
-widthCols inc n w = withDisplay $ \d -> io $ do
-    sh <- getWMNormalHints d w
-    bw <- fromIntegral . wa_border_width <$> getWindowAttributes d w
+widthCols inc n w = do
+    d  <- asks display
+    bw <- asks $ fi . borderWidth . config
+    sh <- io $ getWMNormalHints d w
     let widthHint f = f sh <&> fromIntegral . fst
         oneCol      = fromMaybe inc $ widthHint sh_resize_inc
         base        = fromMaybe 0 $ widthHint sh_base_size

--- a/XMonad/Layout/LayoutScreens.hs
+++ b/XMonad/Layout/LayoutScreens.hs
@@ -62,8 +62,9 @@ import qualified XMonad.StackSet as W
 -- | Modify all screens.
 layoutScreens :: LayoutClass l Int => Int -> l Int -> X ()
 layoutScreens nscr _ | nscr < 1 = trace $ "Can't layoutScreens with only " ++ show nscr ++ " screens."
-layoutScreens nscr l =
-    do rtrect <- asks theRoot >>= getWindowRectangle
+layoutScreens nscr l = asks theRoot >>= \w -> withDisplay $ \d ->
+  withWindowAttributes d w $ \attrs ->
+    do let rtrect = windowRectangle attrs
        (wss, _) <- runLayout (W.Workspace "" l (Just $ W.Stack { W.focus=1, W.up=[],W.down=[1..nscr-1] })) rtrect
        windows $ \ws@W.StackSet{ W.current = v, W.visible = vs, W.hidden = hs } ->
            let x = W.workspace v
@@ -88,11 +89,9 @@ layoutSplitScreen nscr l =
                                 map (\v -> if W.screen v>W.screen c then v{W.screen = W.screen v + fromIntegral (nscr-1)} else v) vs
                   , W.hidden  = ys }
 
-getWindowRectangle :: Window -> X Rectangle
-getWindowRectangle w = withDisplay $ \d ->
-    do a <- io $ getWindowAttributes d w
-       return $ Rectangle (fromIntegral $ wa_x a)     (fromIntegral $ wa_y a)
-                          (fromIntegral $ wa_width a) (fromIntegral $ wa_height a)
+windowRectangle :: WindowAttributes -> Rectangle
+windowRectangle a = Rectangle (fromIntegral $ wa_x a)     (fromIntegral $ wa_y a)
+                              (fromIntegral $ wa_width a) (fromIntegral $ wa_height a)
 
 newtype FixedLayout a = FixedLayout [Rectangle] deriving (Read,Show)
 

--- a/XMonad/Prelude.hs
+++ b/XMonad/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase   #-}
 --------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Prelude
@@ -20,7 +21,11 @@ module XMonad.Prelude (
     (!?),
     NonEmpty((:|)),
     notEmpty,
+    safeGetWindowAttributes,
 ) where
+
+import Foreign (alloca, peek)
+import XMonad
 
 import Control.Applicative as Exports
 import Control.Monad       as Exports
@@ -68,3 +73,10 @@ chunksOf i xs = chunk : chunksOf i rest
 notEmpty :: HasCallStack => [a] -> NonEmpty a
 notEmpty [] = error "unexpected empty list"
 notEmpty (x:xs) = x :| xs
+
+-- | A safe version of 'Graphics.X11.Extras.getWindowAttributes'.
+safeGetWindowAttributes :: Window -> X (Maybe WindowAttributes)
+safeGetWindowAttributes w = withDisplay $ \dpy -> io . alloca $ \p ->
+  xGetWindowAttributes dpy w p >>= \case
+    0 -> pure Nothing
+    _ -> Just <$> peek p

--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -23,7 +23,6 @@ import           XMonad.Prelude
 
 import           Codec.Binary.UTF8.String        (decodeString)
 import           Control.Exception                                     as E
-import           Foreign
 import           Foreign.C.String
 import           Numeric                         (showHex)
 import           System.Exit
@@ -35,7 +34,7 @@ debugWindow   :: Window -> X String
 debugWindow 0 =  return "-no window-"
 debugWindow w =  do
   let wx = pad 8 '0' $ showHex w ""
-  w' <- withDisplay $ \d -> io (safeGetWindowAttributes d w)
+  w' <- safeGetWindowAttributes w
   case w' of
     Nothing                                   ->
       return $ "(deleted window " ++ wx ++ ")"

--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -153,14 +153,6 @@ wrap s =  ' ' : '"' : wrap' s ++ "\""
                   | otherwise  =        s' : wrap' ss
     wrap' ""                   =             ""
 
--- Graphics.X11.Extras.getWindowAttributes is bugggggggy
-safeGetWindowAttributes     :: Display -> Window -> IO (Maybe WindowAttributes)
-safeGetWindowAttributes d w =  alloca $ \p -> do
-  s <- xGetWindowAttributes d w p
-  case s of
-    0 -> return Nothing
-    _ -> Just <$> peek p
-
 -- and so is getCommand
 safeGetCommand     :: Display -> Window -> X [String]
 safeGetCommand d w =  do


### PR DESCRIPTION
### Description

Since X11 is unlikely to get safe bindings anytime soon, I figured this was better than nothing.

##### X.Prelude: Add safeGetWindowAttributes

Move the function from X.U.DebugWindow, where it was defined already.
This is a safe version of getWindowAttributes, returning a Maybe instead
of throwing an exception, in case the window attributes could not be
retrieved.

##### Prefer safe alternatives to getWindowAttributes

Whenever possible, prefer the safe wrappers withWindowAttributes or
safeGetWindowAttributes to getWindowAttributes.

Places where these are not applicable are limited to layouts, where
there is not good "default value" to give back in case these calls fail.
In these cases, we let the exception handling of the layout mechanism
handle it and fall back to the Full layout.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/146

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: it compiles...!

  - [ ] I updated the `CHANGES.md` file
  I'm not sure this warrants an entry since it's not a user-facing change.