### PR TITLE
document need for `manageSpawn` in `SpawnOnce`

### DIFF
--- a/XMonad/Util/SpawnOnce.hs
+++ b/XMonad/Util/SpawnOnce.hs
@@ -14,7 +14,13 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Util.SpawnOnce (spawnOnce, spawnOnOnce, spawnNOnOnce, spawnAndDoOnce) where
+module XMonad.Util.SpawnOnce (spawnOnce,
+                              -- * 'SpawnOn' helpers
+                              -- $spawnon
+                              manageSpawn,
+                              spawnOnOnce,
+                              spawnNOnOnce,
+                              spawnAndDoOnce) where
 
 import XMonad
 import XMonad.Actions.SpawnOn
@@ -43,7 +49,12 @@ doOnce f s = do
 spawnOnce :: String -> X ()
 spawnOnce = doOnce spawn
 
--- | Like spawnOnce but launches the application on the given workspace.
+-- $spawnon
+-- These functions combine 'spawnOnce' with their relatives in
+-- 'XMonad.Actions.SpawnOn'. You must add 'manageSpawn' to your
+-- @manageHook@ for them to work, as with @SpawnOn@.
+
+-- | Like 'spawnOnce' but launches the application on the given workspace.
 spawnOnOnce :: WorkspaceId -> String -> X ()
 spawnOnOnce ws = doOnce (spawnOn ws)
 


### PR DESCRIPTION

### Description

Document that most of the functions in `XMonad.Util.SpawnOnce` rely on `XMonad.Actions.SpawnOn.manageSpawn`. Also, reexport that function for convenience. Closes #663.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: documentation change

  - [n/a] I updated the `CHANGES.md` file
