### PR TITLE
withWorkspace honor fuzzyMatch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -850,6 +850,9 @@
     - Fixed a system freeze when using `X.A.CopyWindow.copy` in
       combination with `removeWorkspace`.
 
+    - `withWorkspace` now honors the users `searchPredicate`, for
+      example `fuzzyMatch` from `Prompt.FuzzyMatch`.
+
 ## 0.16
 
 ### Breaking Changes

--- a/XMonad/Actions/DynamicWorkspaces.hs
+++ b/XMonad/Actions/DynamicWorkspaces.hs
@@ -38,7 +38,7 @@ import XMonad.Prelude (find, isNothing, nub, when)
 import XMonad hiding (workspaces)
 import XMonad.StackSet hiding (filter, modify, delete)
 import XMonad.Prompt.Workspace ( Wor(Wor), workspacePrompt )
-import XMonad.Prompt ( XPConfig, mkXPrompt )
+import XMonad.Prompt ( XPConfig, mkComplFunFromList', mkXPrompt )
 import XMonad.Util.WorkspaceCompare ( getSortByIndex )
 import qualified Data.Map.Strict as Map
 import qualified XMonad.Util.ExtensibleState as XS
@@ -107,17 +107,13 @@ withWorkspaceIndex job widx = do
       ilookup :: WorkspaceIndex -> X (Maybe WorkspaceTag)
       ilookup idx = Map.lookup idx <$> XS.gets workspaceIndexMap
 
-
-mkCompl :: [String] -> String -> IO [String]
-mkCompl l s = return $ filter (\x -> take (length s) x == s) l
-
 withWorkspace :: XPConfig -> (String -> X ()) -> X ()
 withWorkspace c job = do ws <- gets (workspaces . windowset)
                          sort <- getSortByIndex
                          let ts = map tag $ sort ws
                              job' t | t `elem` ts = job t
                                     | otherwise = addHiddenWorkspace t >> job t
-                         mkXPrompt (Wor "") c (mkCompl ts) job'
+                         mkXPrompt (Wor "") c (mkComplFunFromList' c ts) job'
 
 renameWorkspace :: XPConfig -> X ()
 renameWorkspace conf = workspacePrompt conf renameWorkspaceByName


### PR DESCRIPTION
`withWorkspace` prompt should use fuzzy matching if XPConfig includes `searchPredicate =
fuzzyMatch`. See details in https://mail.haskell.org/pipermail/xmonad/2021-December/015491.html

### Description

Fuzzy match did not work with the `withWorkspace` prompt. With the proposed change it does.

### Checklist

  - [X] I've read [CONTRIBUTING.md] (https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:  the change works with my xmonad.hs. (I confess complete Haskell ignorance).

  - [X] I updated the `CHANGES.md` file
