### PR TITLE
Add Modal Keybindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,10 @@
     A module for adding a keybinding to repeat the last action, similar
     to Vim's `.` or Emacs's `dot-mode`.
 
+ * `XMonad.Util.Grab`
+
+    Utilities for making grabbing and ungrabbing keys more convenient.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Prompt.OrgMode`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,10 @@
 
     Utilities for making grabbing and ungrabbing keys more convenient.
 
+  * `XMonad.Hooks.Modal`
+
+    This module implements modal keybindings for xmonad.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Prompt.OrgMode`

--- a/XMonad/Hooks/Modal.hs
+++ b/XMonad/Hooks/Modal.hs
@@ -1,0 +1,275 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Hooks.Modal
+-- Description :  Implements true modality in xmonad key-bindings.
+-- Copyright   :  (c) 2018  L. S. Leary
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Author      :  L. S. Leary
+-- Maintainer  :  Yecine Megdiche <yecine.megdiche@gmail.com>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- This module implements modal keybindings for xmonad.
+--
+--------------------------------------------------------------------------------
+
+-- --< Imports & Exports >-- {{{
+module XMonad.Hooks.Modal
+  (
+ -- * Usage
+ -- $Usage
+    modal
+  , mode'
+  , mode
+  , Mode
+  , setMode
+  , exitMode
+ -- ** Provided Modes
+ -- $ProvidedModes
+  , noModModeLabel
+  , noModMode
+  , floatModeLabel
+  , floatMode
+  , overlayedFloatModeLabel
+  , overlayedFloatMode
+  , floatMap
+  , overlay
+ -- ** Logger
+  , logMode
+  ) where
+
+-- core
+import           XMonad
+
+-- base
+import           Data.Bits                      ( (.&.)
+                                                , complement
+                                                )
+import           Data.List
+import qualified Data.Map.Strict               as M
+import           XMonad.Actions.FloatKeys       ( keysMoveWindow
+                                                , keysResizeWindow
+                                                )
+import           XMonad.Prelude
+import qualified XMonad.Util.ExtensibleConf    as XC
+-- contrib
+import qualified XMonad.Util.ExtensibleState   as XS
+import           XMonad.Util.Grab
+import           XMonad.Util.Loggers
+
+-- }}}
+
+-- Original Draft By L.S.Leary : https://gist.github.com/LSLeary/6741b0572d62db3f0cea8e6618141b2f
+
+-- --< Usage >-- {{{
+
+-- $Usage
+--
+-- This module provides modal keybindings in xmonad. You can think of modes as
+-- submaps from 'XMonad.Actions.Submap', but after each action you execute, you
+-- land back into the submap until you explicitly exit the submap.
+-- To use this module you should apply the 'modal' function to the config, which
+-- will setup the list of modes (or rather, @XConfig Layout -> Mode@) your provide:
+--
+-- >
+-- > import XMonad
+-- > import XMonad.Hooks.Modal
+-- >
+-- > main :: IO ()
+-- > main =
+-- >   xmonad
+-- >     . modal [noModMode, floatMode 10, overlayedFloatMode 10, sayHelloMode]
+-- >     $ def
+-- >     `addiotnalKeysP` [ ("M-S-n", setMode noModModeLabel)
+-- >                      , ("M-S-r", setMode floatModeLabel)
+-- >                      , ("M-S-z", setMode overlayedFloatModeLabel)
+-- >                      ]
+-- >
+-- > sayHelloMode :: Mode
+-- > sayHelloMode = mode "Hello"
+-- >   $ const (M.fromList [((noModMask, xK_h), xmessage "Hello World! ")])
+--
+-- A 'Mode' has a label describing its purpose and keybinings (in form
+-- of @XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())@). The label
+-- of the active mode can be logged with 'logMode' to be displayed in a
+-- status bar, for example (For more information check
+-- 'XMonad.Util.Loggers'). Check $ProvidedModes for a small collection of
+-- provided modes.
+
+-- }}}
+
+-- --< Types >-- {{{
+
+-- | The mode type. Use 'mode' or 'mode'' to create modes.
+data Mode = Mode
+  { label     :: String
+  , boundKeys :: XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())
+  }
+
+-- | Newtype for the extensible config.
+newtype ModeConfig = MC [Mode] deriving Semigroup
+
+-- | Newtype for the extensible state.
+newtype CurrentMode = CurrentMode
+  {  currentMode :: Maybe Mode
+  }
+
+instance ExtensionClass CurrentMode where
+  initialValue = CurrentMode Nothing
+
+-- }}}
+
+-- --< Private >-- {{{
+
+-- | The active keybindings corresponding to the active 'Mode' (or lack
+-- thereof).
+currentKeys :: X (M.Map (ButtonMask, KeySym) (X ()))
+currentKeys = do
+  cnf <- asks config
+  XS.gets currentMode >>= \case
+    Just m  -> pure (boundKeys m cnf)
+    Nothing -> join keys <$> asks config
+
+-- | Grab the keys corresponding to the active 'Mode' (or lack thereof).
+regrab :: X ()
+regrab = grab . M.keys =<< currentKeys
+
+-- | Called after changing the mode. Grabs the correct keys and runs the
+-- 'logHook'.
+refreshMode :: X ()
+refreshMode = regrab >> asks config >>= logHook
+
+-- | Event hook to control the keybindings.
+modalEventHook :: Event -> X All
+modalEventHook = customRegrabEvHook regrab <> \case
+  KeyEvent { ev_event_type = t, ev_state = m, ev_keycode = code }
+    | t == keyPress -> withDisplay $ \dpy -> do
+      kp  <- (,) <$> cleanMask m <*> io (keycodeToKeysym dpy code 0)
+      kbs <- currentKeys
+      userCodeDef () (whenJust (M.lookup kp kbs) id)
+      pure (All False)
+  _ -> pure (All True)
+
+-- }}}
+
+-- --< Public >-- {{{
+
+-- | Adds the provided modes to the user's config, and sets up the bells
+-- and whistles needed for them to work.
+modal :: [Mode] -> XConfig l -> XConfig l
+modal modes = XC.once
+  (\cnf -> cnf { startupHook     = startupHook cnf <> initModes
+               , handleEventHook = handleEventHook cnf <> modalEventHook
+               }
+  )
+  (MC modes)
+  where initModes = XS.put (CurrentMode Nothing) >> refreshMode
+
+-- | Create a 'Mode' from the given binding to 'exitMode', label and
+-- keybindings.
+mode'
+  :: (ButtonMask, KeySym)
+  -> String
+  -> (XConfig Layout -> M.Map (ButtonMask, KeySym) (X ()))
+  -> Mode
+mode' exitKey mlabel keysF = Mode mlabel (M.insert exitKey exitMode . keysF)
+
+-- | Create a 'Mode' from the given label and keybindings. Sets The
+-- @escape@ key to 'exitMode'.
+mode :: String -> (XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())) -> Mode
+mode = mode' (noModMask, xK_Escape)
+
+-- | Set the current @Mode@ based on its label.
+setMode :: String -> X ()
+setMode l = do
+  XC.with $ \(MC ls) -> case find ((== l) . label) ls of
+    Nothing -> mempty
+    Just m  -> do
+      XS.modify $ \cm -> cm { currentMode = Just m }
+      refreshMode
+
+-- | Exists the current mode.
+exitMode :: X ()
+exitMode = do
+  XS.modify $ \m -> m { currentMode = Nothing }
+  refreshMode
+
+-- | A 'Logger' to display the current mode.
+logMode :: Logger
+logMode = fmap label <$> XS.gets currentMode
+
+-- Provided modes
+noModModeLabel, floatModeLabel, overlayedFloatModeLabel :: String
+noModModeLabel = "NoMod"
+floatModeLabel = "Float"
+overlayedFloatModeLabel = "Overlayed Float"
+
+-- | In this @Mode@, all keysbindings are available without the need for pressing
+-- the modifier. Pressing @escape@ exits the mode.
+noModMode :: Mode
+noModMode =
+  mode noModModeLabel $ \cnf -> stripModifier (modMask cnf) (keys cnf cnf)
+
+-- | Generates the keybindings for 'floatMode' and 'overlayedFloatMode'.
+floatMap
+  :: KeyMask -- ^ Move mask
+  -> KeyMask -- ^ Enlarge mask
+  -> KeyMask -- ^ Shrink mask
+  -> Int -- ^ Step size
+  -> M.Map (ButtonMask, KeySym) (X ())
+floatMap move enlarge shrink s = M.fromList
+  [ -- move
+    ((move, xK_h)          , withFocused (keysMoveWindow (-s, 0)))
+  , ((move, xK_j)          , withFocused (keysMoveWindow (0, s)))
+  , ((move, xK_k)          , withFocused (keysMoveWindow (0, -s)))
+  , ((move, xK_l)          , withFocused (keysMoveWindow (s, 0)))
+  -- enlarge
+  , ((enlarge, xK_h), withFocused (keysResizeWindow (s, 0) (1, 0)))
+  , ((enlarge, xK_j), withFocused (keysResizeWindow (0, s) (0, 0)))
+  , ((enlarge, xK_k), withFocused (keysResizeWindow (0, s) (0, 1)))
+  , ((enlarge, xK_l), withFocused (keysResizeWindow (s, 0) (0, 0)))
+  -- shrink
+  , ((shrink, xK_h), withFocused (keysResizeWindow (-s, 0) (0, 0)))
+  , ((shrink, xK_j), withFocused (keysResizeWindow (0, -s) (0, 1)))
+  , ((shrink, xK_k), withFocused (keysResizeWindow (0, -s) (0, 0)))
+  , ((shrink, xK_l), withFocused (keysResizeWindow (-s, 0) (1, 0)))
+  , ((noModMask, xK_Escape), exitMode)
+  ]
+
+-- | A mode to control floating windows with @{hijk}@, @M-{hijk}@ and
+-- @M-S-{hijk}@ in order to respectively move, enlarge and
+-- shrink windows.
+floatMode
+  :: Int -- ^ Step size
+  -> Mode
+floatMode i = mode floatModeLabel $ \XConfig { modMask } ->
+  floatMap noModMask modMask (modMask .|. shiftMask) i
+
+-- | Similar to 'resizeMode', but keeps the bindings of the original
+-- config active.
+overlayedFloatMode
+  :: Int -- ^ Step size
+  -> Mode
+overlayedFloatMode = overlay overlayedFloatModeLabel . floatMode
+
+-- | Modifies a mode so that the keybindings are merged with those from
+-- the config instead of replacing them.
+overlay
+  :: String -- ^ Label for the new mode
+  -> Mode -- ^ Base mode
+  -> Mode
+overlay label m = Mode label $ \cnf -> boundKeys m cnf `M.union` keys cnf cnf
+
+-- | Strips the modifier key from the provided keybindings.
+stripModifier
+  :: ButtonMask -- ^ Modifier to remove
+  -> M.Map (ButtonMask, KeySym) (X ()) -- ^ Original keybinding map
+  -> M.Map (ButtonMask, KeySym) (X ())
+stripModifier mask = M.mapKeys $ \(m, k) -> (m .&. complement mask, k)
+
+-- }}}

