### PR TITLE
migrate build scripts from xmonad-testing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,12 @@
     - Added support for dynamic scratchpads in the form of
       `dynamicNSPAction` and `toggleDynamicNSP`.
 
+### Other changes
+
+  * Migrated the sample build scripts from the deprecated `xmonad-testing` repo to
+    `scripts/build`. This will be followed by a documentation update in the `xmonad`
+    repo.
+
 ## 0.17.0 (October 27, 2021)
 
 ### Breaking Changes

--- a/scripts/build/build-with-cabal.sh
+++ b/scripts/build/build-with-cabal.sh
@@ -1,0 +1,59 @@
+#! /bin/sh -eu
+
+# Your source directory. Default is the config dir, if it can be found.
+SRC_DIR=
+
+# Executable name, from the executable stanza of your cabal file.
+# The script will try to guess it if not specified.
+EXE_NAME=
+
+##############################################################################
+
+# config
+
+output="$1"
+
+if [ "$SRC_DIR" = "" ]; then
+    # look for the config directory, fall back to the old one
+    SRC_DIR="${XMONAD_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config/xmonad}}"
+    if test -f "$SRC_DIR/build"; then
+	:
+    else
+	SRC_DIR="$HOME/.xmonad"
+    fi
+fi
+cd "$SRC_DIR"
+
+if [ "$EXE_NAME" = "" ]; then
+    # try to extract the name of the executable
+    EXE_NAME="$(awk '!done && /^executable / {print $2; done = 1}' *.cabal)"
+    # note that there should be only one cabal file or cabal will report a
+    # conflict; any utilities should be listed after the xmonad executable
+fi
+
+# do it to it
+
+d="$(dirname "$output")"
+f="$(basename "$output")"
+first=0
+for exe in $EXE_NAME; do
+    cabal install exe:"$EXE_NAME" \
+	  --enable-executable-stripping \
+	  --enable-optimization=2 \
+	  --installdir="$d" \
+	  --overwrite-policy=always
+    # NB. a cabal bug may mean it doesn't actually get stripped
+    # we assume the first executable in the list is the new xmonad
+    if [ $first = 0 ]; then
+	first=1
+	if [ "$f" = "$exe" ]; then
+	    : someone will try it…
+	else
+	    ln -sf "$exe" "$output"
+	fi
+    elif [ "$f" = "$exe" ]; then
+	# the link above just got replaced with a direct link into the
+	# cabal package
+	echo I hope you know what you\'re doing... >&2
+    fi
+done

--- a/scripts/build/build-with-stack.sh
+++ b/scripts/build/build-with-stack.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -eu
+
+################################################################################
+# Edit the following constants and then rename this script to ~/.xmonad/build
+
+# The directory holding your source code and stack.yaml file:
+SRC_DIR=~/develop/oss/xmonad-testing
+
+# The name of the executable produced by stack.  This comes from the
+# executable section of your *.cabal or package.yaml file.
+EXE_NAME=xmonad-testing
+
+################################################################################
+
+# Unset STACK_YAML, to ensure that $SRC_DIR/stack.yaml is used.
+unset STACK_YAML
+
+# Do the build.
+cd $SRC_DIR
+stack build
+
+# Create a hard link at the requested destination, replacing any existing one.
+ln -f -T $(stack exec -- which $EXE_NAME) $1


### PR DESCRIPTION
The testing repo was not a good location for them, and is now
deprecated. They are now in `scripts/build`, and will be documented
in the main repo's `INSTALL.md`.