### PR TITLE
new module XMonad.Actions.PerLayoutKeys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,10 @@
 
 ### New Modules
 
+  * `XMonad.Actions.PerLayoutKeys`
+
+    Customizes a keybinding on a per-layout basis. Based on PerWorkspaceKeys.
+
   * `XMonad.Layout.CenteredIfSingle`
 
     Layout modifier that, if only a single window is on screen, places that window

--- a/XMonad/Actions/PerLayoutKeys.hs
+++ b/XMonad/Actions/PerLayoutKeys.hs
@@ -1,0 +1,49 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Actions.PerLayouteKeys
+-- Description :  Define key-bindings on per-layout basis.
+-- Copyright   :  (c) brandon s allbery kf8nh 2022, Roman Cheplyaka, 2008
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  brandon s allbery kf8ng <allbery.b@gmail.com>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Define key-bindings on per-layout basis.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Actions.PerLayoutKeys (
+                                 -- * Usage
+                                 -- $usage
+                                 chooseActionByLayout,
+                                 bindByLayout
+                                ) where
+
+import XMonad
+import XMonad.StackSet as S
+
+-- $usage
+--
+-- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
+--
+-- >  import XMonad.Actions.PerLayoutKeys
+--
+-- >   ,((0, xK_F2), bindOn [("Tall", spawn "rxvt"), ("Mirror Tall", spawn "xeyes"), ("", spawn "xmessage hello")])
+--
+-- For detailed instructions on editing your key bindings, see
+-- "XMonad.Doc.Extending#Editing_key_bindings".
+
+-- | Uses supplied function to decide which action to run depending on current layout name.
+chooseActionByLayout :: (String->X()) -> X()
+chooseActionByLayout f = withWindowSet (f . description . S.layout. S.workspace . S.current)
+
+-- | If current layout is listed, run appropriate action (only the first match counts!)
+-- If it isn't listed, then run default action (marked with empty string, \"\"), or do nothing if default isn't supplied.
+bindByLayout :: [(String, X())] -> X()
+bindByLayout bindings = chooseActionByLayout chooser where
+    chooser l = case lookup l bindings of
+        Just action -> action
+        Nothing -> case lookup "" bindings of
+            Just action -> action
+            Nothing -> return ()

--- a/XMonad/Actions/PerLayoutKeys.hs
+++ b/XMonad/Actions/PerLayoutKeys.hs
@@ -29,7 +29,7 @@ import XMonad.StackSet as S
 --
 -- >  import XMonad.Actions.PerLayoutKeys
 --
--- >   ,((0, xK_F2), bindOn [("Tall", spawn "rxvt"), ("Mirror Tall", spawn "xeyes"), ("", spawn "xmessage hello")])
+-- >   ,((0, xK_F2), bindByLayout [("Tall", spawn "rxvt"), ("Mirror Tall", spawn "xeyes"), ("", spawn "xmessage hello")])
 --
 -- For detailed instructions on editing your key bindings, see
 -- "XMonad.Doc.Extending#Editing_key_bindings".

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -118,6 +118,7 @@ library
                         XMonad.Actions.Navigation2D
                         XMonad.Actions.NoBorders
                         XMonad.Actions.OnScreen
+                        XMonad.Actions.PerLayoutKeys
                         XMonad.Actions.PerWindowKeys
                         XMonad.Actions.PerWorkspaceKeys
                         XMonad.Actions.PhysicalScreens


### PR DESCRIPTION
### Description

This adds a new module `PerLayoutKeys` based on `XMonad.Actions.PerWorkspaceKeys`, which allows conditionalizing keybindings based on the current layout. This was requested by someone in IRC.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: has to be manual

  - [x] I updated the `CHANGES.md` file
