### PR TITLE
Fix synopsis typo

### DIFF
--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -3,7 +3,7 @@ version:            0.17.0.9
 -- ^ also update cpp-options: -DXMONAD_CONTRIB_VERSION_*
 
 homepage:           https://xmonad.org/
-synopsis:           Community-maintained extensions extensions for xmonad
+synopsis:           Community-maintained extensions for xmonad
 description:
     Community-maintained tiling algorithms and extension modules for xmonad,
     an X11 tiling window manager.


### PR DESCRIPTION
Removes a repeating word in a package synopsis.

### Description

I noticed this while walking through the project's Hackage page.
The typo appeared after #630.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
