### PR TITLE
Fix date parsing issue for org mode plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Prompt.OrgMode`
+
+    - Fixes the date parsing issue such that entries with format of
+      `todo +d 12 02 2024` works.
+
   * `XMonad.Prompt`
 
     - Added `transposeChars` to interchange the characters around the

--- a/XMonad/Prompt/OrgMode.hs
+++ b/XMonad/Prompt/OrgMode.hs
@@ -401,6 +401,14 @@ pDate = skipSpaces *> choice
     , pPrefix "su" "nday"     Sunday
     ]
 
+  numWithoutColon :: Parser Int
+  numWithoutColon = do
+    str <- num
+    c <- get
+    if c == ':'
+    then pfail
+    else pure str
+
   pDate' :: Parser (Int, Maybe Int, Maybe Integer)
   pDate' =
     (,,) <$> num
@@ -411,6 +419,7 @@ pDate = skipSpaces *> choice
                , pPrefix "jul" "y"        7 , pPrefix "au"  "gust"    8
                , pPrefix "s"   "eptember" 9 , pPrefix "o"   "ctober"  10
                , pPrefix "n"   "ovember"  11, pPrefix "d"   "ecember" 12
+               , numWithoutColon
                ])
          <*> optional (skipSpaces *> num >>= \i -> guard (i >= 25) $> i)
 

--- a/XMonad/Util/Parser.hs
+++ b/XMonad/Util/Parser.hs
@@ -52,6 +52,7 @@ module XMonad.Util.Parser (
   endBy1,
   munch,
   munch1,
+  pfail
 ) where
 
 import XMonad.Prelude
@@ -135,6 +136,10 @@ instance Alternative Parser where
 -- | Run a parser on a given string.
 runParser :: Parser a -> String -> Maybe a
 runParser (Parser p) = fmap fst . listToMaybe . ReadP.readP_to_S p
+
+-- | Always fails
+pfail :: Parser a
+pfail = Parser $ ReadP.pfail
 
 -- | Consume and return the next character.  Fails if there is no input
 -- left.

--- a/XMonad/Util/Parser.hs
+++ b/XMonad/Util/Parser.hs
@@ -139,7 +139,7 @@ runParser (Parser p) = fmap fst . listToMaybe . ReadP.readP_to_S p
 
 -- | Always fails
 pfail :: Parser a
-pfail = Parser $ ReadP.pfail
+pfail = empty
 
 -- | Consume and return the next character.  Fails if there is no input
 -- left.

--- a/tests/OrgMode.hs
+++ b/tests/OrgMode.hs
@@ -22,6 +22,29 @@ spec = do
   prop "prop_encodeLinearity" prop_encodeLinearity
   prop "prop_decodeLinearity" prop_decodeLinearity
 
+  describe "pInput" $ do
+    it "works with todo +d 22 january 2021" $ do
+      pInput "todo +d 22 ja 2021"
+        `shouldBe` Just
+          ( Deadline
+              "todo"
+              (Time {date = Date (22, Just 1, Just 2021), tod = Nothing})
+          )
+    it "works with todo +d 22 01 2022" $ do
+      pInput "todo +d 22 01 2022"
+        `shouldBe` Just
+          ( Deadline
+              "todo"
+              (Time {date = Date (22, Just 1, Just 2022), tod = Nothing})
+          )
+    it "works with todo +d 1 01:01" $ do
+      pInput "todo +d 1 01:01"
+        `shouldBe` Just
+          ( Deadline
+              "todo"
+              (Time {date = Date (1, Nothing, Nothing), tod = Just $ TimeOfDay 1 1})
+          )
+
   -- Checking for regressions
   context "+d +d f" $ do
     it "encode" $ prop_encodeLinearity (OrgMsg "+d +d f")


### PR DESCRIPTION

### Description

This patch fixes the date parsing issue currently when an entry like
`todo +d 22 01 2022` is used. I have added tests too which demonstrate
the current issue so that we can prevent future regression.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded that my fixes work.

  - [x] I updated the `CHANGES.md` file
