### PR TITLE
X.U.NamedScratchpads: Add dynamic scratchpad capabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -162,6 +162,11 @@
       Translation of key codes to symbols ignores modifiers, so `Shift-Tab` is
       now just `(shiftMap, xK_Tab)` instead of `(shiftMap, xK_ISO_Left_Tab)`.
 
+  * `XMonad.Util.NamedScratchpad`
+
+    - Added support for dynamic scratchpads in the form of
+      `dynamicNSPAction` and `toggleDynamicNSP`.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@
       in the module's documentation) should _not_ notice any difference
       in behaviour.
 
+  * `XMonad.Util.DynamicScratchpads`
+
+    - Deprecated the module; use the new dynamic scratchpad
+      functionality of `XMonad.Util.NamedScratchpad` instead.
+
 [on the website]: https://xmonad.org/configurations.html
 
 ### New Modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,15 @@
     - Deprecated all of these modules.  The user-specific configuration
       modules may still be found [on the website].
 
+ * `XMonad.Util.NamedScratchpad`
+
+    - Scratchpads are now only based on the argument given to
+      `namedScratchpadManageHook`; all other scratchpad arguments are,
+      while still present, ignored.  Users passing all of their
+      scratchpads to functions like `namedScratchpadAction` (as is shown
+      in the module's documentation) should _not_ notice any difference
+      in behaviour.
+
 [on the website]: https://xmonad.org/configurations.html
 
 ### New Modules

--- a/XMonad/Util/DynamicScratchpads.hs
+++ b/XMonad/Util/DynamicScratchpads.hs
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Util.DynamicScratchpads (
+module XMonad.Util.DynamicScratchpads {-# DEPRECATED "Use the dynamic scratchpad facility of XMonad.Util.NamedScratchpad instead." #-} (
   -- * Usage
   -- $usage
   makeDynamicSP,
@@ -36,7 +36,7 @@ import qualified XMonad.Util.ExtensibleState as XS
 -- Like with XMonad.Util.NamedScratchpad, you have to have a workspace called
 -- NSP, where hidden scratchpads will be moved to.
 --
--- You can declare dynamic scrachpads in your xmonad.hs like so:
+-- You can declare dynamic scratchpads in your xmonad.hs like so:
 --
 -- import XMonad.Util.DynamicScratchpads
 --
@@ -65,6 +65,7 @@ makeDynamicSP s w = do
         Just ow  -> if w == ow
                     then removeDynamicSP s
                     else showWindow ow >> addDynamicSP s w
+{-# DEPRECATED makeDynamicSP "Use XMonad.Util.NamedScratchpad.toggleDynamicNSP instead" #-}
 
 -- | Spawn the specified dynamic scratchpad
 spawnDynamicSP :: String -- ^ Scratchpad name
@@ -72,6 +73,7 @@ spawnDynamicSP :: String -- ^ Scratchpad name
 spawnDynamicSP s = do
     (SPStorage m) <- XS.get
     maybe mempty spawnDynamicSP' (M.lookup s m)
+{-# DEPRECATED spawnDynamicSP "Use XMonad.Util.NamedScratchpad.dynamicNSPAction instead" #-}
 
 spawnDynamicSP' :: Window -> X ()
 spawnDynamicSP' w = withWindowSet $ \s -> do

--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -30,14 +30,17 @@ module XMonad.Util.NamedScratchpad (
   customRunNamedScratchpadAction,
   allNamedScratchpadAction,
   namedScratchpadManageHook,
-  namedScratchpadFilterOutWorkspace,
-  namedScratchpadFilterOutWorkspacePP,
   nsHideOnFocusLoss,
 
   -- * Dynamic Scratchpads
   -- $dynamic-scratchpads
   dynamicNSPAction,
   toggleDynamicNSP,
+
+  -- * Deprecations
+  namedScratchpadFilterOutWorkspace,
+  namedScratchpadFilterOutWorkspacePP,
+
   ) where
 
 import Data.Coerce (coerce)


### PR DESCRIPTION
### Description

Supersedes/Closes: https://github.com/xmonad/xmonad-contrib/pull/662

This is a first stab at making X.U.NamedScratchpads a little bit more general (while trying as hard as possible to retain backwards compatibility :/).

#### Summary of Commits

##### X.U.NamedScratchpad: Use ExtensibleState to store scratchpads

Instead of using the scratchpads that the user specifies (as this will realistically just be "all of them"), create some extensible state for the scratchpads to reside in.

To ensure that this is done in a backwards compatible way, function signatures did not change and they instead just ignore the list of scratchpads given to them and the initialisation is done in the manageHook, which users already have to use anyways.

##### X.U.NamedScratchpad: Add support for dynamic scratchpads

With the extensible state machinery in place[1], we are now able to seamlessly integrate dynamic scratchpad functionality into X.U.NamedScratchpad.  This is one step into the direction of having a single scratchpad implementation that can "do anything".

Related: https://github.com/xmonad/xmonad-contrib/issues/591
Related: https://github.com/xmonad/xmonad-contrib/pull/662

[1]: 70d08b82f43057447e8e2479aa515b6db0d199e4
     (X.U.NamedScratchpad: Use ExtensibleState to store scratchpads)

##### X.U.DynamicScratchpads: Deprecate

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: I've tested this manually and (to my surprise!) is actually works

  - [x] I updated the `CHANGES.md` file
