### PR TITLE
X.A.Submap: Add `visualSubmap`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,6 +116,11 @@
       resetting borders back in layouts where you want borders after calling
       `voidBorders`.
 
+  * `XMonad.Prelude`
+
+    - Added `keymaskToString` and `keyToString` to show a key mask and a
+      key in the style of `XMonad.Util.EZConfig`.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -121,6 +121,12 @@
     - Added `keymaskToString` and `keyToString` to show a key mask and a
       key in the style of `XMonad.Util.EZConfig`.
 
+  * `XMonad.Util.XUtils`
+
+    - Added `withSimpleWindow`, `showSimpleWindow`, `WindowConfig`, and
+      `WindowRect` in order to simplify the handling of simply popup
+      windows.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,8 +124,13 @@
   * `XMonad.Util.XUtils`
 
     - Added `withSimpleWindow`, `showSimpleWindow`, `WindowConfig`, and
-      `WindowRect` in order to simplify the handling of simply popup
+      `WindowRect` in order to simplify the handling of simple popup
       windows.
+
+  * `XMonad.Actions.Submap`
+
+    - Added `visualSubmap` to visualise the available keys and their
+      actions when inside a submap.
 
 ## 0.17.0 (October 27, 2021)
 

--- a/XMonad/Hooks/DebugEvents.hs
+++ b/XMonad/Hooks/DebugEvents.hs
@@ -111,7 +111,7 @@ debugEventsHook' ButtonEvent           {ev_window = w
   windowEvent "Button" w
   nl <- gets numberlockMask
   let msk | s == 0    = ""
-          | otherwise = "modifiers " ++ vmask nl s
+          | otherwise = "modifiers " ++ keymaskToString nl s
   say "  button" $ show b ++ msk
 
 debugEventsHook' DestroyWindowEvent    {ev_window = w
@@ -217,28 +217,6 @@ clientMessages =  [("_NET_ACTIVE_WINDOW",("_NET_ACTIVE_WINDOW",32,1))
                   ,("WM_COMMAND"        ,("STRING"            , 8,0))
                   ,("WM_SAVE_YOURSELF"  ,("STRING"            , 8,0))
                   ]
-
--- | Convert a modifier mask into a useful string
-vmask                 :: KeyMask -> KeyMask -> String
-vmask numLockMask msk =  unwords $
-                         reverse $
-                         fst     $
-                         foldr vmask' ([],msk) masks
-    where
-      masks = map (\m -> (m,show m)) [0..toEnum (finiteBitSize msk - 1)] ++
-              [(numLockMask,"num"  )
-              ,(   lockMask,"lock" )
-              ,(controlMask,"ctrl" )
-              ,(  shiftMask,"shift")
-              ,(   mod5Mask,"mod5" )
-              ,(   mod4Mask,"mod4" )
-              ,(   mod3Mask,"mod3" )
-              ,(   mod2Mask,"mod2" )
-              ,(   mod1Mask,"mod1" )
-              ]
-      vmask'   _   a@( _,0)                = a
-      vmask' (m,s)   (ss,v) | v .&. m == m = (s : ss,v .&. complement m)
-      vmask'   _        r                  = r
 
 -- formatting properties.  ick. --
 

--- a/XMonad/Util/NamedActions.hs
+++ b/XMonad/Util/NamedActions.hs
@@ -47,10 +47,9 @@ module XMonad.Util.NamedActions (
 
 
 import XMonad.Actions.Submap(submap)
-import XMonad.Prelude (groupBy)
+import XMonad.Prelude (groupBy, keyToString)
 import XMonad
-import Control.Arrow(Arrow((&&&), second, (***)))
-import Data.Bits(Bits((.&.), complement))
+import Control.Arrow(Arrow((&&&), second))
 import System.Exit(exitSuccess)
 
 import qualified Data.Map as M
@@ -165,22 +164,6 @@ submapName = NamedAction . (submap . M.map getAction . M.fromList &&& showKm)
 (^++^) :: (HasName b, HasName b1) =>
      [(d, b)] -> [(d, b1)] -> [(d, NamedAction)]
 a ^++^ b = map (second NamedAction) a ++ map (second NamedAction) b
-
--- | Or allow another lookup table?
-modToString :: KeyMask -> String
-modToString mask = concatMap (++"-") $ filter (not . null)
-                $ map (uncurry pick)
-                [(mod1Mask, "M1")
-                ,(mod2Mask, "M2")
-                ,(mod3Mask, "M3")
-                ,(mod4Mask, "M4")
-                ,(mod5Mask, "M5")
-                ,(controlMask, "C")
-                ,(shiftMask,"Shift")]
-    where pick m str = if m .&. complement mask == 0 then str else ""
-
-keyToString :: (KeyMask, KeySym) -> [Char]
-keyToString = uncurry (++) . (modToString *** keysymToString)
 
 showKmSimple :: [((KeyMask, KeySym), NamedAction)] -> [[Char]]
 showKmSimple = concatMap (\(k,e) -> if snd k == 0 then "":showName e else map ((keyToString k ++) . smartSpace) $ showName e)


### PR DESCRIPTION
### Description

tl;dr: [screenshot] of the new behaviour.

I'm not quite happy with this, but the reason I'm posting it anyways is that I'm interested in feedback.  We could make this use X.U.NamedActions, which may be conceptually nicer and could make the specification of descriptions a bit cleaner.  This would, however, introduce a regression with regards to `submapNamed`—it could not be in X.U.NamedActions anymore, as we would need to import that module from X.A.Submap.  It may also not be clear which submap implementation is chosen when one specifies named actions via EZConfig (which is something that I haven't touched on at all here).

##### X.Prelude: Add keymaskToString, keyToString

This technically introduces a regression with regards to the way that modifier masks are printed in X.U.NamedActions and X.H.DebugEvents. However, since this way of printing masks is move in line with X.U.EZConfig, I personally don't think that this is noteworthy.

##### X.U.XUtils: Add framework for manipulating simple windows

Adds several new functions and type for manipulating "simple windows".

There are several ways to draw windows in X.U.XUtils and other places already, but they are all quite manual.  Most of the time one does not want to think about dimensions much and assumes that the code is smart enough to "figure it out"; this is an attempt to do exactly that.

There is a less-managed version `showSimpleWindow`, which just creates and shows the windows, as well as a wrapper-like `withSimpleWindow` that also destroys the window once some action finishes executing.

With these functions it should be possible to refactor some contrib modules that currently draw windows manually, like X.U.EasyMotion.

##### X.A.Submap: Add visualSubmap

Add a `visualSubmap` function, which works much like the regular `submap` one, except that it visualises the available choices in a pop-up window.

Related: https://github.com/xmonad/xmonad-contrib/issues/472


[Screenshot]: https://i.imgur.com/mqRGWVw.png

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: works manually...  Not sure there is much chance to test the window stuff, though with `keyToString` we may now have a chance to property test EZConfig!  I've not done this here, though.

  - [x] I updated the `CHANGES.md` file
