### PR TITLE
X.U.Scratchpad: Deprecate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,13 @@
 ## _unreleased_
 
 ### Breaking Changes
+
+* `XMonad.Util.NamedScratchpad`:
+
+  - Deprecated the module; use `XMonad.Util.NamedScratchpad` instead.
+
 ### New Modules
+
 ### Bug Fixes and Minor Changes
 
 * `XMonad.Layout.BorderResize`

--- a/XMonad/Util/Scratchpad.hs
+++ b/XMonad/Util/Scratchpad.hs
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Util.Scratchpad (
+module XMonad.Util.Scratchpad {-# DEPRECATED "Use XMonad.Util.NamedScratchpad instead" #-} (
   -- * Usage
   -- $usage
   scratchpadSpawnAction


### PR DESCRIPTION
This is i) broken and ii) just the functionality of X.U.NamedScratchpad
rewrapped (and not necessarily improved upon) at this point.

With recent changes to the way named scratchpads work[1], we would have
to export internals of X.U.NamedScratchpad in order to restore
X.U.Scratchpad to its full functionality.  This does not seem worth it,
as the latter does not bring anything substantially new to the table.

Closes: https://github.com/xmonad/xmonad-contrib/issues/756
Related: https://github.com/xmonad/xmonad-contrib/issues/591
[1]: 3fc830aa09368dca04df24bf7ec4ac817f2de479

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Haddock and GHC say it's deprecated.

  - [x] I updated the `CHANGES.md` file