### PR TITLE
Fix missing prompt configuration in DynamicProjects example

### DIFF
--- a/XMonad/Actions/DynamicProjects.hs
+++ b/XMonad/Actions/DynamicProjects.hs
@@ -109,8 +109,8 @@ import qualified XMonad.Util.ExtensibleState as XS
 --
 -- And finally, configure some optional key bindings:
 --
--- >  , ((modm, xK_space), switchProjectPrompt)
--- >  , ((modm, xK_slash), shiftToProjectPrompt)
+-- >  , ((modm, xK_space), switchProjectPrompt def)
+-- >  , ((modm, xK_slash), shiftToProjectPrompt def)
 --
 -- For detailed instructions on editing your key bindings, see
 -- "XMonad.Doc.Extending#Editing_key_bindings".


### PR DESCRIPTION
### Description

Trivial fix for missing default argument.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: trivial docs fix, no tests required

  - [ ] I updated the `CHANGES.md` file (not required)
