### PR TITLE
X.U.Loggers: Add variants of logTitle with urgent windows support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -787,6 +787,11 @@
       ones) on the focused workspace, as well as `logTitlesOnScreen` as
       a screen-specific variant thereof.
 
+    - Added `logTitles'` and `logTitleOnScreen'`.  These act like
+      `logTitles` and `logTitlesOnScreen` but use a record as an input
+      to enable logging for more window types.  For example, currently
+      urgent windows are additionally supported.
+
   * `XMonad.Layout.Minimize`
 
     - Export `Minimize` type constructor.


### PR DESCRIPTION
### Description

This is a small addition which enables to add logging for urgent windows. There might be a lot of room for improvement since those added variants looks almost exactly like `logTitles` and `logTitlesOnScreen`.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Tested this manually, urgent windows are logged properly.

  - [X] I updated the `CHANGES.md` file
