### PR TITLE
X.U.Parser: Achieve feature parity with ReadP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,13 @@
 
   - Added `findFile` as a shorthand to call `find-file`.
 
+* `XMonad.Util.Parser`
+
+  - Added the `gather`, `count`, `between`, `option`, `optionally`,
+    `skipMany`, `skipMany1`, `chainr`, `chainr1`, `chainl`, `chainl1`,
+    and `manyTill` functions, in order to achieve feature parity with
+    `Text.ParserCombinators.ReadP`.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)

--- a/XMonad/Prompt/OrgMode.hs
+++ b/XMonad/Prompt/OrgMode.hs
@@ -414,7 +414,7 @@ pInput inp = (`runParser` inp) . choice $
 
 -- | Parse a 'Priority'.
 pPriority :: Parser Priority
-pPriority = pLast (pure NoPriority) $
+pPriority = option NoPriority $
   " " *> skipSpaces *> choice
     [ "#" *> ("A" <|> "a") $> A
     , "#" *> ("B" <|> "b") $> B
@@ -423,7 +423,7 @@ pPriority = pLast (pure NoPriority) $
 
 -- | Try to parse a 'Time'.
 pTimeOfDay :: Parser (Maybe TimeOfDay)
-pTimeOfDay = pLast (pure Nothing) $
+pTimeOfDay = option Nothing $
   skipSpaces *> choice
     [ Just <$> (TimeOfDay <$> pHour <* string ":" <*> pMinute) -- HH:MM
     , Just <$> (TimeOfDay <$> pHour               <*> pure 0 ) -- HH
@@ -485,8 +485,3 @@ pNumBetween lo hi = do
   n <- num
   n <$ guard (n >= lo && n <= hi)
 
--- | A flipped version of '(<|>)'.  Useful when @p'@ is some complicated
--- expression that, for example, consumes spaces and @p@ does not want
--- to do that.
-pLast :: Parser a -> Parser a -> Parser a
-pLast p p' = p' <|> p


### PR DESCRIPTION
### Commit Summary

#### X.U.Parser: Feature parity with ReadP

While not many of these more exotic combinators are used right now, it's still nice to have feature parity (i.e., everything that one could want from a basic parser) such that people don't have to add their own combinators, in case they want to use one that's not already implemented.

#### X.U.Parser: Inline definitions

Most of these definitions are probably small enough to be inlined on their own, but tell GHC to try really hard regardless.  This is commonly done by other parser libraries as well; e.g., [1], so it shouldn't cause any issues either way.

[1]: https://hackage.haskell.org/package/parsers-0.12.11

#### X.P.OrgMode: Remove pLast

Use the more aptly named `option` instead.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Pretty much all definitions are small and just what other parsing libraries do.

  - [x] I updated the `CHANGES.md` file