### PR TITLE
[draft] workspace layouts

### DIFF
--- a/XMonad/Util/OneState.hs
+++ b/XMonad/Util/OneState.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE AllowAmbiguousTypes        #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module XMonad.Util.OneState
+  ( OneState (..)
+  , get
+  , put
+  , modify
+  , add
+  , once
+  , onceM
+  ) where
+
+import           Control.Monad               ((>=>))
+import           Data.Maybe                  (fromMaybe)
+import           XMonad                      hiding (config, get, modify, put,
+                                              state, trace)
+import qualified XMonad.Util.ExtensibleConf  as XC
+import qualified XMonad.Util.ExtensibleState as XS
+
+
+{- |
+
+OneState is a replacement for both @XMonad.Util.ExtensibleState@ and @XMonad.Util.ExtensibleConf@
+
+A comparison of these three modules is as follows:
+
+- @ExtensibleConf@ allows the programmer to accept a user-supplied value at config-time.
+  However, this value cannot be changed during runtime.
+
+- @ExtensibleState@ allows the programmer to keep mutable state.
+  However, the initial value for this state must be known at compile-time and is not
+  configurable at config-time.
+
+- @OneState@ proves an API which matches the power of both @ExtensibleConf@ and @ExtensibleState@,
+  allowing the programmer to keep mutable state *and* allowing this mutable state to be configured
+  at config-time.
+
+-}
+
+
+class Typeable state => OneState state where
+
+  -- | Associated type of config-time modifications to state
+  type Mod state
+
+  -- |
+  --
+  -- How to apply a modification
+  --
+  -- This operation may have effects in the X monad. However, no strong
+  -- guarantees are made about its evaluation, such as guarantees about
+  -- timing or multiplicity. Beware!
+  merge :: Mod state -> (state -> X state)
+
+  -- | Default value for the state
+  defaultState :: state
+
+
+-- hook into ExtensibleState
+newtype State state = State (Maybe state)
+  deriving (Typeable)
+
+instance OneState state => ExtensionClass (State state) where
+  initialValue = State Nothing
+
+-- hook into ExtensibleConf
+newtype Config state = Config [Mod state]
+  deriving newtype (Typeable, Semigroup)
+
+trivialConfig :: Config state
+trivialConfig = Config []
+
+
+-- |
+--
+-- Like @ExtensibleState.get@
+--
+-- Retrieve the current state value
+--
+-- * If the state has been explicitly set during runtime, then the most recent
+--   set value will be returned
+--
+-- * Otherwise, if the state was configured during config-time, then all the
+--   config-time @Mod state@ values will be applied to @defaultState@, and
+--   that will be returned
+--
+-- * Otherwise, @default@ is returned
+get :: forall state. OneState state => X state
+get = XS.get >>= \case
+  State (Just state) -> pure state
+  State Nothing      -> foldConfig
+
+  where
+
+  foldConfig :: X state
+  foldConfig = do
+    Config deltas :: Config state <- fromMaybe trivialConfig <$> XC.ask
+    let bigDelta = foldr (>=>) pure $ merge <$> deltas
+    result <- bigDelta defaultState
+    put result  -- modifications are monadic; ensure we only perform them once
+    pure result
+
+
+-- | Like @ExtensibleState.put@
+put :: OneState state => state -> X ()
+put = XS.put . State . Just
+
+-- | Like @ExtensibleState.modify@
+modify :: OneState state => (state -> state) -> X ()
+modify f = put =<< (f <$> get)
+
+
+-- | Like @ExtensibleConf.onceM@
+onceM
+  :: forall state m l
+   . (OneState state, Applicative m)
+  => (XConfig l -> m (XConfig l))
+  -> Mod state
+  -> (XConfig l -> m (XConfig l))
+onceM modX modState = XC.onceM modX (Config @state . one $ modState)
+  where one x = [x]
+
+-- | Like @ExtensibleConf.once@
+once
+  :: forall state l
+   . OneState state
+   => (XConfig l -> XConfig l)
+   -> Mod state
+   -> (XConfig l -> XConfig l)
+once modX modState = XC.once modX (Config @state . one $ modState)
+  where one x = [x]
+
+-- | Like @ExtensibleConf.add@
+add :: forall state l. OneState state => Mod state -> (XConfig l -> XConfig l)
+add = once @state id

