### PR TITLE
made borderresize take a parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@
 ### Breaking Changes
 ### New Modules
 ### Bug Fixes and Minor Changes
+
+* `XMonad.Layout.BorderResize`
+
+  - Added `borderResizeNear` as a variant of `borderResize` that can
+    control how many pixels near a border resizing still works.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)


### PR DESCRIPTION
Until now it is not possible to change how many pixels near a border is considered "near enough", so that the window can be resized by dragging this border. This is especially frustrating on a touchscreen, where I would wish to have more than just 2 pixels to tap on for resizing windows.
This shoudl allow exactly that. Until now, you were stuck with 2 pixel wide borders for resizing. But now this value is not a global variable but instead a parameter for the borderResize layout modifier