### PR TITLE
X.U.Hacks: Clean up tray padding hooks a bit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,11 +105,10 @@
 
   * `XMonad.Util.Hacks`
 
-    - Added `trayerQuery` for easily querying trayer and
-      `trayerPaddingXmobarEventHook` (as well as a variant to specify a
-      different X property) to communicate trayer resize events to
-      XMobar so that padding space may be reserved on xmobar for the
-      tray.  Requires `xmobar` version 0.40 or higher.
+    - Added `trayerPaddingXmobarEventHook` (plus generic variants for other
+      trays/panels) to communicate trayer resize events to XMobar so that
+      padding space may be reserved on xmobar for the tray.  Requires `xmobar`
+      version 0.40 or higher.
 
   * `XMonad.Layout.VoidBorders`
 


### PR DESCRIPTION
### Description

(these are the cleanups I mentioned in https://github.com/xmonad/xmonad-contrib/pull/643#issuecomment-1013843609)

Un-export trivial/useless definitions and adapt the generic versions of trayerPaddingXmobarEventHook to be more generally useful.

Related: https://github.com/xmonad/xmonad-contrib/pull/643#issuecomment-962661655

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded: hoping the typechecker would tell me if I changed anything significant

  - [X] I updated the `CHANGES.md` file