### PR TITLE
`X.P.Unicode`: `BS` -> `String` to support Unicode descriptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,11 @@
     - Added the ability to specify alphabetic (`#A`, `#B`, and `#C`)
       [priorities] at the end of the input note.
 
+  * `XMonad.Prompt.Unicode`
+
+    - Fixed the display of non-ASCII characters in the description of Unicode
+      characters
+
   * `XMonad.Prompt`
 
     - Added `transposeChars` to interchange the characters around the


### PR DESCRIPTION
This PR changes `X.P.Unicode` string type from `ByteString` to `String` to support Unicode
in descriptions. Closes #733.

### Description

`X.P.Unicode` allows you to work with Emoji in Unicode, but does not allow you to use
non-Latin characters in the description of these Emojis. `X.P.Unicode` works fine, but
cannot display such characters correctly.

![image](https://user-images.githubusercontent.com/20644917/178097187-480416d5-335a-46b1-ab34-38a2e2f8e799.png)

See how to reproduce in #733.

Chose `String` instead of `Text` because I thought it was possible to do without an extra
dependency for `xmonad-contrib`. The branch is editable if you know how to add support
without dropping the `ByteString`.

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
