### PR TITLE
Add XMonad.Hooks.ShowWName

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,11 @@
     visible workspaces combined with the workspace name, for example in a status
     bar. This module provides utility functions to do just that.
 
+  * `XMonad.Hooks.ShowWName`
+
+    Flashes the name of the current workspace when switching to it.
+    Like `XMonad.Layout.ShowWName`, but as a logHook.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Prompt.OrgMode`

--- a/XMonad/Hooks/ShowWName.hs
+++ b/XMonad/Hooks/ShowWName.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE InstanceSigs #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Hooks.ShowWName
+-- Description :  Like 'XMonad.Layout.ShowWName', but as a logHook
+-- Copyright   :  (c) 2022  Solid <soliditsallgood@mailbox.org>
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  soliditsallgood@mailbox.org
+--
+-- Flash the names of workspaces name when switching to them.  This is a
+-- reimplementation of 'XMonad.Layout.ShowWName' as a logHook.
+-----------------------------------------------------------------------------
+
+module XMonad.Hooks.ShowWName (
+  -- * Usage
+  -- $usage
+  showWNameLogHook,
+  SWNConfig(..),
+  flashName,
+) where
+
+import qualified XMonad.StackSet             as W
+import qualified XMonad.Util.ExtensibleState as XS
+
+import XMonad
+import XMonad.Layout.ShowWName (SWNConfig (..))
+import XMonad.Prelude
+import XMonad.Util.XUtils (WindowConfig (..), showSimpleWindow)
+
+import Control.Concurrent (threadDelay)
+
+{- $usage
+
+You can use this module with the following in your
+@~\/.xmonad\/xmonad.hs@:
+
+> import XMonad.Hooks.ShowWName
+>
+> main :: IO ()
+> main = xmonad $ def
+>   { logHook = showWNameLogHook def
+>   }
+
+Whenever a workspace gains focus, the above logHook will flash its name.
+You can customise the duration of the flash, as well as colours by
+customising the 'SWNConfig' argument that 'showWNameLogHook' takes.
+
+Alternatively, you can also bind 'flashName' to a key and manually
+invoke it when you want to know which workspace you are on.
+-}
+
+-- | LogHook for flashing the name of a workspace upon entering it.
+showWNameLogHook :: SWNConfig -> X ()
+showWNameLogHook cfg = do
+  LastShown s <- XS.get
+  foc         <- withWindowSet (pure . W.currentTag)
+  unless (s == foc) $ do
+    flashName cfg
+    XS.put (LastShown foc)
+
+-- | Flash the name of the currently focused workspace.
+flashName :: SWNConfig -> X ()
+flashName cfg = do
+  n <- withWindowSet (pure . W.currentTag)
+  showSimpleWindow cfg' [n] >>= \w -> void . xfork $ do
+    dpy <- openDisplay ""
+    threadDelay (fromEnum $ swn_fade cfg * 1000000) -- 1_000_000 needs GHC 8.6.x and up
+    void $ destroyWindow dpy w
+    closeDisplay dpy
+ where
+  cfg' :: WindowConfig
+  cfg' = def{ winFont = swn_font cfg, winBg = swn_bgcolor cfg, winFg = swn_color cfg }
+
+-- | Last shown workspace.
+newtype LastShown = LastShown WorkspaceId
+  deriving (Show, Read)
+
+instance ExtensionClass LastShown where
+  initialValue :: LastShown
+  initialValue  = LastShown ""
+
+  extensionType :: LastShown -> StateExtension
+  extensionType = PersistentExtension

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -198,6 +198,7 @@ library
                         XMonad.Hooks.Script
                         XMonad.Hooks.ServerMode
                         XMonad.Hooks.SetWMName
+                        XMonad.Hooks.ShowWName
                         XMonad.Hooks.StatusBar
                         XMonad.Hooks.StatusBar.PP
                         XMonad.Hooks.StatusBar.WorkspaceScreen


### PR DESCRIPTION
### Description

This was mostly a test-drive for the simpleWindow part of  https://github.com/xmonad/xmonad-contrib/pull/685, but I figured that—since the code is already there—it wouldn't hurt to submit it as well.

Maybe the docs are a bit lacking, I don't know, but I didn't really know what else to write.

##### Add XMonad.Hooks.ShowWName

This is a reimplementation of X.L.ShowWName as a logHook, using the new
simpleWindow interface from 86b816ec5046ec09b911d48df282b7039a201dfc.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/612

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: it seems to work (:

  - [x] I updated the `CHANGES.md` file