--- a/XMonad/Hooks/Modal.hs
+++ b/XMonad/Hooks/Modal.hs
@@ -99,8 +99,8 @@ import           XMonad.Util.Loggers
 -- of @XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())@). The label
 -- of the active mode can be logged with 'logMode' to be displayed in a
 -- status bar, for example (For more information check
--- 'XMonad.Util.Loggers'). Some examples can be found are included
--- in [the provided modes](#g:ProvidedModes).
+-- 'XMonad.Util.Loggers'). Some examples are included in
+-- [the provided modes](#g:ProvidedModes).
 
 -- }}}
 

--- a/XMonad/Hooks/Modal.hs
+++ b/XMonad/Hooks/Modal.hs
@@ -70,11 +70,12 @@ import           XMonad.Util.Loggers
 
 -- $Usage
 --
--- This module provides modal keybindings in xmonad. You can think of modes as
--- submaps from 'XMonad.Actions.Submap', but after each action you execute, you
--- land back into the submap until you explicitly exit the submap.
--- To use this module you should apply the 'modal' function to the config, which
--- will setup the list of modes (or rather, @XConfig Layout -> Mode@) your provide:
+-- This module provides modal keybindings in xmonad. If you're not familiar with
+-- modal keybindings from Vim, you can think of modes as submaps from
+-- 'XMonad.Actions.Submap', but after each action you execute, you land back in
+-- the submap until you explicitly exit the submap. To use this module you
+-- should apply the 'modal' function to the config, which will setup the list of
+-- modes (or rather, @XConfig Layout -> Mode@) you provide:
 --
 -- >
 -- > import XMonad
