### PR TITLE
expose more messages in MouseResizableTile layout

### DIFF
--- a/XMonad/Layout/MouseResizableTile.hs
+++ b/XMonad/Layout/MouseResizableTile.hs
@@ -20,7 +20,7 @@ module XMonad.Layout.MouseResizableTile (
                                     -- $usage
                                     mouseResizableTile,
                                     mouseResizableTileMirrored,
-                                    MRTMessage (ShrinkSlave, ExpandSlave),
+                                    MRTMessage (ShrinkSlave, ExpandSlave, SetMasterFraction, SetLeftSlaveFraction, SetRightSlaveFraction),
 
                                     -- * Parameters
                                     -- $mrtParameters


### PR DESCRIPTION
Very small and straightforward change, see the following post for context: https://www.reddit.com/r/xmonad/comments/xpzeg9/normalize_the_fraction_between_master_and_slave/

I've also included the SetSlaveFraction messages, because they could be used in a similar (albeit more complicated, as there are multiple slaves) fashion to create a function that normalizes all of the sizes (instead of just the fraction between master and slave).