### PR TITLE
Extend X.U.Run with an EDSL for spawning processes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -186,6 +186,11 @@
     - Added support for `_NET_DESKTOP_VIEWPORT`, which is required by
       some status bars.
 
+  * `XMonad.Util.Run`
+
+    - Added an EDSL—particularly geared towards programs like terminals
+      or Emacs—to spawn processes from XMonad in a compositional way.
+
 ### Other changes
 
   * Migrated the sample build scripts from the deprecated `xmonad-testing` repo to

--- a/XMonad/Prompt/OrgMode.hs
+++ b/XMonad/Prompt/OrgMode.hs
@@ -57,7 +57,6 @@ import XMonad.Util.Parser
 import XMonad.Util.XSelection (getSelection)
 
 import Data.Time (Day (ModifiedJulianDay), NominalDiffTime, UTCTime (utctDay), addUTCTime, defaultTimeLocale, formatTime, fromGregorian, getCurrentTime, iso8601DateFormat, nominalDay, toGregorian)
-import System.Directory (getHomeDirectory)
 import System.IO (IOMode (AppendMode), hPutStrLn, withFile)
 
 {- $usage
@@ -217,10 +216,7 @@ mkOrgPrompt xpc oc@OrgMode{ todoHeader, orgFile, clpSupport } =
                else Body   $ "\n " <> sel
 
     -- Expand path if applicable
-    fp <- case orgFile of
-      '/'       : _ -> pure orgFile
-      '~' : '/' : _ -> getHomeDirectory <&> (<> drop 1 orgFile)
-      _             -> getHomeDirectory <&> (<> ('/' : orgFile))
+    fp <- mkAbsolutePath orgFile
 
     withFile fp AppendMode . flip hPutStrLn
       <=< maybe (pure "") (ppNote clpStr todoHeader) . pInput

--- a/XMonad/Util/Run.hs
+++ b/XMonad/Util/Run.hs
@@ -86,7 +86,7 @@ import qualified XMonad.Util.ExtensibleConf as XC
 
 import Codec.Binary.UTF8.String (encodeString)
 import Control.Concurrent (threadDelay)
-import System.Directory (getDirectoryContents, getHomeDirectory)
+import System.Directory (getDirectoryContents)
 import System.IO
 import System.Posix.IO
 import System.Posix.Process (createSession, executeFile, forkProcess)
@@ -451,12 +451,10 @@ data EmacsLib
 -- in batch mode.
 withEmacsLibs :: [EmacsLib] -> X Input
 withEmacsLibs libs = XC.withDef $ \ProcessConfig{emacsLispDir, emacsElpaDir} -> do
-  home       <- liftIO getHomeDirectory
-  let lispDir = mkAbsolutePath home emacsLispDir
-      elpaDir = mkAbsolutePath home emacsElpaDir
-
-  lisp <- liftIO $ getDirectoryContents lispDir
-  elpa <- liftIO $ getDirectoryContents elpaDir
+  lispDir <- mkAbsolutePath emacsLispDir
+  elpaDir <- mkAbsolutePath emacsElpaDir
+  lisp    <- liftIO $ getDirectoryContents lispDir
+  elpa    <- liftIO $ getDirectoryContents elpaDir
 
   let getLib :: EmacsLib -> Maybe String = \case
         OwnFile f -> (("-l " <> lispDir) <>) <$> find (f          `isInfixOf`) lisp

--- a/XMonad/Util/Run.hs
+++ b/XMonad/Util/Run.hs
@@ -414,19 +414,32 @@ termInDir = inTerm >-> inWorkingDir
 
 -- | Transform the given input into an elisp function; i.e., surround it
 -- with parentheses.
+--
+-- >>> elispFun "arxiv-citation URL"
+-- " '( arxiv-citation URL )' "
 elispFun :: String -> String
-elispFun f = " '(" <> f <> " )' "
+elispFun f = " '( " <> f <> " )' "
 
 -- | Treat an argument as a string; i.e., wrap it with quotes.
+--
+-- >>> asString "string"
+-- " \"string\" "
 asString :: String -> String
 asString s = " \"" <> s <> "\" "
 
--- | Wrap the given commands in a @progn@.  The commands need not be
--- wrapped in parentheses, this will be done by the function.
+-- | Wrap the given commands in a @progn@ and also escape it by wrapping
+-- it inside single quotes.  The given commands need not be wrapped in
+-- parentheses, this will be done by the function.  For example:
+--
+-- >>> progn [require "this-lib", "function-from-this-lib arg", "(other-function arg2)"]
+-- " '( progn (require (quote this-lib)) (function-from-this-lib arg) (other-function arg2) )' "
 progn :: [String] -> String
 progn cmds = elispFun $ "progn " <> unwords (map inParens cmds)
 
 -- | Require a package.
+--
+-- >>> require "arxiv-citation"
+-- "(require (quote arxiv-citation))"
 require :: String -> String
 require = inParens . ("require " <>) .  inParens . ("quote " <>)
 


### PR DESCRIPTION
### Description

This extends X.U.Run with an EDSL for spawning (external) processes.  I will let an example from the documentation speak for itself:

``` haskell
  do url <- getSelection  -- from XMonad.Util.XSelection
     proc $ inEmacs
        >-> withEmacsLibs [ElpaLib "dash", ElpaLib "s", OwnFile "arXiv-citation"]
        >-> asBatch
        >-> eval (elispFun $ "arXiv-citation" <> asString url)
```

is essentially equivalent to (line breaks mine)

``` shell
  /usr/bin/sh -c "emacs -L /home/slot/.config/emacs/elpa/dash-20220417.2250
                        -L /home/slot/.config/emacs/elpa/s-20210616.619
                        -l /home/slot/.config/emacs/lisp/arXiv-citation.el
                        --batch
                        --eval '(arXiv-citation \"<url-in-the-primary-selection>\")'"
```


#### Commit Overview

##### X.U.Run: Add an EDSL to spawn external programs

See above.

##### X.U.Run: Improve and add documentation

This adds documentation for the new EDSL, as well as small fixes to existing docs.

Importantly, I've added myself as a maintainer of the file (even though we don't really care about this at this point) and updated the copyright; the changes seem large enough to warrant this.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Tested manually; confirmed to work.  Most of the logic is trivial, and in X, so not sure how hard I should think about further tests.

  - [x] I updated the `CHANGES.md` file