### PR TITLE
CenteredIfSingle allow resizing in both dimensions

### DIFF
--- a/XMonad/Layout/CenteredIfSingle.hs
+++ b/XMonad/Layout/CenteredIfSingle.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances  #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -26,8 +26,8 @@ module XMonad.Layout.CenteredIfSingle
   ) where
 
 import XMonad
-import XMonad.Prelude (fi)
 import XMonad.Layout.LayoutModifier
+import XMonad.Prelude (fi)
 
 -- $usage
 -- You can use this module by including  the following in your @~\/.xmonad/xmonad.hs@:
@@ -36,30 +36,46 @@ import XMonad.Layout.LayoutModifier
 --
 -- and adding the 'centeredIfSingle' layoutmodifier to your layouts.
 --
--- > myLayoutHook = centeredIfSingle 0.7 Grid ||| ...  
+-- > myLayoutHook = centeredIfSingle 0.7 0.8 Grid ||| ...
 --
 -- For more information on configuring your layouts see "XMonad.Doc.Extending".
 
 
--- | Layout Modifier that places a window in the center of the screen, 
--- leaving room on the left and right if there is only a single window
-newtype CenteredIfSingle a = CenteredIfSingle Double deriving (Show, Read)
+-- | Layout Modifier that places a window in the center of the screen,
+-- leaving room on the left and right if there is only a single window.
+-- The first argument is the horizontal and the second one the vertical
+-- ratio of the screen the centered window should take up.  Both numbers
+-- should be between 0.0 and 1.0.
+data CenteredIfSingle a = CenteredIfSingle !Double !Double
+  deriving (Show, Read)
 
 instance LayoutModifier CenteredIfSingle Window where
-  pureModifier (CenteredIfSingle ratio) r _ [(onlyWindow, _)] = ([(onlyWindow, rectangleCenterPiece ratio r)], Nothing)
+  pureModifier (CenteredIfSingle ratioX ratioY) r _ [(onlyWindow, _)] = ([(onlyWindow, rectangleCenterPiece ratioX ratioY r)], Nothing)
   pureModifier _ _ _ winRects = (winRects, Nothing)
 
--- | Layout Modifier that places a window in the center of the screen, 
--- leaving room on the left and right if there is only a single window
-centeredIfSingle :: Double -- ^ Ratio of the screen the centered window should take up. Should be a value between 0.0 and 1.0
+-- | Layout Modifier that places a window in the center of the screen,
+-- leaving room on all sides if there is only a single window
+centeredIfSingle :: Double -- ^ Horizontal ratio of the screen the centered window should take up; should be a value between 0.0 and 1.0
+                 -> Double -- ^ Vertical ratio; should also be a value between 0.0 and 1.0
                  -> l a    -- ^ The layout that will be used if more than one window is open
                  -> ModifiedLayout CenteredIfSingle l a
-centeredIfSingle ratio = ModifiedLayout (CenteredIfSingle ratio)
+centeredIfSingle ratioX ratioY = ModifiedLayout (CenteredIfSingle ratioX ratioY)
 
 -- | Calculate the center piece of a rectangle given the percentage of the outer rectangle it should occupy.
-rectangleCenterPiece :: Double -> Rectangle -> Rectangle
-rectangleCenterPiece ratio (Rectangle rx ry rw rh) = Rectangle start ry width rh
+rectangleCenterPiece :: Double -> Double -> Rectangle -> Rectangle
+rectangleCenterPiece ratioX ratioY (Rectangle rx ry rw rh) = Rectangle startX startY width height
   where
-    sides = floor $ fi rw * (1.0 - ratio) / 2
-    start = fi rx + sides
-    width = fi $ fi rw - sides * 2
+    startX = rx + left
+    startY = ry + top
+
+    width  = newSize rw left
+    height = newSize rh top
+
+    left = rw `scaleBy` ratioX
+    top  = rh `scaleBy` ratioY
+
+newSize :: Dimension -> Position -> Dimension
+newSize dim pos = fi $ fi dim - pos * 2
+
+scaleBy :: Dimension -> Double -> Position
+scaleBy dim ratio = floor $ fi dim * (1.0 - ratio) / 2


### PR DESCRIPTION
### Description

Modified CenteredIfSingle to accept a second ratio, so that centered windows can be scaled in both directions.
![2022-06-17_14-33](https://user-images.githubusercontent.com/28287/174390433-e822722d-3cf3-45b9-8332-88e37ce62529.png)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (manually) and concluded: it works, and is an improvement IMHO

  - [ ] I updated the `CHANGES.md` file (not sure if this is necessary, since this modifier isn't in a released version yet)