@@ -85,16 +86,16 @@ import           XMonad.Util.Loggers
 -- >   xmonad
 -- >     . modal [noModMode, floatMode 10, overlayedFloatMode 10, sayHelloMode]
 -- >     $ def
--- >     `addiotnalKeysP` [ ("M-S-n", setMode noModModeLabel)
--- >                      , ("M-S-r", setMode floatModeLabel)
--- >                      , ("M-S-z", setMode overlayedFloatModeLabel)
--- >                      ]
+-- >     `additionalKeysP` [ ("M-S-n", setMode noModModeLabel)
+-- >                       , ("M-S-r", setMode floatModeLabel)
+-- >                       , ("M-S-z", setMode overlayedFloatModeLabel)
+-- >                       ]
 -- >
 -- > sayHelloMode :: Mode
 -- > sayHelloMode = mode "Hello"
 -- >   $ const (M.fromList [((noModMask, xK_h), xmessage "Hello World! ")])
 --
--- A 'Mode' has a label describing its purpose and keybinings (in form
+-- A 'Mode' has a label describing its purpose and keybindings (in form
 -- of @XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())@). The label
 -- of the active mode can be logged with 'logMode' to be displayed in a
 -- status bar, for example (For more information check
@@ -179,12 +180,12 @@ mode'
   -> Mode
 mode' exitKey mlabel keysF = Mode mlabel (M.insert exitKey exitMode . keysF)
 
--- | Create a 'Mode' from the given label and keybindings. Sets The
+-- | Create a 'Mode' from the given label and keybindings. Sets the
 -- @escape@ key to 'exitMode'.
 mode :: String -> (XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())) -> Mode
 mode = mode' (noModMask, xK_Escape)
 
