### PR TITLE
X.L.VoidBorders: Add ability to reset borders for certain layouts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,6 +110,12 @@
       different X property) to communicate trayer resize events to
       XMobar so that padding space may be reserved on xmobar for the
       tray.  Requires `xmobar` version 0.40 or higher.
+      
+- `XMonad.Layout.VoidBorders`
+
+    - Added new layout modifier `normalBorders` which can be used for
+      resetting borders back in layouts where you want borders after calling
+      `voidBorders`.
 
 ## 0.17.0 (October 27, 2021)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -110,7 +110,7 @@
       different X property) to communicate trayer resize events to
       XMobar so that padding space may be reserved on xmobar for the
       tray.  Requires `xmobar` version 0.40 or higher.
-      
+
 - `XMonad.Layout.VoidBorders`
 
     - Added new layout modifier `normalBorders` which can be used for

--- a/XMonad/Layout/VoidBorders.hs
+++ b/XMonad/Layout/VoidBorders.hs
@@ -13,19 +13,18 @@
 -- Portability :  unportable
 --
 -- Modifies a layout to set borders to 0 for all windows in the workspace.
--- Unlike XMonad.Layout.NoBorders, this modifier will not restore the window
--- border if the windows are moved to a different workspace or the layout is
--- changed.
+-- It can also restore the window border if the window is moved to a different
+-- workspace or if the layout is changed.
 --
 -- This modifier's primary use is to eliminate the "border flash" you get
--- while switching workspaces with the `noBorders` modifier. It won't return
--- the borders to their original width, however.
+-- while switching workspaces with the `noBorders` modifier.
 --
 -----------------------------------------------------------------------------
 
 module XMonad.Layout.VoidBorders ( -- * Usage
                                    -- $usage
                                    voidBorders
+                                 , normalBorders
                                  ) where
 
 import XMonad
@@ -39,18 +38,16 @@ import XMonad.StackSet (integrate)
 -- > import XMonad.Layout.VoidBorders
 --
 -- and modify the layouts to call 'voidBorders' on the layouts you want to
--- remove borders from windows:
+-- remove borders from windows, and 'normalBorders' on the layouts you want
+-- to keep borders for:
 --
--- > layoutHook = ... ||| voidBorders Full ||| ...
+-- > layoutHook = ... ||| voidBorders Full ||| normalBorders Tall ...
 --
 -- For more detailed instructions on editing the layoutHook see:
 --
 -- "XMonad.Doc.Extending#Editing_the_layout_hook"
 
 data VoidBorders a = VoidBorders deriving (Read, Show)
-
-voidBorders :: l Window -> ModifiedLayout VoidBorders l Window
-voidBorders = ModifiedLayout VoidBorders
 
 instance LayoutModifier VoidBorders Window where
   modifierDescription = const "VoidBorders"
@@ -60,6 +57,30 @@ instance LayoutModifier VoidBorders Window where
     mapM_ setZeroBorder $ integrate s
     return (wrs, Nothing)
 
+voidBorders :: l Window -> ModifiedLayout VoidBorders l Window
+voidBorders = ModifiedLayout VoidBorders
+
+data NormalBorders a = NormalBorders deriving (Read, Show)
+
+instance LayoutModifier NormalBorders Window where
+  modifierDescription = const "NormalBorders"
+
+  redoLayout NormalBorders _ Nothing wrs = return (wrs, Nothing)
+  redoLayout NormalBorders _ (Just s) wrs = do
+    mapM_ resetBorders $ integrate s
+    return (wrs, Nothing)
+
+normalBorders :: l Window -> ModifiedLayout NormalBorders l Window
+normalBorders = ModifiedLayout NormalBorders
+
 -- | Sets border width to 0 for every window from the specified layout.
 setZeroBorder :: Window -> X ()
-setZeroBorder w = withDisplay $ \d -> io $ setWindowBorderWidth d w 0
+setZeroBorder w = setBorders w 0
+
+-- | Resets the border to the value read from the current configuration.
+resetBorders :: Window -> X ()
+resetBorders w = asks (borderWidth . config) >>= setBorders w
+
+setBorders :: Window -> Dimension -> X ()
+setBorders w bw = withDisplay $ \d -> io $ setWindowBorderWidth d w bw
+

--- a/XMonad/Layout/VoidBorders.hs
+++ b/XMonad/Layout/VoidBorders.hs
@@ -13,11 +13,14 @@
 -- Portability :  unportable
 --
 -- Modifies a layout to set borders to 0 for all windows in the workspace.
--- It can also restore the window border if the window is moved to a different
--- workspace or if the layout is changed.
+--
+-- Unlike "XMonad.Layout.NoBorders", the 'voidBorders' modifier will not
+-- restore the window border if the windows are moved to a different workspace
+-- or the layout is changed. There is, however, a companion 'normalBorders'
+-- modifier which explicitly restores the border.
 --
 -- This modifier's primary use is to eliminate the "border flash" you get
--- while switching workspaces with the `noBorders` modifier.
+-- while switching workspaces with the "XMonad.Layout.NoBorders" modifier.
 --
 -----------------------------------------------------------------------------
 
@@ -83,4 +86,3 @@ resetBorders w = asks (borderWidth . config) >>= setBorders w
 
 setBorders :: Window -> Dimension -> X ()
 setBorders w bw = withDisplay $ \d -> io $ setWindowBorderWidth d w bw
-


### PR DESCRIPTION
### Description

Added a new layout modifier `normalBorders` which resets the borders back to their normal values (read from borderWidth) so that it is possible to restore borders after using `voidBorders`, such as when the window is moved to a different workspace or the layout is changed.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [X] I updated the `CHANGES.md` file
