### PR TITLE
XMonad.Hooks.Statusbar: Add parentheses to example

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,10 @@
       `xmonad-contrib` to be compiled with `X11-xft` version 0.3.4 or
       higher.
 
+  * `XMonad.Hooks.StatusBar`
+
+    - Added missing parentheses to example in multiple status bars section
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/XMonad/Hooks/StatusBar.hs
+++ b/XMonad/Hooks/StatusBar.hs
@@ -377,7 +377,7 @@ statusBarPipe cmd xpp = do
 --
 -- > xmobarrc_top
 -- > Config { ...
--- >        , commands = [ Run XPropertyLog "_XMONAD_LOG_1", ... ]
+-- >        , commands = [ Run (XPropertyLog "_XMONAD_LOG_1"), ... ]
 -- >        , template = "%_XMONAD_LOG_1% }{ ..."
 -- >        }
 --


### PR DESCRIPTION
### Description

Add (required) missing parentheses to example xmobar config code in the multiple status bars section of XMonad.Hooks.Statusbar.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: no change needed(?)

  - [x] I updated the `CHANGES.md` file
