### PR TITLE
X.H.EwmhDesktops: Add `_NET_DESKTOP_VIEWPORT` support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,11 @@
     - Added support for dynamic scratchpads in the form of
       `dynamicNSPAction` and `toggleDynamicNSP`.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - Added support for `_NET_DESKTOP_VIEWPORT`, which is required by
+      some status bars.
+
 ### Other changes
 
   * Migrated the sample build scripts from the deprecated `xmonad-testing` repo to


### PR DESCRIPTION
### Description

My implementation of _NET_DESKTOP_VIEWPORT. I don't know how spaghetti it may be since I am not a seasoned haskeller. Part of what makes this so much bigger than the other functions is the sorting part since I don't know how to use the sort' that is already on the log hook of EwmhDesktops since it works with workspace sorting and I needed to sort tuples with workspaces. 

Also the sorting that I put in does not follow the X WorkspaceSort that is provided by the user since you'd have to now ask for instead of a workspace sort, a more general X WorkspaceCompare, which then gets ran though the mkWsSort and mkViewPortSort to both use the same comparison. But that is a question I'd rather ask first. Generally this is more code than what the other ewmh stuff takes to add.

Test this out with polybar, specifically with this commit. 

https://github.com/polybar/polybar/commit/bc9dda266f57f7ae3a2300a9418d94c3fe62c466

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [] I updated the `CHANGES.md` file (Ill do this if this even goes through)