--- | Set the current @Mode@ based on its label.
+-- | Set the current 'Mode' based on its label.
 setMode :: String -> X ()
 setMode l = do
   XC.with $ \(MC ls) -> case find ((== l) . label) ls of
@@ -193,7 +194,7 @@ setMode l = do
       XS.modify $ \cm -> cm { currentMode = Just m }
       refreshMode
 
--- | Exists the current mode.
+-- | Exits the current mode.
 exitMode :: X ()
 exitMode = do
   XS.modify $ \m -> m { currentMode = Nothing }
@@ -209,7 +210,7 @@ noModModeLabel = "NoMod"
 floatModeLabel = "Float"
 overlayedFloatModeLabel = "Overlayed Float"
 
--- | In this @Mode@, all keysbindings are available without the need for pressing
+-- | In this 'Mode', all keybindings are available without the need for pressing
 -- the modifier. Pressing @escape@ exits the mode.
 noModMode :: Mode
 noModMode =

--- a/XMonad/Hooks/Modal.hs
+++ b/XMonad/Hooks/Modal.hs
@@ -29,7 +29,7 @@ module XMonad.Hooks.Modal
   , Mode
   , setMode
   , exitMode
- -- ** Provided Modes
+ -- * Provided Modes #ProvidedModes#
  -- $ProvidedModes
   , noModModeLabel
   , noModMode
@@ -39,7 +39,7 @@ module XMonad.Hooks.Modal
   , overlayedFloatMode
   , floatMap
   , overlay
- -- ** Logger
+ -- * Logger
   , logMode
   ) where
 
@@ -99,8 +99,8 @@ import           XMonad.Util.Loggers
 -- of @XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())@). The label
 -- of the active mode can be logged with 'logMode' to be displayed in a
 -- status bar, for example (For more information check
--- 'XMonad.Util.Loggers'). Check $ProvidedModes for a small collection of
--- provided modes.
+-- 'XMonad.Util.Loggers'). Some examples can be found are included
+-- in [the provided modes](#g:ProvidedModes).
 
 -- }}}
 

