### PR TITLE
Fix nix flake compilation.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         overrides = prev.lib.composeExtensions (old.overrides or (_: _: {}))
         (hself: hsuper: {
           xmonad-contrib =
-            hself.callCabal2nix "xmonad-contrib" (git-ignore-nix.gitIgnoreSource ./.) { };
+            hself.callCabal2nix "xmonad-contrib" (git-ignore-nix.lib.gitignoreSource ./.) { };
         });
       });
     };


### PR DESCRIPTION
### Description

Was no longer compiling, attribute `gitIgnoreSource` didn't exist, it was moved to `lib.gitignoreSource`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: It works!

  - [ ] I updated the `CHANGES.md` file

Not sure that last checkbox is relevant here.