### PR TITLE
Fix typo on the 'XMonad.Hooks.Rescreen' doc

### DIFF
--- a/XMonad/Hooks/Rescreen.hs
+++ b/XMonad/Hooks/Rescreen.hs
@@ -34,7 +34,7 @@ import qualified XMonad.Util.ExtensibleConf as XC
 --
 -- To use this, include the following in your @~\/.xmonad\/xmonad.hs@:
 --
--- > import XMonad.Hooks.RescreenHook
+-- > import XMonad.Hooks.Rescreen
 --
 -- define your custom hooks:
 --


### PR DESCRIPTION
### Description

Just a trivial typo fix.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