--- a/XMonad/WorkspaceLayout/Core.hs
+++ b/XMonad/WorkspaceLayout/Core.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedLabels           #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TupleSections              #-}
+{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module XMonad.WorkspaceLayout.Core where
+
+import           Prelude                      hiding (span)
+
+import           Control.Category             ((>>>))
+import           Data.Function                (on)
+import           Data.List                    (elemIndex)
+import           GHC.Generics                 (Generic)
+import           XMonad                       hiding (config, modify, state,
+                                               trace, workspaces)
+import           XMonad.Hooks.StatusBar.PP    (PP (..))
+import           XMonad.StackSet              (tag)
+import           XMonad.Util.WorkspaceCompare (mkWsSort)
+
+
+-- |
+--
+-- Encompasses information needed to render a workspace layout
+data WorkspaceLayoutView = WSLView
+  { label        :: String
+  , neighborhood :: [WorkspaceId]
+  , toName       :: WorkspaceId -> String
+  } deriving (Generic)
+
+
+render :: WorkspaceLayoutView -> PP
+render (WSLView { neighborhood, toName, label }) =
+
+  withLabel . withNameTransform . withNeighborhood $ def
+
+  where
+
+  withNameTransform pp = pp
+    { ppCurrent = toName
+    , ppHidden = toName
+    , ppHiddenNoWindows = toName
+    }
+
+  withNeighborhood pp = pp
+    { ppSort = do
+        sort <- (mkWsSort . pure) (compare `on` flip elemIndex neighborhood)
+        pure $ filter (tag >>> (`elem` neighborhood)) >>> sort
+    }
+
+  withLabel pp = pp
+    { ppOrder = \(workspaces : rest) -> (label <> workspaces) : rest
+    }
+

--- a/XMonad/WorkspaceLayout/Cycle.hs
+++ b/XMonad/WorkspaceLayout/Cycle.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedLabels    #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+module XMonad.WorkspaceLayout.Cycle
+  ( Coord (..)
+  , Config (..)
+  , BoundsMode (..)
+  , move
+  , swap
+  , hook
+  , getView
+  ) where
+
+import           Prelude
+
+import           Control.Monad.State         (execState)
+import           GHC.Generics                (Generic)
+import qualified XMonad
+import           XMonad                      hiding (config, state, trace,
+                                              workspaces)
+import           XMonad.StackSet             (greedyView, shift)
+
+import qualified XMonad.Util.OneState        as St
+import           XMonad.Util.OneState        (OneState (..))
+import           XMonad.WorkspaceLayout.Core (WorkspaceLayoutView (..))
+import           XMonad.WorkspaceLayout.Util (affineMod, (!%))
+
+
+
+data Coord = Coord
+  { offset   :: Int
+  , position :: Int
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+data Config = Config
+  { width      :: Int
+  , workspaces :: [WorkspaceId]
+  }
+  deriving (Show, Generic)
+
+data State = State
+  { coord  :: Coord
+  , config :: Config
+  }
+  deriving (Show, Generic)
+
+instance OneState State where
+  type Mod State = State -> State
+  merge ma s = pure (ma s)
+  defaultState = State
+    { coord = Coord 0 0
+    , config = Config 5 (single <$> ['a' .. 'j'])
+    }
+    where single = (:[])
+
+
+data BoundsMode = Clamp | Wrap
+
+move :: BoundsMode -> (Coord -> Coord) -> X ()
+move mode f = do
+  (coord', wid') <- calc mode f
+  St.modify $ \st -> st { coord = coord' }
+  windows (greedyView wid')
+
+swap :: BoundsMode -> (Coord -> Coord) -> X ()
+swap mode f = do
+  (_, wid') <- calc mode f
+  windows (shift wid')
+
+calc :: BoundsMode -> (Coord -> Coord) -> X (Coord, WorkspaceId)
+calc mode f = do
+  State coord (Config { width, workspaces }) <- St.get
+  let coord' = flip execState coord $ do
+        modify f
+        offset' <- offset <$> get
+        modify $
+          let updatePosition =
+                (let lo = offset' - width `div` 2
+                     hi = offset' + width `div` 2
+                in case mode of
+                  Clamp -> max lo . min hi
+                  Wrap  -> affineMod (lo, hi))
+          in \st -> st { position = updatePosition (position st) }
+  let wid = workspaces !% (position coord')
+  pure (coord', wid)
+
+
+hook :: Config -> XConfig l -> XConfig l
+hook config = St.once @State
+  (\xc -> xc { XMonad.workspaces = workspaces config })
+  (\state -> state { config = config })
+
+getView :: X WorkspaceLayoutView
+getView = do
+  State (Coord { offset }) (Config { width, workspaces }) <- St.get
+  pure $ WSLView
+    { toName = id
+    , label = ""
+    , neighborhood =
+            (do pos <- [offset - width `div` 2 .. offset + width `div` 2]
+                pure $ workspaces !% (pos `mod` length workspaces)
+            )
+    }
+

--- a/XMonad/WorkspaceLayout/Grid.hs
+++ b/XMonad/WorkspaceLayout/Grid.hs
@@ -1,0 +1,326 @@
+{-# LANGUAGE AllowAmbiguousTypes       #-}
+{-# LANGUAGE DataKinds                 #-}
+{-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
+{-# LANGUAGE KindSignatures            #-}
+{-# LANGUAGE LambdaCase                #-}
+{-# LANGUAGE NamedFieldPuns            #-}
+{-# LANGUAGE NoImplicitPrelude         #-}
+{-# LANGUAGE OverloadedLabels          #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
+{-# LANGUAGE StandaloneDeriving        #-}
+{-# LANGUAGE TypeApplications          #-}
+{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE ViewPatterns              #-}
+{-# OPTIONS_GHC -Wall -Werror #-}
+
+{- | Two-dimensional workspaces for XMonad -}
+
+module XMonad.WorkspaceLayout.Grid
+  ( Formatted (..)
+  , IsFormatted (..)
+  , unsafeChangeFormatting
+  , Mapping (..)
+  , SomeMapping (..)
+  , Dims(..)
+  , fromMap
+  , fromFunction
+  , grid
+  , grid'
+  , group
+  , column
+  , Coord (..)
+  , Wrapping (..)
+  , State (..)
+  , move
+  , swap
+  , update
+  , Init (..)
+  , hook
+  , getView
+  ) where
+
+import           Prelude                     hiding (span)
+
+import           Control.Category            ((>>>))
+import           Data.Foldable               (fold, toList)
+import           Data.Function               ((&))
+import           Data.List                   (intercalate, nub)
+import           Data.List.Split             (splitOn)
+import           Data.Map                    (Map)
+import qualified Data.Map                    as Map
+import           Data.Maybe                  (catMaybes, fromMaybe)
+import           Data.Monoid                 (Endo (..), appEndo)
+import           GHC.Generics                (Generic)
+import           XMonad                      hiding (config, state, trace)
+import           XMonad.StackSet             (greedyView, shift)
+
+import qualified XMonad.Util.OneState        as St
+import           XMonad.WorkspaceLayout.Core (WorkspaceLayoutView (..))
+import           XMonad.WorkspaceLayout.Util (affineMod)
+
+
+
+data Formatted
+
+  = Unformatted
+      -- ^
+      --
+      -- Workspace IDs are left untouched
+
+  | Formatted
+      -- ^
+      -- Workspace IDs are formatted
+      --
+      -- This means *specifically* that workspace IDs are of the format
+      --   <uniq>:<name>
+      -- Where
+      -- * <uniq> contains a uniquely-identifying string
+      -- * <name> contains the workspace name
+      -- * <uniq> may not contain colons
+      --
+      -- (Editor's note: ideally, I'd like to allow custom formats beyond
+      -- just this specific one. Such a desire is, however, in tension with
+      -- retaining the static guarantee that formats are not mixed. Achieving
+      -- this might be possible, but I'm judging it not worth the effort.)
+
+
+doFormat :: forall ftd. IsFormatted ftd => Coord -> String -> WorkspaceId
+doFormat (XY x y) name =
+  case demoteFormatted @ftd of
+    Formatted   -> show y <> "/" <> show x <> ":" <> name
+    Unformatted -> name
+
+
+doToName :: forall ftd. IsFormatted ftd => WorkspaceId -> String
+doToName =
+  case demoteFormatted @ftd of
+    Unformatted -> id
+    Formatted   -> splitOn ":" >>> drop 1 >>> intercalate ":"
+
+
+class IsFormatted (ftd :: Formatted) where
+  demoteFormatted :: Formatted
+
+instance IsFormatted 'Unformatted where
+  demoteFormatted = Unformatted
+
+instance IsFormatted 'Formatted where
+  demoteFormatted = Formatted
+
+
+newtype Mapping (ftd :: Formatted) = Mapping { unMapping :: Map Coord WorkspaceId }
+  deriving (Show, Generic)
+
+unsafeChangeFormatting :: forall old (ftd :: Formatted). Mapping old -> Mapping ftd
+unsafeChangeFormatting (Mapping mp) = Mapping mp
+
+instance Semigroup (Mapping ftd) where
+  Mapping ma <> Mapping mb = Mapping (mb <> ma)  -- right-biased
+
+instance Monoid (Mapping ftd) where
+  mempty = Mapping mempty
+
+
+data SomeMapping = forall ftd. IsFormatted ftd => SomeMapping (Mapping ftd)
+
+-- onTheMap :: (Map Coord WorkspaceId -> Map Coord WorkspaceId) -> (SomeMapping -> SomeMapping)
+-- onTheMap f (SomeMapping (Mapping mp :: Mapping ftd)) = (SomeMapping (Mapping @ftd (f mp)))
+
+getTheMap :: SomeMapping -> Map Coord WorkspaceId
+getTheMap (SomeMapping (Mapping mp)) = mp
+
+range :: Ord x => (Coord -> x) -> SomeMapping -> Maybe (x, x)
+range proj (getTheMap -> mapping) =
+  let xs = proj <$> Map.keys mapping
+  in case xs of
+      [] -> Nothing
+      _  -> Just (minimum xs, maximum xs)
+
+span :: (Ord x, Enum x) => (Coord -> x) -> SomeMapping -> [x]
+span proj (getTheMap -> mapping) =
+  let xs = proj <$> Map.keys mapping
+  in case xs of
+      [] -> []
+      _  -> [minimum xs .. maximum xs]
+
+
+
+data Dims = Dims { width :: Int, height :: Int }
+
+
+-- | Construct a Mapping from a Map
+fromMap :: Map Coord WorkspaceId -> Mapping 'Unformatted
+fromMap = Mapping
+
+
+-- | Construct a Mapping from a function
+fromFunction :: Dims -> (Coord -> WorkspaceId) -> Mapping 'Unformatted
+fromFunction (Dims { width, height }) =
+  let domain = XY <$> [0 .. width - 1] <*> [0 .. height - 1]
+  in fromMap . funToMap domain
+
+  where
+  funToMap :: Ord k => [k] -> (k -> v) -> Map k v
+  funToMap xs f = Map.fromList $ (\k -> (k, f k)) <$> xs
+
+
+-- |
+--
+-- Construct a 2d grid
+--
+-- Each coordinate (x, y) will be given the name @show (x + 1)@
+grid :: Dims -> Mapping 'Formatted
+grid = grid' (\(XY x _) -> show $ x + 1)
+
+
+-- |
+--
+-- Construct a 2d grid
+--
+-- Each coordinate will be assigned a name according to the supplied function
+grid' :: (Coord -> String) -> Dims -> Mapping 'Formatted
+grid' toName (Dims { width, height }) =
+  Mapping . fold $ do
+    y <- [0 .. height - 1]
+    x <- [0 .. width - 1]
+    let coord = XY x y
+    pure $ Map.singleton coord (doFormat @'Formatted coord $ toName coord)
+
+
+-- | Glue together a group of workspaces
+group :: forall f ftd. (IsFormatted ftd, Foldable f) => f Coord -> String -> Mapping ftd
+group (toList -> xs) name = case xs of
+  []     -> Mapping mempty
+  (x0:_) -> Mapping $ xs & foldMap (\x -> Map.singleton x (doFormat @ftd x0 name))
+
+
+-- | Glue together a column of workspaces
+column :: forall ftd. IsFormatted ftd => Dims -> Int -> String -> Mapping ftd
+column (Dims { height }) x name =
+  Mapping . fold $ do
+    y <- [0 .. height - 1]
+    let topLeft = XY x 0
+    pure $ Map.singleton (XY x y) (doFormat @ftd topLeft name)
+
+
+
+
+data Coord = XY { x :: Int, y :: Int }
+  deriving (Show, Ord, Eq, Generic)
+
+data Wrapping = Wrapping
+  { wrapX :: Bool
+  , wrapY :: Bool
+  }
+  deriving (Show, Generic)
+
+data State = State
+  { mapping  :: SomeMapping
+      -- ^ Coordinate -> WorkspaceId mapping
+  , labelf   :: Coord -> Maybe String
+      -- ^ Labels
+  , wrapping :: Wrapping
+      -- ^ Wrapping mode
+  , coord    :: Coord
+      -- ^ Current coordinate
+  } deriving (Generic)
+
+instance St.OneState State where
+  type Mod State = State -> State
+  merge ma s = pure (ma s)
+  defaultState = State
+    { mapping = SomeMapping (grid $ Dims 5 5)
+    , wrapping = Wrapping False False
+    , coord = XY 0 0
+    , labelf = const Nothing
+    }
+
+-- Wrap a coordinate around the x/y axes according to the configured wrapping mode
+wrap :: State -> (Coord -> Coord)
+wrap state =
+
+  appEndo . fromMaybe (Endo id) $ do
+    xRange <- range x (mapping state)
+    yRange <- range y (mapping state)
+
+    pure $ guard (state & wrapping & wrapX) (Endo $ \c -> c { x = affineMod xRange (x c) })
+        <> guard (state & wrapping & wrapY) (Endo $ \c -> c { y = affineMod yRange (y c) })
+
+  where
+
+  guard :: Monoid m => Bool -> m -> m
+  guard = \case { True -> id; False -> const mempty }
+
+
+
+-- |
+--
+-- The call @move f@ replaces the current coordinate to @f currentCoord@
+--
+-- If @f currentCoord@ is out-of-bounds, do nothing
+--
+-- Use this to move around workspaces
+move :: (Coord -> Coord) -> X ()
+move = update $ \coord wid -> do
+  St.modify $ \st -> st { coord = coord }
+  windows (greedyView wid)
+
+
+-- |
+--
+-- The call @swap f@ moves the selected window to @f currentCoord@
+--
+-- If @f currentCoord@ is out-of-bounds, do nothing
+swap :: (Coord -> Coord) -> X ()
+swap = update $ \_ wid -> windows (shift wid)
+
+update :: (Coord -> WorkspaceId -> X ()) -> (Coord -> Coord) -> X ()
+update act f = do
+  state@State { coord, mapping } <- St.get
+  let coord' = coord & f & wrap state
+  case Map.lookup coord' (getTheMap mapping) of
+    Nothing -> pure ()
+    Just wid -> do
+     act coord' wid
+
+
+data Init = Init
+  { initMapping  :: SomeMapping
+      -- ^ Physical layout
+  , initWrapping :: Wrapping
+      -- ^ Wrapping mode
+  , initLabelf   :: Coord -> Maybe String
+      -- ^
+      -- Displayed to the left of the axis workspaces
+      -- When Nothing is returned, uses a fallback
+  }
+
+-- | Hook the grid layout into XMonad
+hook :: Init -> XConfig l -> XConfig l
+hook Init { initMapping, initWrapping, initLabelf } =
+  St.once @State
+    (\xc -> xc { XMonad.workspaces = workspaces })
+    (\state -> state
+        { mapping = initMapping
+        , wrapping = initWrapping
+        , labelf = initLabelf
+        })
+
+  where
+  workspaces = toList (getTheMap initMapping)
+             & nub  -- account for two coordinates pointing to the same workspace
+
+getView :: X WorkspaceLayoutView
+getView = do
+  State { coord, mapping, labelf } <- St.get
+  let XY _ y = coord
+  pure $ WSLView
+    { neighborhood =
+           let coords = (flip XY y) <$> span x mapping
+           in coords & fmap (flip Map.lookup (getTheMap mapping)) & catMaybes & nub
+    , toName = case mapping of SomeMapping (_ :: Mapping ftd) -> doToName @ftd
+    , label = labelf coord & fromMaybe (show (y + 1) <> " / ")
+    }
+

--- a/XMonad/WorkspaceLayout/Util.hs
+++ b/XMonad/WorkspaceLayout/Util.hs
@@ -1,0 +1,11 @@
+module XMonad.WorkspaceLayout.Util where
+
+(!%) :: [a] -> Int -> a
+xs !% n = xs !! (n `mod` length xs)
+
+-- Doubly-inclusive
+affineMod :: (Ord a, Num a) => (a, a) -> (a -> a)
+affineMod range@(lo, hi) x
+  | x > hi = affineMod range (x - (hi - lo + 1))
+  | x < lo = affineMod range (x + (hi - lo + 1))
+  | otherwise = x


### PR DESCRIPTION
### Description

---

This PR introduces "workspace layouts", which allow non-standard organization of the workspaces themselves, such as alignment into a grid, or combination of multiple workspaces.

The modules (at the time of PR creation) are as follows:

- `XMonad.Util.OneState` and `XMonad.WorkspaceLayout.Util` -- Utility modules
- `XMonad.WorkspaceLayout.Core` -- Defines functionality shared between workspace layouts
- `XMonad.WorkspaceLayout.Grid` -- Defines a 2d-grid workspace layout. This is like `XMonad.Actions.Plane`, but not hacky and more featurful. The grid layout allows the user to organize their workspaces into a grid *and* for multiple coordinates on the grid to map to the same workspace.
- `XMonad.WorkspaceLayout.Cycle` -- Defines a cyclic workspace layout. This module is intended to be more of a demonstration than anything. Its use for me during development was to help mitigate the risk of me over-coupling generic code with the grid layout.

---

Let me elaborate a bit on the deal with the grid layout by way of giving the example of my own current XMonad layout. I have a grid which is 10 cells across, and 4 cells tall. Altogether it looks like this:
```
y=1 | α 1 2 3 4 γ 6 7 8
y=2 | α 1 2 3 4 γ 6 7 8
y=3 | α 1 2 3 4 γ 6 7 8
y=4 | α 1 2 3 4 γ 6 7 8
```
This means that I have a grid of 32 cells total. Each row has the same names for its cells but these cells are distinct.

As I write this, I am positioned on cell `α` of row `y=1`:

![image](https://user-images.githubusercontent.com/14851215/190120284-a9ee7bb8-c468-49ed-b002-0d4f76b53d08.png)

Using keybindings `MOD+n` for a number `n`, I can move around the row `y=1` to other workspaces on that row. If I press `MOD+3`, for instance, I move to workspace `3` on row `y=1`, which contains some terminals:

![image](https://user-images.githubusercontent.com/14851215/190120591-baf9c567-cf6e-4a94-937e-f40abaf1e1c4.png)

To move around the y-axis, I press `MOD+s` to increment `y` and `MOD+w` to decrement it. If I increment `y` twice to reach row `y=3`, my status bar looks like this:

![image](https://user-images.githubusercontent.com/14851215/190120835-ec7827c2-d5e4-4ce9-99ee-b8b24dbfd549.png)

This row contains a different set of workspaces than `y=1`, hence the difference in coloration for the labels.

It's also worth noting that I have the `α` and `γ` cells in each row to be linked together. This means that if I am on row `y=2` and open a terminal in cell `γ`, and then I move to cell `γ` of row `y=3`, the same terminal will be there. Under the hood, the workspaces `y=2 γ` and `y=3 γ` are actually the same workspace.

---

My intent with the inclusion of the namespace `XMonad.WorkspaceLayout` and the module `XMonad.WorkspaceLayout.Core` is to encourage other XMonad contributors to possibly create and add their own workspace layouts besides just `Grid` and `Cycle`. (As it so happens, `XMonad.WorkspaceLayout.Core` turned out to be minimal in terms of code, but so be it.)

---

This PR is far from complete. The checklist below enumerates a number of outstanding tasks.

However, I wanted to open it earlier rather than later to start receiving feedback as soon as possible. Some questions include:

- Is there interest for the grid and cycle layouts?
- Is there interest for the generic "workspace layout" abstraction and the `XMonad.WorkspaceLayout` namespace?
- Should the "workspace layout" abstraction be developed, so that the `XMonad.WorkspaceLayout.Core` affordance is not so ... lacking?

Thanks!

post-script. I recognize that I haven't include any example client code that _uses_ this PR. As of right now, the best example I have is my own XMonad config; see specifically how I [hook into XMonad](https://github.com/Quelklef/habitat/blob/cc164b43d77c3e0ea9551699873d4a87e8614871/files/xmonad/xmonad.hs#L64-L66), [hook into my status bar](https://github.com/Quelklef/habitat/blob/cc164b43d77c3e0ea9551699873d4a87e8614871/files/xmonad/xmonad.hs#L93-L107), and [deifne my keybindings](https://github.com/Quelklef/habitat/blob/cc164b43d77c3e0ea9551699873d4a87e8614871/files/xmonad/xmonad.hs#L202-L219).

---

### Checklist
- [x] Read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)
- [ ] Documentation: comments + examples
- [ ] Manual tests performed
- [ ] `xmonad-contrib` tests still pass
- [ ] `CHANGES.md` updated
- [ ] `hlint` passes
- [ ] PR generates no new warnings