--- a/XMonad/Util/Grab.hs
+++ b/XMonad/Util/Grab.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE LambdaCase #-}
+
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Util.Grab
+-- Description :  Utilities for grabbing/ungrabbing keys.
+-- Copyright   :  (c) 2018  L. S. Leary
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  L. S. Leary
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- This module should not be directly used by users. Its purpose is to
+-- facilitate grabbing and ungrabbing keys.
+--------------------------------------------------------------------------------
+
+-- --< Imports & Exports >-- {{{
+
+module XMonad.Util.Grab
+  (
+ -- * Usage
+ -- $Usage
+    grabKP
+  , ungrabKP
+  , grabUngrab
+  , grab
+  , customRegrabEvHook
+  ) where
+
+-- core
+import           XMonad
+
+import           Control.Monad                  ( when )
+import           Data.Bits                      ( setBit )
+import           Data.Foldable                  ( traverse_ )
+-- base
+import qualified Data.Map.Strict               as M
+import           Data.Semigroup                 ( All(..) )
+import           Data.Traversable               ( for )
+
+-- }}}
+
+-- --< Usage >-- {{{
+
+-- $Usage
+--
+-- This module should not be directly used by users. Its purpose is to
+-- facilitate grabbing and ungrabbing keys.
+
+-- }}}
+
+-- --< Public Utils >-- {{{
+
+-- | A more convenient version of 'grabKey'.
+grabKP :: KeyMask -> KeyCode -> X ()
+grabKP mdfr kc = do
+  XConf { display = dpy, theRoot = rootw } <- ask
+  io (grabKey dpy kc mdfr rootw True grabModeAsync grabModeAsync)
+
+-- | A more convenient version of 'ungrabKey'.
+ungrabKP :: KeyMask -> KeyCode -> X ()
+ungrabKP mdfr kc = do
+  XConf { display = dpy, theRoot = rootw } <- ask
+  io (ungrabKey dpy kc mdfr rootw)
+
+-- | A convenience function to grab and ungrab keys
+grabUngrab
+  :: [(KeyMask, KeySym)] -- ^  Keys to grab
+  -> [(KeyMask, KeySym)] -- ^ Keys to ungrab
+  -> X ()
+grabUngrab gr ugr = do
+  f <- mkGrabs
+  traverse_ (uncurry ungrabKP) (f ugr)
+  traverse_ (uncurry grabKP)   (f gr)
+
+-- | A convenience function to grab keys. This also ungrabs all
+-- previously grabbed keys.
+grab :: [(KeyMask, KeySym)] -> X ()
+grab ks = do
+  XConf { display = dpy, theRoot = rootw } <- ask
+  io (ungrabKey dpy anyKey anyModifier rootw)
+  grabUngrab ks []
+
+-- | An event hook that runs a custom action to regrab the necessary keys.
+customRegrabEvHook :: X () -> Event -> X All
+customRegrabEvHook regr = \case
+  e@MappingNotifyEvent{} -> do
+    io (refreshKeyboardMapping e)
+    when (ev_request e `elem` [mappingKeyboard, mappingModifier])
+      $  setNumlockMask
+      >> regr
+    pure (All False)
+  _ -> pure (All True)
+
+-- }}}
+
+-- --< Private Utils >-- {{{
+
+-- | Private action shamelessly copied and restyled from XMonad.Main source.
+setNumlockMask :: X ()
+setNumlockMask = withDisplay $ \dpy -> do
+  ms <- io (getModifierMapping dpy)
+  xs <- sequence
+    [ do
+        ks <- io (keycodeToKeysym dpy kc 0)
+        pure $ if ks == xK_Num_Lock
+          then setBit 0 (fromIntegral m)
+          else 0 :: KeyMask
+    | (m, kcs) <- ms
+    , kc       <- kcs
+    , kc /= 0
+    ]
+  modify $ \s -> s { numberlockMask = foldr (.|.) 0 xs }
+
+-- | Private function shamelessly copied and refactored from XMonad.Main source.
+mkGrabs :: X ([(KeyMask, KeySym)] -> [(KeyMask, KeyCode)])
+mkGrabs = withDisplay $ \dpy -> do
+  let (minCode, maxCode) = displayKeycodes dpy
+      allCodes           = [fromIntegral minCode .. fromIntegral maxCode]
+  syms <- io . for allCodes $ \code -> keycodeToKeysym dpy code 0
+  let keysymMap = M.fromListWith (++) (zip syms $ pure <$> allCodes)
+      keysymToKeycodes sym = M.findWithDefault [] sym keysymMap
+  extraMods <- extraModifiers
+  pure $ \ks -> do
+    (mask, sym) <- ks
+    keycode     <- keysymToKeycodes sym
+    extraMod    <- extraMods
+    pure (mask .|. extraMod, keycode)
+
+-- }}}
+
+
+-- NOTE: there is some duplication between this module and core. The
+-- latter probably will never change, but this needs to be kept in sync
+-- with any potential bugs that might arise.

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -191,6 +191,7 @@ library
                         XMonad.Hooks.ManageDocks
                         XMonad.Hooks.ManageHelpers
                         XMonad.Hooks.Minimize
