### PR TITLE
silence warning about extraneous Data.Bits import

### DIFF
--- a/XMonad/Util/Font.hs
+++ b/XMonad/Util/Font.hs
@@ -39,7 +39,6 @@ import XMonad.Prelude
 import Foreign
 import Control.Exception as E
 import Text.Printf (printf)
-import Data.Bits ((.&.))
 
 #ifdef XFT
 import qualified Data.List.NonEmpty as NE


### PR DESCRIPTION
### Description

I had copied it in from `WindowNavigation`, but it already got the import from `XMonad.Prelude`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: not needed

  - [ ] I updated the `CHANGES.md` file
