### PR TITLE
X.H.Modal: Add EZConfig support

### DIFF
--- a/XMonad/Hooks/Modal.hs
+++ b/XMonad/Hooks/Modal.hs
@@ -84,6 +84,8 @@ import           XMonad.Util.Parser            ( runParser )
 -- >
 -- > import XMonad
 -- > import XMonad.Hooks.Modal
+-- > import XMonad.Util.EZConfig
+-- > import qualified Data.Map as M
 -- >
 -- > main :: IO ()
 -- > main =
@@ -93,18 +95,41 @@ import           XMonad.Util.Parser            ( runParser )
 -- >     `additionalKeysP` [ ("M-S-n", setMode noModModeLabel)
 -- >                       , ("M-S-r", setMode floatModeLabel)
 -- >                       , ("M-S-z", setMode overlayedFloatModeLabel)
+-- >                       , ("M-S-h", setMode "Hello")
 -- >                       ]
 -- >
 -- > sayHelloMode :: Mode
--- > sayHelloMode = mode "Hello"
--- >   $ const (M.fromList [((noModMask, xK_h), xmessage "Hello World! ")])
+-- > sayHelloMode = mode "Hello" $ mkKeysEz
+-- >   [ ("h", xmessage "Hello, World!")
+-- >   , ("M-g", xmessage "Goodbye, World!")
+-- >   ]
 --
--- A 'Mode' has a label describing its purpose and keybindings (in form
--- of @XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())@). The label
--- of the active mode can be logged with 'logMode' to be displayed in a
--- status bar, for example (For more information check
--- "XMonad.Util.Loggers"). Some examples are included in
--- [the provided modes](#g:ProvidedModes).
+-- Alternatively, one could have defined @sayHelloMode@ as
+--
+-- > sayHelloMode :: Mode
+-- > sayHelloMode = mode "Hello" $ \cfg ->
+-- >   M.fromList [ ((noModMask, xK_h), xmessage "Hello, World!")
+-- >              , ((modMask cfg, xK_g), xmessage "Goodbye, World!")
+-- >              ]
+--
+-- In short, a 'Mode' has a label describing its purpose, as well as
+-- attached keybindings. These are of the form
+--
+--   - @[(String, X ())]@, or
+--
+--   - @XConfig Layout -> M.Map (ButtonMask, KeySym) (X ())@).
+--
+-- The former—accessible via 'mkKeysEz'—is how specifying keys work with
+-- "XMonad.Util.EZConfig", while the latter is more geared towards how
+-- defining keys works by default in xmonad. Note that, by default,
+-- modes are exited with the Escape key. If one wishes to customise
+-- this, the 'modeWithExit' function should be used instead of 'mode'
+-- when defining a new mode.
+--
+-- The label of the active mode can be logged with 'logMode' to be
+-- displayed in a status bar, for example (For more information check
+-- "XMonad.Util.Loggers"). Some examples are included in [the provided
+-- modes](#g:ProvidedModes).
 
 -- }}}
 


### PR DESCRIPTION
### Description

I had a little bit of time on my hands today (yay, food poisoning), so I figured I'd try my hands at hacking EZConfig support into X.H.Modal, as discussed in https://github.com/xmonad/xmonad-contrib/pull/703.  Worked out pretty well, I think.

#### Commit Summary

##### X.H.Modal: Cleanup

Mostly small things, like making imports line up with the provided comments.  Also:

+ Rename mode' -> modeWithExit.  This seems like a better name for discoverability reasons.

+ Make the fields of Mode strict, because they have no reason not to, really.

##### X.H.Modal: Add support for EZConfig-style bindings

Add support for EZConfig-style bindings while also maintaining some guarantees as to which type of representation we will store in the extensible state.  This means that parsing of the keys will happen no later than the call to `modal`.

Users can choose to use `mkKeysEz` or `mkKeysFun` to create a new collection of keys to bind for a mode.  This is deemed more ergonomic than exporting the respective constructors directly.

##### X.H.Modal: Update documentation

Now that we use a slightly different setup, as well as EZConfig support, rewrite the introduction to the module a little.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: it's more-or-less a straightforward refactor; I've tested manually that it doesn't cause things to explode and it seems fine.

  - [ ] I updated the `CHANGES.md` file

    The changelog entry for `X.H.Modal` probably does not need to be modified.