### PR TITLE
Complete #708 by updating _NET_SUPPORTED.

### DIFF
--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -511,6 +511,7 @@ setSupported = withDisplay $ \dpy -> do
                          ,"_NET_ACTIVE_WINDOW"
                          ,"_NET_WM_DESKTOP"
                          ,"_NET_WM_STRUT"
+                         ,"_NET_DESKTOP_VIEWPORT"
                          ]
     io $ changeProperty32 dpy r a aTOM propModeReplace (fmap fromIntegral supp)
 


### PR DESCRIPTION
### Description

#708 is incomplete because it doesn't add `_NET_DESKTOP_VIEWPORT` to `_NET_SUPPORTED`. This update makes that addition, which should make polybar happy. Closes #708.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: needs to be manual

  - [n/a] I updated the `CHANGES.md` file
