### PR TITLE
ci: Update supported GHC versions

### DIFF
--- a/.github/workflows/haskell-ci-hackage.patch
+++ b/.github/workflows/haskell-ci-hackage.patch
@@ -38,13 +38,13 @@ set in GitHub repository secrets.
    linux:
      name: Haskell-CI - Linux - ${{ matrix.compiler }}
 @@ -31,6 +38,7 @@
-             compilerVersion: 9.0.1
-             setup-method: hvr-ppa
+             compilerVersion: 9.0.2
+             setup-method: ghcup
              allow-failure: false
 +            upload: true
-           - compiler: ghc-8.10.4
+           - compiler: ghc-8.10.7
              compilerKind: ghc
-             compilerVersion: 8.10.4
+             compilerVersion: 8.10.7
 @@ -209,8 +217,80 @@
            ${CABAL} -vnormal check
        - name: haddock

--- a/.github/workflows/haskell-ci-hlint.patch
+++ b/.github/workflows/haskell-ci-hlint.patch
@@ -1,0 +1,16 @@
+Work around an hlint bug where it does not recognise CPP when
+Haskell2010 is passed to it; see
+
+    https://github.com/ndmitchell/hlint/issues/1360
+
+--- a/.github/workflows/haskell-ci.yml.orig
++++ b/.github/workflows/haskell-ci.yml
+@@ -247,7 +247,7 @@
+           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
+       - name: hlint
+         run: |
+-          if [ $((HCNUMVER >= 90000 && HCNUMVER < 90200)) -ne 0 ] ; then (cd ${PKGDIR_xmonad_contrib} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 .) ; fi
++          if [ $((HCNUMVER >= 90000 && HCNUMVER < 90200)) -ne 0 ] ; then (cd ${PKGDIR_xmonad_contrib} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 -XCPP .) ; fi
+       - name: cabal check
+         run: |
+           cd ${PKGDIR_xmonad_contrib} || false

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211030
+# version: 0.14.3
 #
-# REGENDATA ("0.13.20211030",["github","cabal.project"])
+# REGENDATA ("0.14.3",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -27,27 +27,29 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.1
+          - compiler: ghc-9.2.2
             compilerKind: ghc
-            compilerVersion: 9.2.1
+            compilerVersion: 9.2.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
             upload: true
-          - compiler: ghc-8.10.4
+          - compiler: ghc-8.10.7
             compilerKind: ghc
-            compilerVersion: 8.10.4
-            setup-method: hvr-ppa
+            compilerVersion: 8.10.7
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
@@ -72,7 +74,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
@@ -83,7 +85,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME" libx11-dev libxext-dev libxft-dev libxinerama-dev libxrandr-dev libxss-dev
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi
@@ -145,6 +147,10 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -157,7 +163,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-a0115d6a
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-d795995c
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -241,7 +247,7 @@ jobs:
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: hlint
         run: |
-          if [ $((HCNUMVER >= 90000 && HCNUMVER < 90200)) -ne 0 ] ; then (cd ${PKGDIR_xmonad_contrib} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml .) ; fi
+          if [ $((HCNUMVER >= 90000 && HCNUMVER < 90200)) -ne 0 ] ; then (cd ${PKGDIR_xmonad_contrib} && hlint -h ${GITHUB_WORKSPACE}/source/.hlint.yaml -XHaskell2010 -XCPP .) ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_xmonad_contrib} || false

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -24,14 +24,14 @@ jobs:
           - resolver: lts-16
             ghc: 8.8.4
             yaml: stack-master.yaml
-          - resolver: lts-17
-            ghc: 8.10.4
+          - resolver: lts-18
+            ghc: 8.10.7
             yaml: stack-master.yaml
-          - resolver: lts-18
-            ghc: 8.10.7
+          - resolver: lts-19
+            ghc: 9.0.2
             yaml: stack.yaml
-          - resolver: lts-18
-            ghc: 8.10.7
+          - resolver: lts-19
+            ghc: 9.0.2
             yaml: stack-master.yaml
 
     steps:

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -7,11 +7,12 @@ apt:
   libxss-dev
 
 hlint: True
-hlint-job: 9.0.1
+hlint-job: 9.0.2
 hlint-yaml: .hlint.yaml
 
 github-patches:
   .github/workflows/haskell-ci-hackage.patch
+  .github/workflows/haskell-ci-hlint.patch
 
 raw-project
   optimization: False

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -33,7 +33,7 @@ cabal-version:      1.12
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.4 || == 9.0.1 || == 9.2.1
+tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
NOTE: I will prepare the same thing for the `xmonad` repo, but don't want to create too much noise with PRs.  After this is rubber-stamped I will just push it directly.

### Description

+ Prefer GHC 8.10.7 to 8.10.4, as versions seem to have stabilised now.
+ Add support for Stackage LTS 19, which ships with GHC 9.0.2.
+ Since a new version of 9.2 has been released, prefer 9.2.2 over 9.2.1.

Also, explicitly pass -XCPP to hlint; see [1].

[1]: https://github.com/ndmitchell/hlint/issues/1360

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: CI passes

  - [n/a] I updated the `CHANGES.md` file