### PR TITLE
X.L.MagicFocus: always use focused as master

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,12 @@
     -  Fixed navigation getting "stuck" in certain situations for
        widescreen resolutions.
 
+  * `XMonad.Layout.MagicFocus`
+
+    - The focused window will always be at the master area in the stack being
+      passed onto the modified layout, even when focus leaves the workspace
+      using the modified layout.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/XMonad/Layout/MagicFocus.hs
+++ b/XMonad/Layout/MagicFocus.hs
@@ -57,14 +57,11 @@ magicFocus = ModifiedLayout MagicFocus
 data MagicFocus a = MagicFocus deriving (Show, Read)
 
 instance LayoutModifier MagicFocus Window where
-  modifyLayout MagicFocus (W.Workspace i l s) r =
-    withWindowSet $ \wset ->
-      runLayout (W.Workspace i l (s >>= \st -> Just $ swap st (W.peek wset))) r
+  modifyLayout MagicFocus (W.Workspace i l s) =
+    runLayout (W.Workspace i l (s >>= Just . shift))
 
-swap :: (Eq a) => W.Stack a -> Maybe a -> W.Stack a
-swap (W.Stack f u d) focused
-    | Just f == focused = W.Stack f [] (reverse u ++ d)
-    | otherwise         = W.Stack f u d
+shift :: (Eq a) => W.Stack a -> W.Stack a
+shift (W.Stack f u d) = W.Stack f [] (reverse u ++ d)
 
 -- | An eventHook that overrides the normal focusFollowsMouse. When the mouse
 -- it moved to another window, that window is replaced as the master, and the


### PR DESCRIPTION
### Description

Instead of searching for the currently focused window across workspaces,
make it so there is never any window above focus on the Stack that is
given to the modified layout.

Closes #657.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually

  - [x] I updated the `CHANGES.md` file
