### PR TITLE
Deprecate user and abandoned modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@
       now return a `Parser` (from `XMonad.Util.Parser`) instead of a
       `ReadP`.
 
+  * `XMonad.Config.{Arossato,Bluetile,Dmwit,Droundy,Monad,Prime,Saegesser,Sjanssen}`
+
+    - Deprecated all of these modules.  The user-specific configuration
+      modules may still be found [on the website].
+
+[on the website]: https://xmonad.org/configurations.html
+
 ### New Modules
 
   * `XMonad.Layout.CenteredIfSingle`

--- a/XMonad/Config/Arossato.hs
+++ b/XMonad/Config/Arossato.hs
@@ -16,6 +16,7 @@
 ------------------------------------------------------------------------
 
 module XMonad.Config.Arossato
+    {-# DEPRECATED "This module contains a personal configuration, to be removed from xmonad-contrib.  If you use this module, please copy the relevant parts to your configuration or obtain a copy of it on https://xmonad.org/configurations.html and include it as a local module." #-}
     ( -- * Usage
       -- $usage
       arossatoConfig

--- a/XMonad/Config/Bluetile.hs
+++ b/XMonad/Config/Bluetile.hs
@@ -20,7 +20,7 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Config.Bluetile (
+module XMonad.Config.Bluetile {-# DEPRECATED "This module contains a personal configuration, to be removed from xmonad-contrib.  If you use this module, please copy the relevant parts to your configuration or obtain a copy of it on https://xmonad.org/configurations.html and include it as a local module." #-} (
     -- * Usage
     -- $usage
     bluetileConfig

--- a/XMonad/Config/Dmwit.hs
+++ b/XMonad/Config/Dmwit.hs
@@ -7,7 +7,7 @@
 -- Description :  Daniel Wagner's xmonad configuration.
 --
 ------------------------------------------------------------------------
-module XMonad.Config.Dmwit where
+module XMonad.Config.Dmwit {-# DEPRECATED "This module contains a personal configuration, to be removed from xmonad-contrib.  If you use this module, please copy the relevant parts to your configuration or obtain a copy of it on https://xmonad.org/configurations.html and include it as a local module." #-} where
 
 -- system imports
 import Control.Monad.Trans

--- a/XMonad/Config/Droundy.hs
+++ b/XMonad/Config/Droundy.hs
@@ -8,7 +8,7 @@
 -- License     :  BSD3-style (see LICENSE)
 --
 ------------------------------------------------------------------------
-module XMonad.Config.Droundy ( config, mytab ) where
+module XMonad.Config.Droundy {-# DEPRECATED "This module contains a personal configuration, to be removed from xmonad-contrib.  If you use this module, please copy the relevant parts to your configuration or obtain a copy of it on https://xmonad.org/configurations.html and include it as a local module." #-} ( config, mytab ) where
 
 import XMonad hiding (keys, config)
 import qualified XMonad (keys)

--- a/XMonad/Config/Monad.hs
+++ b/XMonad/Config/Monad.hs
@@ -15,7 +15,7 @@ ideas:
     "only once" features like avoidStruts, ewmhDesktops
 -}
 
-module XMonad.Config.Monad where
+module XMonad.Config.Monad {-# DEPRECATED "This module does not work." #-} where
 
 import XMonad hiding (terminal, keys)
 import qualified XMonad as X

--- a/XMonad/Config/Prime.hs
+++ b/XMonad/Config/Prime.hs
@@ -23,7 +23,7 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Config.Prime (
+module XMonad.Config.Prime {-# DEPRECATED "This module is a perpetual draft and will therefore be removed from xmonad-contrib in the near future." #-} (
 -- Note: The identifiers here are listed in the order that makes the most sense
 -- for a user, while the definitions below are listed in the order that makes
 -- the most sense for a developer.

--- a/XMonad/Config/Saegesser.hs
+++ b/XMonad/Config/Saegesser.hs
@@ -6,6 +6,8 @@
 -- A mostly striped down configuration that demonstrates spawnOnOnce
 --
 ---------------------------------------------------------------------
+module XMonad.Config.Saegesser {-# DEPRECATED "This module contains a personal configuration, to be removed from xmonad-contrib.  If you use this module, please copy the relevant parts to your configuration or obtain a copy of it on https://xmonad.org/configurations.html and include it as a local module." #-} where
+
 import System.IO
 
 import XMonad

--- a/XMonad/Config/Sjanssen.hs
+++ b/XMonad/Config/Sjanssen.hs
@@ -5,7 +5,7 @@
 -- Description :  Spencer Janssen's xmonad config.
 --
 ------------------------------------------------------------------------
-module XMonad.Config.Sjanssen (sjanssenConfig) where
+module XMonad.Config.Sjanssen {-# DEPRECATED "This module contains a personal configuration, to be removed from xmonad-contrib.  If you use this module, please copy the relevant parts to your configuration or obtain a copy of it on https://xmonad.org/configurations.html and include it as a local module." #-} (sjanssenConfig) where
 
 import XMonad hiding (Tall(..))
 import qualified XMonad.StackSet as W

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -78,7 +78,7 @@ import qualified XMonad.StackSet as W
 -- screen into a physical workspace name.
 --
 -- A complete example abusing many of the functions below is available in the
--- "XMonad.Config.Dmwit" module.
+-- <https://xmonad.org/configurations.html XMonad.Config.Dmwit> configuration.
 
 type VirtualWorkspace  = WorkspaceId
 type PhysicalWorkspace = WorkspaceId


### PR DESCRIPTION
### Description

NOTE: I'm bad at writing things like this, so feel free to suggest improvements.

Now that the user configs are on the website, it is time to deprecate them.  At the same time deprecated X.C.Monad, which hasn't been updated since 2008 and X.C.Prime, which has confused users quite recently, thinking it to be a better starting place.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/677
Fixes: https://github.com/xmonad/xmonad-contrib/issues/595
Related: https://github.com/xmonad/xmonad-web/pull/49

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Deprecation warnings work as expected.

  - [x] I updated the `CHANGES.md` file