### PR TITLE
Apply Patch in Nix Flake; Enable Configuration (Contrib Edition)

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -15,3 +15,55 @@ pkgs: devInputs: devInputs // {
     [ cabal-install hlint ghcid ormolu implicit-hie haskell-language-server ];
 }
 ```
+
+## NixOS Modules
+
+The core and contrib flakes provide NixOS configuration modules.
+You can bring them into your system flake like so:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-<version>;
+    xmonad.url = github:xmonad/xmonad;
+    xmonad-contrib.url = github:xmonad/xmonad-contrib;
+  };
+
+  outputs = { self, nixpkgs, xmonad, xmonad-contrib }: {
+    nixosConfigurations.<hostname> = nixpkgs.lib.nixosSystem rec {
+      system = <arch>;
+      modules = [
+        ./configuration.nix
+        xmonad.nixosModule
+        xmonad-contrib.nixosModule
+      ];
+    };
+  };
+}
+```
+
+Then you can set the provided options in your `configuration.nix` under `flake`:
+
+```nix
+  services.xserver.windowManager.xmonad = {
+    enable = true;
+    enableContribAndExtras = true;
+    flake = {
+      enable = true;
+    # prefix = "unstable";
+      compiler = "ghc921";
+    };
+  };
+```
+
+This will use core and contrib from git for your system xmonad, building your
+config with the compiler of your choice.
+
+With the flake enabled, the `xmonad.haskellPackages` option is not used directly,
+and is instead set by the `flake.compiler` option. When `compiler` is unset,
+the default `pkgs.haskellPackages` is used.
+
+The `prefix` option is used if you wish to select your haskell packages from
+within, e.g., unstable overlaid into `pkgs` as `pkgs.unstable`.
+
+See the flakes themselves and nix flake documentation for full detail.

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,5 @@
-# This file is maintained by @IvanMalison (github)
+# This file is maintained by @IvanMalison and @LSLeary (github)
+# See NIX.md for an overview of module usage.
 {
   inputs = {
     flake-utils.url = github:numtide/flake-utils;

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       xmonad-contrib = hself.callCabal2nix "xmonad-contrib"
         (git-ignore-nix.lib.gitignoreSource ./.) { };
     };
-    overlay = xmonad.lib.fromHOL hoverlay;
+    overlay = xmonad.lib.fromHOL hoverlay { };
     overlays = xmonad.overlays ++ [ overlay ];
   in flake-utils.lib.eachDefaultSystem (system:
   let
@@ -27,5 +27,5 @@
       nativeBuildInputs = [ pkgs.cabal-install ];
     });
     defaultPackage = pkgs.haskellPackages.xmonad-contrib;
-  }) // { inherit overlay overlays; };
+  }) // { inherit hoverlay overlay overlays; } ;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,15 +7,11 @@
   };
   outputs = { self, flake-utils, nixpkgs, git-ignore-nix, xmonad }:
   let
-    overlay = final: prev: {
-      haskellPackages = prev.haskellPackages.override (old: {
-        overrides = prev.lib.composeExtensions (old.overrides or (_: _: {}))
-        (hself: hsuper: {
-          xmonad-contrib =
-            hself.callCabal2nix "xmonad-contrib" (git-ignore-nix.lib.gitignoreSource ./.) { };
-        });
-      });
+    hoverlay = final: prev: hself: hsuper: {
+      xmonad-contrib = hself.callCabal2nix "xmonad-contrib"
+        (git-ignore-nix.lib.gitignoreSource ./.) { };
     };
+    overlay = xmonad.lib.fromHOL hoverlay;
     overlays = xmonad.overlays ++ [ overlay ];
   in flake-utils.lib.eachDefaultSystem (system:
   let
@@ -31,5 +27,5 @@
       nativeBuildInputs = [ pkgs.cabal-install ];
     });
     defaultPackage = pkgs.haskellPackages.xmonad-contrib;
-  }) // { inherit overlay overlays; } ;
+  }) // { inherit overlay overlays; };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,24 @@
     xmonad.url = github:xmonad/xmonad;
   };
   outputs = { self, flake-utils, nixpkgs, git-ignore-nix, xmonad }:
+  with xmonad.lib;
   let
     hoverlay = final: prev: hself: hsuper: {
       xmonad-contrib = hself.callCabal2nix "xmonad-contrib"
         (git-ignore-nix.lib.gitignoreSource ./.) { };
     };
-    overlay = xmonad.lib.fromHOL hoverlay { };
+    overlay = fromHOL hoverlay { };
     overlays = xmonad.overlays ++ [ overlay ];
+    nixosModule = { config, lib, ... }: with lib;
+      let
+        cfg = config.services.xserver.windowManager.xmonad;
+        comp = { inherit (cfg.flake) prefix compiler; };
+      in {
+        config = mkIf (cfg.flake.enable && cfg.enableContribAndExtras) {
+          nixpkgs.overlays = [ (fromHOL hoverlay comp) ];
+        };
+      };
+    nixosModules = xmonad.nixosModules ++ [ nixosModule ];
   in flake-utils.lib.eachDefaultSystem (system:
   let
     pkgs = import nixpkgs { inherit system overlays; };
@@ -27,5 +38,5 @@
       nativeBuildInputs = [ pkgs.cabal-install ];
     });
     defaultPackage = pkgs.haskellPackages.xmonad-contrib;
-  }) // { inherit hoverlay overlay overlays; } ;
+  }) // { inherit hoverlay overlay overlays nixosModule nixosModules; } ;
 }


### PR DESCRIPTION
### Description

See xmonad/xmonad#392.

This is the contrib half. Note that the nix build is expected to fail until the core half is merged.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
