### PR TITLE
Fixes and Workarounds in flake.nix, Documentation in NIX.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,6 @@ tags
 
 stack.yaml.lock
 
+# nix artifacts
+result
 flake.lock

--- a/NIX.md
+++ b/NIX.md
@@ -16,6 +16,24 @@ pkgs: devInputs: devInputs // {
 }
 ```
 
+## Selecting a Compiler
+
+A `comp.nix` file can be used to set the compiler used for `nix build` etc. E.g.
+
+```nix
+{ compiler = "ghc924"; }
+```
+
+Note that you must `git add comp.nix`, or it will be invisible to the flake.
+
+There is also a `prefix` option (see documentation below) but it doesn't really
+work in this context, since the xmonad flakes don't see the effects of your
+system overlays. Instead try the `--override-input` flag, e.g.
+
+```sh
+$ nix develop . --override-input nixpkgs 'github:NixOS/nixpkgs/nixos-unstable'
+```
+
 ## NixOS Modules
 
 The core and contrib flakes provide NixOS configuration modules.
@@ -25,24 +43,42 @@ You can bring them into your system flake like so:
 {
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/nixos-<version>;
-    xmonad.url = github:xmonad/xmonad;
+    # The xmonad-contrib flake depends upon and re-exports from the xmonad
+    # flake. As such, you don't need to use the latter directly. If you wish to
+    # use /only/ the xmonad flake, you should beware that the version of
+    # contrib you get from nixpkgs might not build against it.
     xmonad-contrib.url = github:xmonad/xmonad-contrib;
   };
 
-  outputs = { self, nixpkgs, xmonad, xmonad-contrib }: {
+  outputs = { self, nixpkgs, xmonad-contrib }: {
     nixosConfigurations.<hostname> = nixpkgs.lib.nixosSystem rec {
-      system = <arch>;
+      system = <system>;
+      # NixOS module composition is /not/ commutative; order matters.
+      # To avoid issues, add `xmonad-contrib.nixosModules` after your standard
+      # configuration, but before `modernise` or any module overlaying in a
+      # "prefix".
       modules = [
         ./configuration.nix
-        xmonad.nixosModule
-        xmonad-contrib.nixosModule
+        ./hardware-configuration.nix
+        <myMiscConfigModule>
+      ] ++ xmonad-contrib.nixosModules ++ [
+        # `modernise` replaces the standard xmonad module and wrapper script
+        # with those from unstable. This is currently a necessary workaround to
+        # make Mod-q recompilation work.
+        xmonad-contrib.modernise.${system}
+        <myPrefixModule>
       ];
     };
   };
 }
 ```
 
-Then you can set the provided options in your `configuration.nix` under `flake`:
+Note that `<thing>` should be replaced with a user-supplied `thing`.
+`<version>`, `<hostname>` and `<system>` are necessary, while
+` <myMiscConfigModule>` and `<myPrefixModule>` are entirely optional.
+
+Having brought in `xmonad-contrib.nixosModules`, you can then set the provided
+options in your `configuration.nix` under `flake`:
 
 ```nix
   services.xserver.windowManager.xmonad = {
@@ -59,9 +95,9 @@ Then you can set the provided options in your `configuration.nix` under `flake`:
 This will use core and contrib from git for your system xmonad, building your
 config with the compiler of your choice.
 
-With the flake enabled, the `xmonad.haskellPackages` option is not used directly,
-and is instead set by the `flake.compiler` option. When `compiler` is unset,
-the default `pkgs.haskellPackages` is used.
+With the flake enabled, the `xmonad.haskellPackages` option is not used
+directly, and is instead set by the `flake.compiler` option. When `compiler` is
+unset, the default `pkgs.haskellPackages` is used.
 
 The `prefix` option is used if you wish to select your haskell packages from
 within, e.g., unstable overlaid into `pkgs` as `pkgs.unstable`.


### PR DESCRIPTION
### Description

Sister PR to: xmonad/xmonad#420

Makes corresponding changes to `flake.nix` and `NIX.md`, as well as some general improvements.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit, manually, ...) and concluded: my system (that depends on the flake and sets `xmonad.flake` options) builds and xmonad recompiles as expected.

  - [ ] I updated the `CHANGES.md` file
      - N/A