### PR TITLE
X.A.WindowNavigation: fix navigation being "stuck" in certain situations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,11 @@
     - Flipped how `(^?)`, `(~?)`, and `($?)` work to more accurately
       reflect how one uses these operators.
 
+  * `XMonad.Actions.WindowNavigation`
+
+    -  Fixed navigation getting "stuck" in certain situations for
+       widescreen resolutions.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/XMonad/Actions/WindowNavigation.hs
+++ b/XMonad/Actions/WindowNavigation.hs
@@ -209,9 +209,9 @@ inr D (Point px py) (Rectangle rx ry w h) = px >= rx && px < rx + fromIntegral w
                                                         py < ry + fromIntegral h
 inr U (Point px py) (Rectangle rx ry w _) = px >= rx && px < rx + fromIntegral w &&
                                             py >  ry
-inr R (Point px py) (Rectangle rx ry _ h) = px <  rx &&
+inr R (Point px py) (Rectangle rx ry w h) =             px < rx + fromIntegral w &&
                                             py >= ry && py < ry + fromIntegral h
-inr L (Point px py) (Rectangle rx ry w h) =             px > rx + fromIntegral w &&
+inr L (Point px py) (Rectangle rx ry _ h) = px >  rx &&
                                             py >= ry && py < ry + fromIntegral h
 
 sortby :: Direction2D -> [(a,Rectangle)] -> [(a,Rectangle)]


### PR DESCRIPTION
### Description

Update left and right navigation to behave correctly even if the currently saved position is directly on the edge of the focused
window.
This makes the L/R behavior consistent with U/D navigation.

How to reproduce the issue:
- configure Grid layout;
- open 4 terminals;
- navigate to the top-right terminal;
- open another terminal;
- immediately close it;
- try navigating left from the currently focused top-right terminal;
- observe navigation being "stuck".

Minimized configuration to test the issue:

```hs
{-# OPTIONS_GHC -fno-warn-type-defaults #-}

import XMonad
import XMonad.Config.Xfce
import XMonad.Hooks.SetWMName
import XMonad.Layout.Grid
import XMonad.Actions.WindowNavigation

main :: IO ()
main = do
  myConfig <- withWindowNavigation (xK_k, xK_h, xK_j, xK_l) $
              xfceConfig
              { terminal = "gnome-terminal"
              , modMask = mod4Mask
              , layoutHook = GridRatio (4/3)
              , startupHook = do
                  startupHook xfceConfig
                  setWMName "LG3D"
              , workspaces = map show [0..15]
              }
  xmonad myConfig
```

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I've tested the changes manually.

  - [X] I updated the `CHANGES.md` file
