### PR TITLE
Document interaction of `avoidStruts` with the screen rectangle

### DIFF
--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -216,12 +216,18 @@ calcGap ss = do
 
 -- | Adjust layout automagically: don't cover up any docks, status
 --   bars, etc.
+--
+--   Note that this modifier must be applied before any modifier that
+--   changes the screen rectangle, or struts will be applied in the wrong
+--   place and may affect the other modifier(s) in odd ways. This is
+--   most commonly seen with the 'spacing' modifier and friends.
 avoidStruts :: LayoutClass l a => l a -> ModifiedLayout AvoidStruts l a
 avoidStruts = avoidStrutsOn [U,D,L,R]
 
 -- | Adjust layout automagically: don't cover up docks, status bars,
---   etc. on the indicated sides of the screen.  Valid sides are U
---   (top), D (bottom), R (right), or L (left).
+--   etc. on the indicated sides of the screen.  Valid sides are 'U'
+--   (top), 'D' (bottom), 'R' (right), or 'L' (left). The warning in
+--   'avoidStruts' applies to this modifier as well.
 avoidStrutsOn :: LayoutClass l a =>
                  [Direction2D]
               -> l a

--- a/XMonad/Layout/Gaps.hs
+++ b/XMonad/Layout/Gaps.hs
@@ -91,6 +91,10 @@ import XMonad.Util.Types (Direction2D(..))
 --
 -- To configure gaps differently per-screen, use
 -- "XMonad.Layout.PerScreen" (coming soon).
+--
+-- __Warning__: If you also use the 'avoidStruts' layout modifier, it
+-- must come /before/ any of these modifiers. See the documentation of
+-- 'avoidStruts' for details.
 
 -- | A manual gap configuration.  Each side of the screen on which a
 --   gap is enabled is paired with a size in pixels.

--- a/XMonad/Layout/Spacing.hs
+++ b/XMonad/Layout/Spacing.hs
@@ -96,6 +96,10 @@ import           XMonad.Actions.MessageFeedback
 --     every direction.
 --
 --   - @True@: Enable the 'windowBorder'.
+--
+-- __Warning__: If you also use the 'avoidStruts' layout modifier, it
+-- must come /before/ any of these modifiers. See the documentation of
+-- 'avoidStruts' for details.
 
 -- | Represent the borders of a rectangle.
 data Border = Border


### PR DESCRIPTION
### Description

Document the interaction between `avoidStruts` and layout modifiers that affect the screen rectangle. Fixes https://github.com/xmonad/xmonad-contrib/issues/665.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: no testing, documentation only

  - [n/a] I updated the `CHANGES.md` file
