### PR TITLE
Use `mkAbsolutePath` in `doAppend` (XMonad.Prompt.AppendFile)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,10 @@
     - Added `WindowScreen`, which is a type synonym for the specialized `Screen`
       type, that results from the `WindowSet` definition in `XMonad.Core`.
 
+    - Modified `mkAbsolutePath` to support a leading environment variable, so
+      things like `$HOME/NOTES` work. If you want more general environment
+      variable support, comment on [this PR].
+
   * `XMonad.Util.XUtils`
 
     - Added `withSimpleWindow`, `showSimpleWindow`, `WindowConfig`, and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Prompt.AppendFile`
+
+    - Use `XMonad.Prelude.mkAbsolutePath` to force names to be relative to the
+      home directory and support `~/` prefixes.
+
   * `XMonad.Prompt.OrgMode`
 
     - Fixes the date parsing issue such that entries with format of
@@ -224,6 +229,8 @@
   * `XMonad.Hooks.UrgencyHook`
 
     - Added a `Default` instance for `UrgencyConfig` and `DzenUrgencyHook`.
+
+[this PR]: https://github.com/xmonad/xmonad-contrib/pull/744
 
 ### Other changes
 

--- a/XMonad/Prompt/AppendFile.hs
+++ b/XMonad/Prompt/AppendFile.hs
@@ -30,6 +30,7 @@ module XMonad.Prompt.AppendFile (
 
 import XMonad.Core
 import XMonad.Prompt
+import XMonad.Prelude (mkAbsolutePath)
 
 import System.IO
 
@@ -91,4 +92,4 @@ appendFilePrompt' c trans fn = mkXPrompt (AppendFile fn)
 
 -- | Append a string to a file.
 doAppend :: (String -> String) -> FilePath -> String -> X ()
-doAppend trans fn = io . withFile fn AppendMode . flip hPutStrLn . trans
+doAppend trans fn s = mkAbsolutePath fn >>= \f -> (io . withFile f AppendMode . flip hPutStrLn . trans) s


### PR DESCRIPTION
### Description

Enhance `mkAbsolutePath` to support environment variables, then use it in XMonad.Prompt.AppendFile's `doAppend` so filespecs like `~/NOTES` and `$HOME/file.txt` are supported.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually tested in ghci

  - [ ] I updated the `CHANGES.md` file
