### PR TITLE
Add SPStorage to exports of XMonad.Util.DynamicScratchpads

### DIFF
--- a/XMonad/Util/DynamicScratchpads.hs
+++ b/XMonad/Util/DynamicScratchpads.hs
@@ -17,7 +17,8 @@ module XMonad.Util.DynamicScratchpads (
   -- * Usage
   -- $usage
   makeDynamicSP,
-  spawnDynamicSP
+  spawnDynamicSP,
+  SPStorage
   ) where
 
 import Graphics.X11.Types


### PR DESCRIPTION
### Description

Allow the user of DynamicScratchpads to access the current DynamicScratchpads state.

### Checklist

  - [ x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
