### PR TITLE
keysMoveWindow: change signature type D to ChangeDim in XMonad.Actions.FloatKeys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,11 @@
       `xmonad-contrib` to be compiled with `X11-xft` version 0.3.4 or
       higher.
 
+  * `XMonad.Actions.FloatKeys`
+
+    - Changed type signature of `keysMoveWindow` from `D -> Window -> X ()`
+      to `ChangeDim -> Window -> X ()` to allow negative numbers without compiler warnings.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/XMonad/Actions/FloatKeys.hs
+++ b/XMonad/Actions/FloatKeys.hs
@@ -43,7 +43,7 @@ import XMonad.Prelude (fi)
 
 -- | @keysMoveWindow (dx, dy)@ moves the window by @dx@ pixels to the
 --   right and @dy@ pixels down.
-keysMoveWindow :: D -> Window -> X ()
+keysMoveWindow :: ChangeDim -> Window -> X ()
 keysMoveWindow (dx,dy) w = whenX (isClient w) $ withDisplay $ \d ->
   withWindowAttributes d w $ \wa -> do
     io $ moveWindow d w (fi (fi (wa_x wa) + dx))


### PR DESCRIPTION
### Description

keysMoveWindow takes a (Dimension, Dimension) which is a word32, which doesnt take negative numbers.
At the moment it works to just put a negative number in there, but the compiler shows warnings.
So this change should get rid of compiler warnings when doing `keysMoveWindow (0,-20)` for example.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
