### PR TITLE
X.L.BinarySpacePartition: Ignore minimized windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,10 +59,17 @@
     - Flipped how `(^?)`, `(~?)`, and `($?)` work to more accurately
       reflect how one uses these operators.
 
+    - Added `isMinimized`
+
   * `XMonad.Actions.WindowNavigation`
 
     -  Fixed navigation getting "stuck" in certain situations for
        widescreen resolutions.
+
+  * `XMonad.Layout.BinarySpacePartition`
+
+    - Hidden windows are now ignored by the layout so that hidden windows in
+      the stack don't offset position calculations in the layout.
 
   * `XMonad.Layout.MagicFocus`
 

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -49,6 +49,7 @@ module XMonad.Hooks.ManageHelpers (
     isInProperty,
     isKDETrayWindow,
     isFullscreen,
+    isMinimized,
     isDialog,
     pid,
     transientTo,
@@ -182,6 +183,11 @@ isInProperty p v = ask >>= \w -> liftX $ do
 -- See also 'doFullFloat'.
 isFullscreen :: Query Bool
 isFullscreen = isInProperty "_NET_WM_STATE" "_NET_WM_STATE_FULLSCREEN"
+
+-- | A predicate to check whether a window is hidden (minimized).
+-- See also "XMonad.Actions.Minimize".
+isMinimized :: Query Bool
+isMinimized = isInProperty "_NET_WM_STATE" "_NET_WM_STATE_HIDDEN"
 
 -- | A predicate to check whether a window is a dialog.
 isDialog :: Query Bool


### PR DESCRIPTION
### Description

Hidden windows are now ignored by the layout so that hidden windows in the stack don't offset position calculations in the layout.

Also in X.H.ManageHelpers: added `isMinimized`



### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I use the BSP layout with hidden windows present a lot and this patch is essential to me. At least one other person on the mailing list is also happy with it: https://mail.haskell.org/pipermail/xmonad/2021-May/015432.html

  - [x] I updated the `CHANGES.md` file