+                        XMonad.Hooks.Modal
                         XMonad.Hooks.Place
                         XMonad.Hooks.PositionStoreHooks
                         XMonad.Hooks.RefocusLast

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -353,6 +353,7 @@ library
                         XMonad.Util.ExtensibleConf
                         XMonad.Util.ExtensibleState
                         XMonad.Util.Font
+                        XMonad.Util.Grab
                         XMonad.Util.Hacks
                         XMonad.Util.Image
                         XMonad.Util.Invisible


### PR DESCRIPTION
### Description

An alternative to #213 based on L. S. Leary's work (https://gist.github.com/LSLeary/6741b0572d62db3f0cea8e6618141b2f). I didn't change much (_yet_) from the original draft, I just played around with the code and took it out for a spin. Now that I have some opinions on the code, I figured opening a PR would be better to concretely discuss how to best go forward with this. 

Here are the things I changed:
- I made the modes included use the keybindings from the given config, not from the default config. This seemed form me as a better UX. 
- I dropped `insertMode` and renamed `normalMode` to `noModMode` ( I don't particularly see the utility).
- I added loggers and made `setTo` run `refresh`, so the loggers are updated

Here are things that are still open:
- [x] ~Decide: Should we keep "GrabAll | GrabBound"?~ Drop it
  - [x] ~If yes, investigate the bug where key grabs without a modifier on GrabAll don't work (example below)~ No idea, see the comments below
- [x] `defaultMode` as an `initialValue` for the `ExtensionClass`, and drop the parameter from `modal`? 
- [x] Add an example for a "resize mode"
- [x] ~I don't like the duplication `X.U.Grab` has with the logic in the core, maybe we can avoid that somehow~ Probably fine as is
- [x] Finish the documentation




##### GrabAll bug:

> I'm running into problems with using GrabAll from the gist: keys with no modifiers aren't grabbed. In the example below, pressing M-F works, but D doesn't. Replacing that with GrabBound makes both work
> 
> ```
> main = xmonad …
>   . modal passiveMode
>   …
>   def …
> 
> 
> passiveMode :: XConfig Layout -> Mode
> passiveMode cnf = Mode
>   "DEFAULT"
>   GrabBound
>   (M.insert (modMask cnf, xK_n) (setTo (echoMode cnf) >> refresh) (keys cnf cnf))
> 
> 
> echoMode :: XConfig Layout -> Mode
> echoMode cnf = Mode "ECHO" GrabAll $ M.fromList
>   [ ((noModMask, xK_d)  , xmessage "D")
>   , ((modMask cnf, xK_d), setTo (passiveMode cnf) >> refresh)
>   , ((modMask cnf, xK_f), xmessage "F")
>   ]
> ``` 



### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (ran the code) and concluded: it's a very useful addition but some things need to be tweaked

  - [x] I updated the `CHANGES.md` file
