### PR TITLE
Fix memory leaks on `historyHook` and `workspaceHistoryHook`

### DIFF
--- a/XMonad/Hooks/WorkspaceHistory.hs
+++ b/XMonad/Hooks/WorkspaceHistory.hs
@@ -77,8 +77,10 @@ workspaceHistoryHook = gets windowset >>= (XS.modify . updateLastActiveOnEachScr
 -- | Like 'workspaceHistoryHook', but with the ability to exclude
 -- certain workspaces.
 workspaceHistoryHookExclude :: [WorkspaceId] -> X ()
-workspaceHistoryHookExclude ws =
-  gets windowset >>= XS.modify . updateLastActiveOnEachScreenExclude ws
+workspaceHistoryHookExclude ws = do
+  s <- gets windowset
+  let update' a = force (updateLastActiveOnEachScreenExclude ws s a)
+  XS.modify' update'
 
 workspaceHistoryWithScreen :: X [(ScreenId, WorkspaceId)]
 workspaceHistoryWithScreen = XS.gets history

--- a/XMonad/Util/ExtensibleState.hs
+++ b/XMonad/Util/ExtensibleState.hs
@@ -94,7 +94,7 @@ modify f = put . f =<< get
 -- | Like @modify@ but the result value is applied strictly in respect to
 -- the monadic environment.
 modify' :: (ExtensionClass a, XLike m) => (a -> a) -> m ()
-modify' f = (\a -> let res = f a in res `seq` put res) =<< get
+modify' f = (put $!) . f =<< get
 
 -- | Add a value to the extensible state field. A previously stored value with the same
 -- type will be overwritten. (More precisely: A value whose string representation of its type

--- a/XMonad/Util/ExtensibleState.hs
+++ b/XMonad/Util/ExtensibleState.hs
@@ -20,6 +20,7 @@ module XMonad.Util.ExtensibleState (
                               -- $usage
                               put
                               , modify
+                              , modify'
                               , remove
                               , get
                               , gets
@@ -89,6 +90,11 @@ modifyStateExts f = State.modify $ \st -> st { extensibleState = f (extensibleSt
 -- is none.
 modify :: (ExtensionClass a, XLike m) => (a -> a) -> m ()
 modify f = put . f =<< get
+
+-- | Like @modify@ but the result value is applied strictly in respect to
+-- the monadic environment.
+modify' :: (ExtensionClass a, XLike m) => (a -> a) -> m ()
+modify' f = (\a -> let res = f a in res `seq` put res) =<< get
 
 -- | Add a value to the extensible state field. A previously stored value with the same
 -- type will be overwritten. (More precisely: A value whose string representation of its type

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -61,7 +61,8 @@ library
                    unix,
                    X11 >= 1.10 && < 1.11,
                    xmonad >= 0.16.99999 && < 0.18,
-                   utf8-string
+                   utf8-string,
+                   parallel
     default-language: Haskell2010
 
     cpp-options:   -DXMONAD_CONTRIB_VERSION_MAJOR=0
@@ -448,6 +449,7 @@ test-suite tests
                , process
                , unix
                , utf8-string
+               , parallel
                , xmonad >= 0.16.9999 && < 0.18
   cpp-options: -DTESTING
   ghc-options: -Wall -Wno-unused-do-bind

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -62,7 +62,7 @@ library
                    X11 >= 1.10 && < 1.11,
                    xmonad >= 0.16.99999 && < 0.18,
                    utf8-string,
-                   parallel
+                   deepseq
     default-language: Haskell2010
 
     cpp-options:   -DXMONAD_CONTRIB_VERSION_MAJOR=0
@@ -449,7 +449,7 @@ test-suite tests
                , process
                , unix
                , utf8-string
-               , parallel
+               , deepseq
                , xmonad >= 0.16.9999 && < 0.18
   cpp-options: -DTESTING
   ghc-options: -Wall -Wno-unused-do-bind


### PR DESCRIPTION
### Description

Both of these hooks leaked memory on long running sessions.
![per-cost-center](https://user-images.githubusercontent.com/1875145/142929692-f70a8e3f-ae43-448e-9a70-ae304e637ec1.png)

To fix it I had to force the thunks stored on the hooks as the compiler wouldn't be able to see where they would be demanded as they depended on the user interaction. Now the graph looks like this.
![fixed-leak](https://user-images.githubusercontent.com/1875145/142930233-a50bd8d6-733b-4315-8307-3e96e2851ec9.png)

The most polemic change on this PR is the inclusion of the `parallel` library as a dependency. I needed for the `Control.Seq` module which gave me combinators to force just enough of the `Data.Seq` and `[]` data types.

### Checklist

  - [🗸] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [🗸] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: It shows the memory improvements!

  - [🗸] I updated the `CHANGES.md` file (None)
