### PR TITLE
Have `X.U.SpawnOnce` point to `X.U.SessionStart`

### DIFF
--- a/XMonad/Util/SpawnOnce.hs
+++ b/XMonad/Util/SpawnOnce.hs
@@ -10,7 +10,9 @@
 -- Portability :  not portable
 --
 -- A module for spawning a command once, and only once.  Useful to start
--- status bars and make session settings inside startupHook.
+-- status bars and make session settings inside startupHook. See also
+-- 'XMonad.Util.SessionStart' for a different and more flexible way to
+-- run commands only on first startup.
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

Just a simple doc change, but should make `X.U.SessionStart` more discoverable.

Closes #696.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: doc change

  - [n/a] I updated the `CHANGES.md` file
