### PR TITLE
X.P.OrgMode: Add orgPromptRefile[To]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,12 @@
     in case `lineNavigation` can't find a window.  This benefits
     especially users who use `XMonad.Layout.Spacing`.
 
+* `XMonad.Prompt.OrgMode`
+
+  - Added `orgPromptRefile` and `orgPromptRefileTo` for interactive and
+    targeted refiling of the entered note into some existing tree of
+    headings, respectively.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,8 @@
 
   - Added `findFile` as a shorthand to call `find-file`.
 
+  - Added `list` and `saveExcursion` to the list of Emacs commands.
+
 * `XMonad.Util.Parser`
 
   - Added the `gather`, `count`, `between`, `option`, `optionally`,

--- a/XMonad/Prompt/OrgMode.hs
+++ b/XMonad/Prompt/OrgMode.hs
@@ -202,7 +202,7 @@ orgPrompt
                --   a single @*@
   -> FilePath  -- ^ Path to @.org@ file, e.g. @home\/me\/todos.org@
   -> X ()
-orgPrompt xpc = (mkOrgPrompt xpc =<<) .: mkOrgCfg NoClpSupport
+orgPrompt xpc = (void . mkOrgPrompt xpc =<<) .: mkOrgCfg NoClpSupport
 
 -- | Like 'orgPrompt', but additionally make use of the primary
 -- selection.  If it is a URL, then use an org-style link
@@ -212,12 +212,14 @@ orgPrompt xpc = (mkOrgPrompt xpc =<<) .: mkOrgCfg NoClpSupport
 -- The prompt will display a little @+ PS@ in the window
 -- after the type of note.
 orgPromptPrimary :: XPConfig -> String -> FilePath -> X ()
-orgPromptPrimary xpc = (mkOrgPrompt xpc =<<) .: mkOrgCfg PrimarySelection
+orgPromptPrimary xpc = (void . mkOrgPrompt xpc =<<) .: mkOrgCfg PrimarySelection
 
--- | Create the actual prompt.
-mkOrgPrompt :: XPConfig -> OrgMode -> X ()
+-- | Create the actual prompt.  Returns 'False' when the input was
+-- cancelled by the user (by, for example, pressing @Esc@ or @C-g@) and
+-- 'True' otherwise.
+mkOrgPrompt :: XPConfig -> OrgMode -> X Bool
 mkOrgPrompt xpc oc@OrgMode{ todoHeader, orgFile, clpSupport } =
-  mkXPrompt oc xpc (const (pure [])) appendNote
+  isJust <$> mkXPromptWithReturn oc xpc (const (pure [])) appendNote
  where
   -- | Parse the user input, create an @org-mode@ note out of that and
   -- try to append it to the given file.

--- a/XMonad/Util/Run.hs
+++ b/XMonad/Util/Run.hs
@@ -446,14 +446,14 @@ elispFun f = " '( " <> f <> " )' "
 asString :: String -> String
 asString s = " \"" <> s <> "\" "
 
--- | Wrap the given commands in a @progn@ and also escape it by wrapping
--- it inside single quotes.  The given commands need not be wrapped in
--- parentheses, this will be done by the function.  For example:
+-- | Wrap the given commands in a @progn@.  The given commands need not
+-- be wrapped in parentheses (but can); this will be done by the
+-- function.  For example:
 --
 -- >>> progn [require "this-lib", "function-from-this-lib arg", "(other-function arg2)"]
--- " '( progn (require (quote this-lib)) (function-from-this-lib arg) (other-function arg2) )' "
+-- "(progn (require (quote this-lib)) (function-from-this-lib arg) (other-function arg2))"
 progn :: [String] -> String
-progn cmds = elispFun $ "progn " <> unwords (map inParens cmds)
+progn = inParens . ("progn " <>) . unwords . map inParens
 
 -- | Require a package.
 --

--- a/XMonad/Util/Run.hs
+++ b/XMonad/Util/Run.hs
@@ -77,6 +77,8 @@ module XMonad.Util.Run (
   progn,
   quote,
   findFile,
+  list,
+  saveExcursion,
 
   -- * Re-exports
   hPutStr,
@@ -473,6 +475,20 @@ quote = inParens . ("quote " <>)
 -- "(find-file \"/path/to/file\" )"
 findFile :: String -> String
 findFile = inParens . ("find-file" <>) . asString
+
+-- | Make a list of the given inputs.
+--
+-- >>> list ["foo", "bar", "baz", "qux"]
+-- "(list foo bar baz qux)"
+list :: [String] -> String
+list = inParens . ("list " <>) . unwords
+
+-- | Like 'progn', but with @save-excursion@.
+--
+-- >>> saveExcursion [require "this-lib", "function-from-this-lib arg", "(other-function arg2)"]
+-- "(save-excursion (require (quote this-lib)) (function-from-this-lib arg) (other-function arg2))"
+saveExcursion :: [String] -> String
+saveExcursion = inParens . ("save-excursion " <>) . unwords . map inParens
 
 -----------------------------------------------------------------------
 -- Batch mode


### PR DESCRIPTION
### Description

~~This is still a bit WIP in the sense that documentation and other fluff is missing, but it at least seems complete feature-wise.~~ This should now be ready to review.  Since someone asked me whether I could implement this, I figured it was best to open this to "public testing" as soon as possible.

#### Commit Summary

##### X.U.Run: Add list, saveExcursion

##### X.U.Run: Don't use elispFun in progn

This is already taken care of by execute and eval, so forcing it in progn only hampers composability.

##### X.P.OrgMode: Add mkOrgCfg

This ensures that we always immediately expand the file path upon constructing an `OrgMode` record.  We thus do not have to do this in `mkOrgPrompt` anymore.

##### X.P.OrgMode: Return "exitCode" mkOrgPrompt

More formally, return whether the user cancelled the prompt or not. This is useful in case we want to do things only after a "successful" input.

##### X.P.OrgMode: Add orgPromptRefile[To]

Add orgPromptRefile and orgPromptRefileTo in order to refile entries after insertion.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested manually; seems to work.  Probably best to write some property tests for the file parsing at some point in the future.

  - [x] I updated the `CHANGES.md` file