### PR TITLE
A Potpourri of Small Changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,11 @@
   - Added `directionMoveWindow` and `directionMoveWindow` as more
     alternatives to the existing functions.
 
+* `XMonad.Hooks.InsertPosition`
+
+  - Added `setupInsertPosition` as a combinator alternative to
+    `insertPosition`.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,12 @@
   - Added `setupInsertPosition` as a combinator alternative to
     `insertPosition`.
 
+* `XMonad.Actions.Navigation2D`
+
+  - Added `sideNavigation` as a fallback to the default tiling strategy,
+    in case `lineNavigation` can't find a window.  This benefits
+    especially users who use `XMonad.Layout.Spacing`.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,11 @@
     and `manyTill` functions, in order to achieve feature parity with
     `Text.ParserCombinators.ReadP`.
 
+* `XMonad.Actions.FloatKeys`
+
+  - Added `directionMoveWindow` and `directionMoveWindow` as more
+    alternatives to the existing functions.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)

--- a/XMonad/Actions/Commands.hs
+++ b/XMonad/Actions/Commands.hs
@@ -57,7 +57,7 @@ import XMonad.Prelude
 -- bindings!)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Create a 'Data.Map.Map' from @String@s to xmonad actions from a
 --   list of pairs.

--- a/XMonad/Actions/CopyWindow.hs
+++ b/XMonad/Actions/CopyWindow.hs
@@ -77,7 +77,7 @@ import qualified XMonad.StackSet as W
 -- >  , ((modm .|. shiftMask, xK_v ),  killAllOtherCopies) -- @@ Toggle window state back
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- $logHook
 --

--- a/XMonad/Actions/CycleRecentWS.hs
+++ b/XMonad/Actions/CycleRecentWS.hs
@@ -49,7 +49,7 @@ import Data.Function (on)
 -- >   , ((modm, xK_Tab), cycleRecentWS [xK_Alt_L] xK_Tab xK_grave)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Cycle through most recent workspaces with repeated presses of a key, while
 --   a modifier key is held down. The recency of workspaces previewed while browsing

--- a/XMonad/Actions/CycleWS.hs
+++ b/XMonad/Actions/CycleWS.hs
@@ -122,7 +122,7 @@ import XMonad.Util.WorkspaceCompare
 -- >            windows . view $ t                                         )
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- When using the toggle functions, in order to ensure that the workspace
 -- to which you switch is the previously viewed workspace, use the

--- a/XMonad/Actions/CycleWindows.hs
+++ b/XMonad/Actions/CycleWindows.hs
@@ -79,7 +79,7 @@ import Control.Arrow (second)
 --
 -- Also, if you use focus follows mouse, you will want to read the section
 -- on updating the mouse pointer below.  For detailed instructions on
--- editing your key bindings, see "XMonad.Doc.Extending#Editing_key_bindings".
+-- editing your key bindings, see <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 {- $pointer
 With FocusFollowsMouse == True, the focus is updated after binding
 actions, possibly focusing a window you didn't intend to focus. Most

--- a/XMonad/Actions/DeManage.hs
+++ b/XMonad/Actions/DeManage.hs
@@ -48,7 +48,7 @@ import XMonad
 -- > , ((modm,               xK_d     ), withFocused demanage)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Stop managing the currently focused window.
 demanage :: Window -> X ()

--- a/XMonad/Actions/DwmPromote.hs
+++ b/XMonad/Actions/DwmPromote.hs
@@ -40,7 +40,7 @@ import qualified Data.List.NonEmpty as NE
 -- >   , ((modm,               xK_Return), dwmpromote)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Swap the focused window with the master window. If focus is in
 --   the master, swap it with the next window in the stack. Focus

--- a/XMonad/Actions/DynamicProjects.hs
+++ b/XMonad/Actions/DynamicProjects.hs
@@ -113,7 +113,7 @@ import qualified XMonad.Util.ExtensibleState as XS
 -- >  , ((modm, xK_slash), shiftToProjectPrompt def)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 --------------------------------------------------------------------------------
 type ProjectName  = String

--- a/XMonad/Actions/DynamicWorkspaces.hs
+++ b/XMonad/Actions/DynamicWorkspaces.hs
@@ -75,7 +75,7 @@ import qualified XMonad.Util.ExtensibleState as XS
 -- >    zip (zip (repeat (modm .|. controlMask)) [xK_1..xK_9]) (map (setWorkspaceIndex) [1..])
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings". See also the documentation for
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>. See also the documentation for
 -- "XMonad.Actions.CopyWindow", 'windows', 'shift', and 'XPConfig'.
 
 type WorkspaceTag = String

--- a/XMonad/Actions/FindEmptyWorkspace.hs
+++ b/XMonad/Actions/FindEmptyWorkspace.hs
@@ -38,7 +38,7 @@ import XMonad.StackSet
 -- will tag the current window to an empty workspace and view it.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Find the first hidden empty workspace in a StackSet. Returns
 -- Nothing if all workspaces are in use. Function searches currently

--- a/XMonad/Actions/FloatKeys.hs
+++ b/XMonad/Actions/FloatKeys.hs
@@ -19,11 +19,15 @@ module XMonad.Actions.FloatKeys (
                 keysMoveWindowTo,
                 keysResizeWindow,
                 keysAbsResizeWindow,
+                directionMoveWindow,
+                directionResizeWindow,
+                Direction2D(..),
                 P, G, ChangeDim
                 ) where
 
 import XMonad
 import XMonad.Prelude (fi)
+import XMonad.Util.Types
 
 -- $usage
 -- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
@@ -38,8 +42,36 @@ import XMonad.Prelude (fi)
 -- >  , ((modm .|. shiftMask, xK_s     ), withFocused (keysAbsResizeWindow (10,10) (1024,752)))
 -- >  , ((modm,               xK_a     ), withFocused (keysMoveWindowTo (512,384) (1%2,1%2)))
 --
+-- Using "XMonad.Util.EZConfig" syntax, we can easily build keybindings
+-- where @M-<arrow-keys>@ moves the currently focused window and
+-- @M-S-<arrow-keys>@ resizes it using 'directionMoveWindow' and
+-- 'directionResizeWindow':
+--
+-- > [ ("M-" <> m <> k, withFocused $ f i)
+-- > | (i, k) <- zip [U, D, R, L] ["<Up>", "<Down>", "<Right>", "<Left>"]
+-- > , (f, m) <- [(directionMoveWindow 10, ""), (directionResizeWindow 10, "S-")]
+-- > ]
+--
 -- For detailed instructions on editing your key bindings, see
 -- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
+
+-- | @directionMoveWindow delta dir win@ moves the window @win@ by
+--   @delta@ pixels in direction @dir@.
+directionMoveWindow :: Int -> Direction2D -> Window -> X ()
+directionMoveWindow delta dir win = case dir of
+  U -> keysMoveWindow (0, -delta) win
+  D -> keysMoveWindow (0, delta)  win
+  R -> keysMoveWindow (delta, 0)  win
+  L -> keysMoveWindow (-delta, 0) win
+
+-- | @directionResizeWindow delta dir win@ resizes the window @win@ by
+--   @delta@ pixels in direction @dir@.
+directionResizeWindow :: Int -> Direction2D -> Window -> X ()
+directionResizeWindow delta dir win = case dir of
+  U -> keysResizeWindow (0, -delta) (0, 0) win
+  D -> keysResizeWindow (0, delta)  (0, 0) win
+  R -> keysResizeWindow (delta, 0)  (0, 0) win
+  L -> keysResizeWindow (-delta, 0) (0, 0) win
 
 -- | @keysMoveWindow (dx, dy)@ moves the window by @dx@ pixels to the
 --   right and @dy@ pixels down.

--- a/XMonad/Actions/FloatKeys.hs
+++ b/XMonad/Actions/FloatKeys.hs
@@ -39,7 +39,7 @@ import XMonad.Prelude (fi)
 -- >  , ((modm,               xK_a     ), withFocused (keysMoveWindowTo (512,384) (1%2,1%2)))
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | @keysMoveWindow (dx, dy)@ moves the window by @dx@ pixels to the
 --   right and @dy@ pixels down.

--- a/XMonad/Actions/FloatSnap.hs
+++ b/XMonad/Actions/FloatSnap.hs
@@ -53,7 +53,7 @@ import XMonad.Actions.AfterDrag
 -- >        , ((modm .|. shiftMask, xK_Down),  withFocused $ snapGrow D Nothing)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- And possibly add appropriate mouse bindings, for example:
 --

--- a/XMonad/Actions/FocusNth.hs
+++ b/XMonad/Actions/FocusNth.hs
@@ -36,7 +36,7 @@ import XMonad.StackSet
 -- >     | (i, k) <- zip [0 .. 8] [xK_1 ..]]
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Give focus to the nth window of the current workspace.
 focusNth :: Int -> X ()

--- a/XMonad/Actions/LinkWorkspaces.hs
+++ b/XMonad/Actions/LinkWorkspaces.hs
@@ -58,7 +58,7 @@ import qualified Data.Map as M
 -- >       , (i, k) <- zip (XMonad.workspaces conf) [xK_1 .. xK_9]]
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data MessageConfig = MessageConfig {  messageFunction :: ScreenId -> [Char] -> [Char] -> [Char] -> X()
                     , foreground :: [Char]

--- a/XMonad/Actions/MouseResize.hs
+++ b/XMonad/Actions/MouseResize.hs
@@ -50,9 +50,9 @@ import XMonad.Util.XUtils
 --
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 mouseResize :: l a -> ModifiedLayout MouseResize l a
 mouseResize = ModifiedLayout (MR [])

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -161,7 +161,7 @@ import XMonad.Util.Types
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- $finer_points
 -- #Finer_Points#

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -97,7 +97,14 @@ import XMonad.Util.Types
 -- >                              False
 -- >               $ def
 --
--- Alternatively, you can use navigation2DP:
+-- /NOTE/: the @def@ argument to 'navigation2D' contains the strategy
+-- that decides which windows actually get selected.  If you use modules
+-- that influence tiling in some way, like "XMonad.Layout.Spacing" or
+-- "XMonad.Layout.Gaps", you should think about using a different
+-- strategy, if you find the default behaviour to be unnatural.  Check
+-- out the [finer points](#g:Finer_Points) below for more information.
+--
+-- Alternatively to 'navigation2D', you can use 'navigation2DP':
 --
 -- > main = xmonad $ navigation2DP def
 -- >                               ("<Up>", "<Left>", "<Down>", "<Right>")
@@ -107,7 +114,7 @@ import XMonad.Util.Types
 -- >               $ def
 --
 -- That's it. If instead you'd like more control, you can combine
--- withNavigation2DConfig and additionalNav2DKeys or additionalNav2DKeysP:
+-- 'withNavigation2DConfig' and 'additionalNav2DKeys' or 'additionalNav2DKeysP':
 --
 -- > main = xmonad $ withNavigation2DConfig def
 -- >               $ additionalNav2DKeys (xK_Up, xK_Left, xK_Down, xK_Right)
@@ -178,9 +185,19 @@ import XMonad.Util.Types
 -- values in the above example to 'True'.  You could also decide you want
 -- wrapping only for a subset of the operations and no wrapping for others.
 --
--- By default, all layouts use the 'defaultTiledNavigation' strategy specified
--- in the 'Navigation2DConfig' (by default, line navigation is used).  To
--- override this behaviour for some layouts, add a pair (\"layout name\",
+-- By default, all layouts use the 'defaultTiledNavigation' strategy
+-- specified in the 'Navigation2DConfig' (by default, line navigation is
+-- used).  Many more navigation strategies are available; some may feel
+-- more natural, depending on the layout and user:
+--
+--   * 'lineNavigation'
+--   * 'centerNavigation'
+--   * 'sideNavigation'
+--   * 'sideNavigationWithBias'
+--
+-- There is also the ability to combine two strategies with 'hybridOf'.
+--
+-- To override the default behaviour for some layouts, add a pair (\"layout name\",
 -- navigation strategy) to the 'layoutNavigation' list in the
 -- 'Navigation2DConfig', where \"layout name\" is the string reported by the
 -- layout's description method (normally what is shown as the layout name in
@@ -326,7 +343,7 @@ centerNavigation = N 2 doCenterNavigation
 -- and push it to the right until it intersects with at least one other window.
 -- Of those windows, one with a point that is the closest to the centre of the
 -- line (+1) is selected. This is probably the most intuitive strategy for the
--- tiled layer when using XMonad.Layout.Spacing.
+-- tiled layer when using "XMonad.Layout.Spacing".
 sideNavigation :: Navigation2D
 sideNavigation = N 1 (doSideNavigationWithBias 1)
 

--- a/XMonad/Actions/Navigation2D.hs
+++ b/XMonad/Actions/Navigation2D.hs
@@ -98,8 +98,9 @@ import XMonad.Util.Types
 -- >               $ def
 --
 -- /NOTE/: the @def@ argument to 'navigation2D' contains the strategy
--- that decides which windows actually get selected.  If you use modules
--- that influence tiling in some way, like "XMonad.Layout.Spacing" or
+-- that decides which windows actually get selected.  While the default
+-- behaviour tries to keep them into account, if you use modules that
+-- influence tiling in some way, like "XMonad.Layout.Spacing" or
 -- "XMonad.Layout.Gaps", you should think about using a different
 -- strategy, if you find the default behaviour to be unnatural.  Check
 -- out the [finer points](#g:Finer_Points) below for more information.
@@ -463,7 +464,7 @@ withNavigation2DConfig conf2d xconf = xconf { startupHook  = startupHook xconf
                                             }
 
 instance Default Navigation2DConfig where
-    def                   = Navigation2DConfig { defaultTiledNavigation = lineNavigation
+    def                   = Navigation2DConfig { defaultTiledNavigation = hybridOf lineNavigation sideNavigation
                                                , floatNavigation        = centerNavigation
                                                , screenNavigation       = lineNavigation
                                                , layoutNavigation       = []

--- a/XMonad/Actions/OnScreen.hs
+++ b/XMonad/Actions/OnScreen.hs
@@ -183,4 +183,4 @@ toggleOrView' f i st = fromMaybe (f i st) $ do
 -- where 0 is the first screen and \"1\" the workspace with the tag \"1\".
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.

--- a/XMonad/Actions/PerLayoutKeys.hs
+++ b/XMonad/Actions/PerLayoutKeys.hs
@@ -32,7 +32,7 @@ import XMonad.StackSet as S
 -- >   ,((0, xK_F2), bindByLayout [("Tall", spawn "rxvt"), ("Mirror Tall", spawn "xeyes"), ("", spawn "xmessage hello")])
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Uses supplied function to decide which action to run depending on current layout name.
 chooseActionByLayout :: (String->X()) -> X()

--- a/XMonad/Actions/PerWindowKeys.hs
+++ b/XMonad/Actions/PerWindowKeys.hs
@@ -41,7 +41,7 @@ import XMonad
 -- doThisIfTheOthersFail)]@.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Run an action if a Query holds true. Doesn't stop at the first one that
 -- does, however, and could potentially run all actions.

--- a/XMonad/Actions/PerWorkspaceKeys.hs
+++ b/XMonad/Actions/PerWorkspaceKeys.hs
@@ -32,7 +32,7 @@ import XMonad.StackSet as S
 -- >   ,((0, xK_F2), bindOn [("1", spawn "rxvt"), ("2", spawn "xeyes"), ("", spawn "xmessage hello")])
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Uses supplied function to decide which action to run depending on current workspace name.
 chooseAction :: (String->X()) -> X()

--- a/XMonad/Actions/PhysicalScreens.hs
+++ b/XMonad/Actions/PhysicalScreens.hs
@@ -65,7 +65,7 @@ Example usage in your @~\/.xmonad\/xmonad.hs@ file:
 >     , (f, mask) <- [(viewScreen def, 0), (sendToScreen def, shiftMask)]]
 
 For detailed instructions on editing your key bindings, see
-"XMonad.Doc.Extending#Editing_key_bindings".
+<https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
  -}
 
 -- | The type of the index of a screen by location

--- a/XMonad/Actions/Plane.hs
+++ b/XMonad/Actions/Plane.hs
@@ -59,7 +59,7 @@ import XMonad.Util.Run
 -- > myNewKeys (XConfig {modMask = modm}) = planeKeys modm (Lines 3) Finite
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Direction to go in the plane.
 data Direction =  ToLeft | ToUp | ToRight | ToDown deriving Enum

--- a/XMonad/Actions/Promote.hs
+++ b/XMonad/Actions/Promote.hs
@@ -37,7 +37,7 @@ import XMonad.StackSet
 -- >   , ((modm,               xK_Return), promote)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Move the focused window to the master pane. All other windows
 --   retain their order. If focus is in the master, swap it with the

--- a/XMonad/Actions/RotSlaves.hs
+++ b/XMonad/Actions/RotSlaves.hs
@@ -39,7 +39,7 @@ import XMonad.Prelude
 -- TwoPane layout (see "XMonad.Layout.TwoPane").
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Rotate the windows in the current stack, excluding the first one
 --   (master).

--- a/XMonad/Actions/SimpleDate.hs
+++ b/XMonad/Actions/SimpleDate.hs
@@ -35,7 +35,7 @@ import XMonad.Util.Run
 -- In this example, a popup date menu will now be bound to @mod-d@.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 date :: X ()
 date = unsafeSpawn "(date; sleep 10) | dzen2"

--- a/XMonad/Actions/SinkAll.hs
+++ b/XMonad/Actions/SinkAll.hs
@@ -32,4 +32,4 @@ import XMonad.Actions.WithAll (sinkAll)
 -- >   , ((modm .|. shiftMask, xK_t), sinkAll)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.

--- a/XMonad/Actions/SpawnOn.hs
+++ b/XMonad/Actions/SpawnOn.hs
@@ -63,7 +63,7 @@ import XMonad.Util.Process (getPPIDChain)
 -- the spawned application(e.g. float or resize it).
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 newtype Spawner = Spawner {pidsRef :: [(ProcessID, ManageHook)]}
 

--- a/XMonad/Actions/Submap.hs
+++ b/XMonad/Actions/Submap.hs
@@ -56,7 +56,7 @@ because that is a special value passed to XGrabKey() and not an actual
 modifier.
 
 For detailed instructions on editing your key bindings, see
-"XMonad.Doc.Extending#Editing_key_bindings".
+<https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -}
 

--- a/XMonad/Actions/SwapWorkspaces.hs
+++ b/XMonad/Actions/SwapWorkspaces.hs
@@ -44,7 +44,7 @@ import XMonad.Util.WorkspaceCompare
 -- will swap workspaces 1 and 5.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Swaps the currently focused workspace with the given workspace tag, via
 --   @swapWorkspaces@.

--- a/XMonad/Actions/TagWindows.hs
+++ b/XMonad/Actions/TagWindows.hs
@@ -64,7 +64,7 @@ econst = const . return
 --       the tags \"a\" and \"b\" but not \"a b\".
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | set multiple tags for a window at once (overriding any previous tags)
 setTags :: [String] -> Window -> X ()

--- a/XMonad/Actions/Warp.hs
+++ b/XMonad/Actions/Warp.hs
@@ -45,7 +45,7 @@ Note that warping to a particular screen may change the focus.
 -}
 
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 
 data Corner = UpperLeft | UpperRight | LowerLeft | LowerRight

--- a/XMonad/Actions/WindowBringer.hs
+++ b/XMonad/Actions/WindowBringer.hs
@@ -46,7 +46,7 @@ import XMonad.Util.NamedWindows (getName, getNameWMClass)
 -- > , ((modm .|. shiftMask, xK_b     ), bringMenu)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data WindowBringerConfig = WindowBringerConfig
     { menuCommand :: String -- ^ The shell command that will handle window selection

--- a/XMonad/Actions/WindowGo.hs
+++ b/XMonad/Actions/WindowGo.hs
@@ -66,7 +66,8 @@ appropriate one, or cover your bases by using instead something like:
 > (className =? "Firefox" <||> className =? "Firefox-bin")
 
 For detailed instructions on editing your key bindings, see
-"XMonad.Doc.Extending#Editing_key_bindings". -}
+<https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
+-}
 
 -- | Get the list of workspaces sorted by their tag
 workspacesSorted :: Ord i => W.StackSet i l a s sd -> [W.Workspace i l a]

--- a/XMonad/Actions/WithAll.hs
+++ b/XMonad/Actions/WithAll.hs
@@ -33,7 +33,7 @@ import XMonad.StackSet
 --     , ((modm .|. shiftMask, xK_t), sinkAll)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Un-float all floating windows on the current workspace.
 sinkAll :: X ()

--- a/XMonad/Actions/Workscreen.hs
+++ b/XMonad/Actions/Workscreen.hs
@@ -58,7 +58,7 @@ import XMonad.Actions.OnScreen
 -- >      , (f, m) <- [(Workscreen.viewWorkscreen, 0), (Workscreen.shiftToWorkscreen, shiftMask)]]
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 
 data Workscreen = Workscreen{workscreenId::Int,workspaces::[WorkspaceId]} deriving (Show)

--- a/XMonad/Actions/WorkspaceNames.hs
+++ b/XMonad/Actions/WorkspaceNames.hs
@@ -88,7 +88,7 @@ import qualified Data.Map as M
 -- >     | (i, k) <- zip workspaces [xK_1 ..]]
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 
 

--- a/XMonad/Config/Desktop.hs
+++ b/XMonad/Config/Desktop.hs
@@ -91,7 +91,7 @@ import qualified Data.Map as M
 
 -- $customizing
 -- To customize a desktop config, modify its fields as is illustrated with
--- the default configuration @def@ in "XMonad.Doc.Extending#Extending xmonad".
+-- the default configuration @def@ in <https://xmonad.org/TUTORIAL.html the tutorial>.
 
 -- $layouts
 -- See also "XMonad.Util.EZConfig" for more options for modifying key bindings.

--- a/XMonad/Doc/Configuring.hs
+++ b/XMonad/Doc/Configuring.hs
@@ -14,7 +14,9 @@
 -- <https://xmonad.org/TUTORIAL.html xmonad website>.
 --
 -- For more detailed instructions on extending xmonad with the
--- xmonad-contrib library, see "XMonad.Doc.Extending".
+-- xmonad-contrib library, see
+-- <https://xmonad.org/TUTORIAL.html the tutorial>
+-- and "XMonad.Doc.Extending".
 --
 -----------------------------------------------------------------------------
 

--- a/XMonad/Hooks/DebugKeyEvents.hs
+++ b/XMonad/Hooks/DebugKeyEvents.hs
@@ -51,9 +51,8 @@ import           System.IO                       (hPutStrLn
 -- the key; @mask@ is raw, and @clean@ is what @xmonad@ sees after
 -- sanitizing it (removing @numberLockMask@, etc.)
 --
--- For more detailed instructions on editing the logHook see:
---
--- "XMonad.Doc.Extending#The_log_hook_and_external_status_bars"
+-- For more detailed instructions on editing the logHook see
+-- <https://xmonad.org/TUTORIAL.html#make-xmonad-and-xmobar-talk-to-each-other the tutorial>.
 
 -- | Print key events to stderr for debugging
 debugKeyEvents :: Event -> X All

--- a/XMonad/Hooks/FadeInactive.hs
+++ b/XMonad/Hooks/FadeInactive.hs
@@ -47,13 +47,12 @@ import qualified XMonad.StackSet as W
 -- you will need to have xcompmgr <http://freedesktop.org/wiki/Software/xapps>
 -- or something similar for this to do anything
 --
--- For more detailed instructions on editing the logHook see:
+-- For more detailed instructions on editing the logHook see
+-- <https://xmonad.org/TUTORIAL.html#make-xmonad-and-xmobar-talk-to-each-other the tutorial>.
 --
--- "XMonad.Doc.Extending#The_log_hook_and_external_status_bars"
---
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | Converts a percentage to the format required for _NET_WM_WINDOW_OPACITY
 rationalToOpacity :: Integral a => Rational -> a

--- a/XMonad/Hooks/FadeWindows.hs
+++ b/XMonad/Hooks/FadeWindows.hs
@@ -105,9 +105,8 @@ import           Graphics.X11.Xlib.Extras                (Event(..))
 -- aren't running a compositing manager, the opacity will be recorded
 -- but won't take effect until a compositing manager is started.
 --
--- For more detailed instructions on editing the 'logHook' see:
---
--- "XMonad.Doc.Extending#The_log_hook_and_external_status_bars"
+-- For more detailed instructions on editing the 'logHook' see
+-- <https://xmonad.org/TUTORIAL.html#make-xmonad-and-xmobar-talk-to-each-other the tutorial>.
 --
 -- For more detailed instructions on editing the 'handleEventHook',
 -- see:

--- a/XMonad/Hooks/InsertPosition.hs
+++ b/XMonad/Hooks/InsertPosition.hs
@@ -17,27 +17,41 @@
 module XMonad.Hooks.InsertPosition (
     -- * Usage
     -- $usage
-    insertPosition
+    setupInsertPosition, insertPosition
     ,Focus(..), Position(..)
     ) where
 
-import XMonad(ManageHook, MonadReader(ask))
+import XMonad (ManageHook, MonadReader (ask), XConfig (manageHook))
 import XMonad.Prelude (Endo (Endo), find)
 import qualified XMonad.StackSet as W
 
 -- $usage
--- You can use this module with the following in your @~\/.xmonad\/xmonad.hs@:
+-- You can use this module by importing it in your @~\/.xmonad\/xmonad.hs@:
 --
 -- > import XMonad.Hooks.InsertPosition
+--
+-- You then just have to add 'setupInsertPosition' to your @main@ function:
+--
+-- > main = xmonad $ … $ setupInsertPosition Master Newer $ def { … }
+--
+-- Alternatively (i.e., you should /not/ do this if you already have set
+-- up the above combinator), you can also directly insert
+-- 'insertPosition' into your manageHook:
+--
 -- > xmonad def { manageHook = insertPosition Master Newer <> myManageHook }
 --
--- You should you put the manageHooks that use 'doShift' to take effect
+-- NOTE: You should you put the manageHooks that use 'doShift' to take effect
 -- /before/ 'insertPosition', so that the window order will be consistent.
 -- Because ManageHooks compose from right to left (like function composition
 -- '.'), this means that 'insertPosition' should be the leftmost ManageHook.
 
 data Position = Master | End | Above | Below
 data Focus = Newer | Older
+
+-- | A combinator for setting up 'insertPosition'.
+setupInsertPosition :: Position -> Focus -> XConfig a -> XConfig a
+setupInsertPosition pos foc cfg =
+  cfg{ manageHook = insertPosition pos foc <> manageHook cfg }
 
 -- | insertPosition. A manage hook for placing new windows. XMonad's default is
 -- the same as using: @insertPosition Above Newer@.

--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -83,7 +83,7 @@ import qualified XMonad.StackSet as W
 -- > layoutHook = avoidStrutsOn [U,L] (tall ||| mirror tall ||| ...)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 
 -- | Add docks functionality to the given config.  See above for an example.

--- a/XMonad/Hooks/SetWMName.hs
+++ b/XMonad/Hooks/SetWMName.hs
@@ -33,7 +33,7 @@
 -- fails miserably by guessing absolutely bogus values.
 --
 -- For detailed instructions on editing your hooks, see
--- "XMonad.Doc.Extending#4".
+-- <https://xmonad.org/TUTORIAL.html the tutorial> and "XMonad.Doc.Extending".
 -----------------------------------------------------------------------------
 
 module XMonad.Hooks.SetWMName (

--- a/XMonad/Hooks/WindowSwallowing.hs
+++ b/XMonad/Hooks/WindowSwallowing.hs
@@ -66,7 +66,7 @@ import           System.Posix.Types             ( ProcessID )
 -- instead of swallowing the window it will merge the child window with the parent. (this does not work with floating windows)
 --
 -- For more information on editing your handleEventHook and key bindings,
--- see "XMonad.Doc.Extending".
+-- see <https://xmonad.org/TUTORIAL.html the tutorial> and "XMonad.Doc.Extending".
 
 -- | Run @action@ iff both parent- and child queries match and the child
 -- is a child by PID.

--- a/XMonad/Layout/Accordion.hs
+++ b/XMonad/Layout/Accordion.hs
@@ -34,9 +34,9 @@ import Data.Ratio
 -- > myLayout = Accordion ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data Accordion a = Accordion deriving ( Read, Show )
 

--- a/XMonad/Layout/AvoidFloats.hs
+++ b/XMonad/Layout/AvoidFloats.hs
@@ -44,8 +44,9 @@ import qualified Data.Set as S
 --
 -- > layoutHook = ... ||| avoidFloats Full ||| ...
 --
--- For more detailed instructions on editing the layoutHook see:
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- Then add appropriate key bindings, for example:
 --
@@ -54,7 +55,7 @@ import qualified Data.Set as S
 -- > ,((modm .|. shiftMask .|. controlMask, xK_b), sendMessage (AvoidFloatSet False) >> sendMessage AvoidFloatClearItems)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- Note that this module is incompatible with an old way of configuring
 -- "XMonad.Actions.FloatSnap". If you are having problems, please update your

--- a/XMonad/Layout/BoringWindows.hs
+++ b/XMonad/Layout/BoringWindows.hs
@@ -60,9 +60,9 @@ import qualified XMonad.StackSet as W
 -- > , ((modm, xK_k), focusDown)
 -- > , ((modm, xK_m), focusMaster)
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 
 data BoringMessage = FocusUp | FocusDown | FocusMaster | IsBoring Window | ClearBoring

--- a/XMonad/Layout/CenteredIfSingle.hs
+++ b/XMonad/Layout/CenteredIfSingle.hs
@@ -38,7 +38,9 @@ import XMonad.Prelude (fi)
 --
 -- > myLayoutHook = centeredIfSingle 0.7 0.8 Grid ||| ...
 --
--- For more information on configuring your layouts see "XMonad.Doc.Extending".
+-- For more information on configuring your layouts see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>
+-- and "XMonad.Doc.Extending".
 
 
 -- | Layout Modifier that places a window in the center of the screen,

--- a/XMonad/Layout/Circle.hs
+++ b/XMonad/Layout/Circle.hs
@@ -35,9 +35,9 @@ import XMonad.StackSet (integrate, peek)
 -- > myLayout = Circle ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data Circle a = Circle deriving ( Read, Show )
 

--- a/XMonad/Layout/Combo.hs
+++ b/XMonad/Layout/Combo.hs
@@ -40,9 +40,9 @@ import qualified XMonad.StackSet as W ( differentiate )
 --
 -- to your layouts.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- combineTwo is a new simple layout combinator. It allows the
 -- combination of two layouts using a third to split the screen
@@ -57,7 +57,7 @@ import qualified XMonad.StackSet as W ( differentiate )
 -- >    , ((modm .|. controlMask .|. shiftMask, xK_Down ), sendMessage $ Move D)
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- These bindings will move a window into the sublayout that is
 -- up\/down\/left\/right of its current position.  Note that there is some

--- a/XMonad/Layout/ComboP.hs
+++ b/XMonad/Layout/ComboP.hs
@@ -44,9 +44,9 @@ import qualified XMonad.StackSet as W
 -- to your layouts. This way all windows with class = \"Firefox\" will always go
 -- to the left pane, all others - to the right.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- 'combineTwoP' is a simple layout combinator based on 'combineTwo' from Combo, with
 -- addition of a 'Property' which tells where to put new windows. Windows mathing
@@ -64,7 +64,7 @@ import qualified XMonad.StackSet as W
 -- >    , ((modm .|. controlMask .|. shiftMask, xK_s    ), sendMessage $ SwapWindow)
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data SwapWindow =  SwapWindow        -- ^ Swap window between panes
                  | SwapWindowN Int   -- ^ Swap window between panes in the N-th nested ComboP. @SwapWindowN 0@ equals to SwapWindow

--- a/XMonad/Layout/DecorationMadness.hs
+++ b/XMonad/Layout/DecorationMadness.hs
@@ -108,9 +108,9 @@ import XMonad.Layout.SimpleFloat
 --
 -- > main = xmonad def { layoutHook = someMadLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You can also edit the default theme:
 --

--- a/XMonad/Layout/Dishes.hs
+++ b/XMonad/Layout/Dishes.hs
@@ -36,9 +36,9 @@ import XMonad.Prelude (ap)
 -- > myLayout = Dishes 2 (1/6) ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data Dishes a = Dishes Int Rational deriving (Show, Read)
 instance LayoutClass Dishes a where

--- a/XMonad/Layout/DragPane.hs
+++ b/XMonad/Layout/DragPane.hs
@@ -44,9 +44,9 @@ import XMonad.Util.XUtils
 -- > myLayout = dragPane Horizontal 0.1 0.5 ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 halfHandleWidth :: Integral a => a
 halfHandleWidth = 1

--- a/XMonad/Layout/Dwindle.hs
+++ b/XMonad/Layout/Dwindle.hs
@@ -68,9 +68,9 @@ import XMonad.Util.Types ( Direction2D(..) )
 -- 1.1, is the factor by which the third parameter increases or decreases in
 -- response to Expand or Shrink messages.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | Layouts with geometrically decreasing window sizes.  'Spiral' and 'Dwindle'
 -- split the screen into a rectangle for the first window and a rectangle for

--- a/XMonad/Layout/DwmStyle.hs
+++ b/XMonad/Layout/DwmStyle.hs
@@ -40,9 +40,9 @@ import XMonad.Layout.Decoration
 -- > myL = dwmStyle shrinkText def (layoutHook def)
 -- > main = xmonad def { layoutHook = myL }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You can also edit the default configuration options.
 --

--- a/XMonad/Layout/FixedAspectRatio.hs
+++ b/XMonad/Layout/FixedAspectRatio.hs
@@ -53,8 +53,8 @@ import           XMonad.Layout.LayoutHints
 -- depending on the size hints (for example for programs like mpv),
 -- see "XMonad.Layout.LayoutHints"
 --
--- See "XMonad.Doc.Extending#Editing_the_layout_hook" for more info on
--- the 'layoutHook'.
+-- See <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook" for more info on the 'layoutHook'.
 --
 -- You also want to add keybindings to set and clear the aspect ratio:
 --
@@ -73,7 +73,7 @@ import           XMonad.Layout.LayoutHints
 --
 -- >  , ((modMask .|. shiftMask, xK_c), withFocused (sendMessage . ResetRatio) >> kill)
 --
--- See "XMonad.Doc.Extending#Editing_key_bindings" for more info
+-- See <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> for more info
 -- on customizing the keybindings.
 --
 -- This layout also comes with a 'ManageHook' 'doFixAspect' to
@@ -84,7 +84,8 @@ import           XMonad.Layout.LayoutHints
 -- >   ...
 -- > ]
 --
--- Check "XMonad.Doc.Extending#Editing_the_manage_hook" for more information on
+-- Check <https://xmonad.org/TUTORIAL.html#final-touches the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_manage_hook" for more information on
 -- customizing the manage hook.
 
 -- | Similar to 'layoutHintsWithReplacement', but relies on the user to

--- a/XMonad/Layout/FixedColumn.hs
+++ b/XMonad/Layout/FixedColumn.hs
@@ -37,9 +37,9 @@ import qualified XMonad.StackSet as W
 -- > myLayout = FixedColumn 1 20 80 10 ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | A tiling mode based on preserving a nice fixed width
 --   window. Supports 'Shrink', 'Expand' and 'IncMasterN'.

--- a/XMonad/Layout/Grid.hs
+++ b/XMonad/Layout/Grid.hs
@@ -40,9 +40,9 @@ import XMonad.StackSet
 --
 -- > myLayout = GridRatio (4/3) ||| etc.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data Grid a = Grid | GridRatio Double deriving (Read, Show)
 

--- a/XMonad/Layout/Groups/Examples.hs
+++ b/XMonad/Layout/Groups/Examples.hs
@@ -84,8 +84,8 @@ import XMonad.Layout.Simplest
 --   the "XMonad.Layout.Groups.Helpers" module, which are all
 --   re-exported by this module.
 --
--- For more information on how to extend your layour hook and key bindings, see
---   "XMonad.Doc.Extending".
+-- For more information on how to extend your layoutHook and key bindings, see
+-- <https://xmonad.org/TUTORIAL.html the tutorial> and "XMonad.Doc.Extending".
 
 
 -- * Helper: ZoomRow of Group elements

--- a/XMonad/Layout/Groups/Helpers.hs
+++ b/XMonad/Layout/Groups/Helpers.hs
@@ -83,8 +83,8 @@ import qualified Data.Map as M
 --
 -- > import qualified XMonad.Layout.Groups as G
 --
--- For more information on how to extend your layour hook and key bindings, see
--- "XMonad.Doc.Extending".
+-- For more information on how to extend your layoutHook and key bindings, see
+-- <https://xmonad.org/TUTORIAL.html the tutorial> and "XMonad.Doc.Extending".
 
 -- ** Layout-generic actions
 -- #Layout-generic actions#

--- a/XMonad/Layout/Groups/Wmii.hs
+++ b/XMonad/Layout/Groups/Wmii.hs
@@ -79,8 +79,8 @@ import XMonad.Layout.Simplest
 --
 -- and so on.
 --
--- For more information on how to extend your layout hook and key bindings, see
--- "XMonad.Doc.Extending".
+-- For more information on how to extend your layoutHook and key bindings, see
+-- <https://xmonad.org/TUTORIAL.html the tutorial> and "XMonad.Doc.Extending".
 --
 -- Finally, you will probably want to be able to move focus and windows
 -- between groups in a consistent fashion. For this, you should take a look

--- a/XMonad/Layout/Hidden.hs
+++ b/XMonad/Layout/Hidden.hs
@@ -46,9 +46,9 @@ import qualified XMonad.StackSet as W
 -- > myLayout = hiddenWindows (Tall 1 (3/100) (1/2)) ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- In the key bindings, do something like:
 --
@@ -58,7 +58,7 @@ import qualified XMonad.StackSet as W
 --
 -- For detailed instruction on editing the key bindings see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 --------------------------------------------------------------------------------
 newtype HiddenWindows a = HiddenWindows [Window] deriving (Show, Read)

--- a/XMonad/Layout/HintedGrid.hs
+++ b/XMonad/Layout/HintedGrid.hs
@@ -51,6 +51,7 @@ infixr 9 .
 -- > myLayout = GridRatio (4/3) False ||| etc.
 --
 -- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
 -- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | Automatic mirroring of hinted layouts doesn't work very well, so this

--- a/XMonad/Layout/HintedTile.hs
+++ b/XMonad/Layout/HintedTile.hs
@@ -46,9 +46,9 @@ import XMonad.Prelude
 -- built-in Tall with HintedTile, change @import Xmonad@ to
 -- @import Xmonad hiding (Tall)@.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data HintedTile a = HintedTile
     { nmaster     :: !Int         -- ^ number of windows in the master pane

--- a/XMonad/Layout/IM.hs
+++ b/XMonad/Layout/IM.hs
@@ -55,9 +55,9 @@ import Control.Arrow (first)
 --
 -- Screenshot: <http://haskell.org/haskellwiki/Image:Xmonad-layout-im.png>
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- $hints
 --

--- a/XMonad/Layout/LayoutBuilder.hs
+++ b/XMonad/Layout/LayoutBuilder.hs
@@ -103,9 +103,9 @@ import XMonad.Util.WindowProperties
 --
 -- These examples require "XMonad.Layout.Tabbed".
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You may wish to add the following keybindings:
 --
@@ -114,7 +114,7 @@ import XMonad.Util.WindowProperties
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 --------------------------------------------------------------------------------
 -- $selectWin

--- a/XMonad/Layout/LayoutCombinators.hs
+++ b/XMonad/Layout/LayoutCombinators.hs
@@ -61,9 +61,9 @@ import XMonad.Layout.DragPane
 -- > myLayout = (Tall 1 (3/100) (1/2) *//* Full)  ||| (Tall 1 (3/100) (1/2) ***||** Full) ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the @layoutHook@ see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the @layoutHook@ see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 
 -- $combine

--- a/XMonad/Layout/LayoutHints.hs
+++ b/XMonad/Layout/LayoutHints.hs
@@ -66,9 +66,9 @@ import qualified Data.Set as Set
 --
 -- > myLayout = layoutHintsToCenter (Tall 1 (3/100) (1/2))
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- To make XMonad reflect changes in window hints immediately, add
 -- 'hintsEventHook' to your 'handleEventHook'.

--- a/XMonad/Layout/LayoutScreens.hs
+++ b/XMonad/Layout/LayoutScreens.hs
@@ -57,7 +57,7 @@ import qualified XMonad.StackSet as W
 -- >   , ((modm .|. controlMask .|. shiftMask, xK_space), rescreen)
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Modify all screens.
 layoutScreens :: LayoutClass l Int => Int -> l Int -> X ()

--- a/XMonad/Layout/LimitWindows.hs
+++ b/XMonad/Layout/LimitWindows.hs
@@ -56,7 +56,7 @@ import qualified XMonad.StackSet as W
 -- actions.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- See also 'XMonad.Layout.BoringWindows.boringAuto' for keybindings that skip
 -- the hidden windows.

--- a/XMonad/Layout/MagicFocus.hs
+++ b/XMonad/Layout/MagicFocus.hs
@@ -45,9 +45,9 @@ import qualified Data.Map as M
 -- > main = xmonad def { layoutHook = myLayout,
 -- >                     handleEventHook = promoteWarp }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | Create a new layout which automagically puts the focused window
 --   in the master area.

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -76,9 +76,9 @@ import XMonad.StackSet
 -- functions in this module are essentially just creative applications
 -- of it.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- Magnifier supports some commands, see 'MagnifyMsg'.  To use them add
 -- something like this to your key bindings:
@@ -101,7 +101,7 @@ import XMonad.StackSet
 -- like @Mag.Toggle@, @Mag.magnifier@, and so on.
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Add magnification capabilities to a certain layout.
 --

--- a/XMonad/Layout/Master.hs
+++ b/XMonad/Layout/Master.hs
@@ -52,6 +52,7 @@ import Control.Arrow (first)
 -- Grid manage the right half.
 --
 -- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
 -- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- Like 'XMonad.Layout.Tall', 'withMaster' supports the

--- a/XMonad/Layout/Maximize.hs
+++ b/XMonad/Layout/Maximize.hs
@@ -46,9 +46,9 @@ import XMonad.Prelude ( partition )
 -- > myLayout = maximizeWithPadding 10 (Tall 1 (3/100) (1/2)) ||| Full ||| etc..)
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- In the key-bindings, do something like:
 --
@@ -57,7 +57,7 @@ import XMonad.Prelude ( partition )
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data Maximize a = Maximize Dimension (Maybe Window) deriving ( Read, Show )
 maximize :: LayoutClass l Window => l Window -> ModifiedLayout Maximize l Window

--- a/XMonad/Layout/Minimize.hs
+++ b/XMonad/Layout/Minimize.hs
@@ -39,9 +39,9 @@ import qualified XMonad.Util.ExtensibleState as XS
 -- > myLayout = minimize (Tall 1 (3/100) (1/2)) ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- The module is designed to work together with "XMonad.Layout.BoringWindows" so
 -- that minimized windows will be skipped over when switching the focused window with

--- a/XMonad/Layout/Mosaic.hs
+++ b/XMonad/Layout/Mosaic.hs
@@ -58,9 +58,9 @@ import Control.Arrow(second, first)
 --
 --  > , ((modm, xK_r), sendMessage Reset)
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data Aspect
     = Taller

--- a/XMonad/Layout/MosaicAlt.hs
+++ b/XMonad/Layout/MosaicAlt.hs
@@ -48,9 +48,9 @@ import Data.Ratio
 -- > myLayout = MosaicAlt M.empty ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- In the key-bindings, do something like:
 --
@@ -63,7 +63,7 @@ import Data.Ratio
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data HandleWindowAlt =
     ShrinkWindowAlt Window

--- a/XMonad/Layout/MouseResizableTile.hs
+++ b/XMonad/Layout/MouseResizableTile.hs
@@ -53,9 +53,9 @@ import Graphics.X11 as X
 -- > main = xmonad def { layoutHook = myLayout }
 --
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You may also want to add the following key bindings:
 --
@@ -64,7 +64,7 @@ import Graphics.X11 as X
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- $mrtParameters
 -- The following functions are also labels for updating the @data@ (whose

--- a/XMonad/Layout/MultiColumns.hs
+++ b/XMonad/Layout/MultiColumns.hs
@@ -56,9 +56,9 @@ import XMonad.Prelude
 -- columns, the screen is instead split equally among all columns. Therefore,
 -- if equal size among all columns are desired, set the size to -0.5.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | Layout constructor.
 multiCol

--- a/XMonad/Layout/MultiDishes.hs
+++ b/XMonad/Layout/MultiDishes.hs
@@ -53,9 +53,9 @@ import XMonad.Prelude (ap)
 -- > |_______|
 -- > |___|___|
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data MultiDishes a = MultiDishes Int Int Rational deriving (Show, Read)
 instance LayoutClass MultiDishes a where

--- a/XMonad/Layout/Named.hs
+++ b/XMonad/Layout/Named.hs
@@ -37,9 +37,9 @@ import XMonad.Layout.Renamed
 -- > myLayout = named "real big" Full ||| (nameTail $ named "real big" $ Full) ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- Note that this module has been deprecated and may be removed in a future
 -- release, please use "XMonad.Layout.Renamed" instead.

--- a/XMonad/Layout/NoBorders.hs
+++ b/XMonad/Layout/NoBorders.hs
@@ -54,9 +54,9 @@ import qualified Data.Map                       as M
 --
 -- > layoutHook = ... ||| noBorders Full ||| ...
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- todo, use an InvisibleList.
 data WithBorder a = WithBorder Dimension [a] deriving ( Read, Show )

--- a/XMonad/Layout/ResizableThreeColumns.hs
+++ b/XMonad/Layout/ResizableThreeColumns.hs
@@ -55,9 +55,9 @@ import Data.Ratio
 --
 -- The ResizableThreeColMid variant places the main window between the slave columns.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 
 -- | Arguments are nmaster, delta, fraction

--- a/XMonad/Layout/ResizableTile.hs
+++ b/XMonad/Layout/ResizableTile.hs
@@ -36,9 +36,9 @@ import qualified Data.Map as M
 -- > myLayout =  ResizableTall 1 (3/100) (1/2) [] ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You may also want to add the following key bindings:
 --
@@ -47,7 +47,7 @@ import qualified Data.Map as M
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data MirrorResize = MirrorShrink | MirrorExpand
 instance Message MirrorResize

--- a/XMonad/Layout/ResizeScreen.hs
+++ b/XMonad/Layout/ResizeScreen.hs
@@ -39,9 +39,9 @@ import XMonad.Layout.Decoration
 --
 -- > layoutHook = resizeHorizontal 40 Full
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 resizeHorizontal :: Int -> l a -> ModifiedLayout ResizeScreen l a
 resizeHorizontal i = ModifiedLayout (ResizeScreen L i)

--- a/XMonad/Layout/Roledex.hs
+++ b/XMonad/Layout/Roledex.hs
@@ -36,9 +36,9 @@ import Data.Ratio
 -- > myLayout =  Roledex ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- $screenshot
 -- <<http://www.timthelion.com/rolodex.png>>

--- a/XMonad/Layout/ShowWName.hs
+++ b/XMonad/Layout/ShowWName.hs
@@ -41,9 +41,9 @@ import XMonad.Util.XUtils
 -- > myLayout = layoutHook def
 -- > main = xmonad def { layoutHook = showWName myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | A layout modifier to show the workspace name when switching
 showWName :: l a -> ModifiedLayout ShowWName l a

--- a/XMonad/Layout/SimpleDecoration.hs
+++ b/XMonad/Layout/SimpleDecoration.hs
@@ -42,9 +42,9 @@ import XMonad.Layout.Decoration
 -- > myL = simpleDeco shrinkText def (layoutHook def)
 -- > main = xmonad def { layoutHook = myL }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You can also edit the default configuration options.
 --

--- a/XMonad/Layout/SimpleFloat.hs
+++ b/XMonad/Layout/SimpleFloat.hs
@@ -42,9 +42,9 @@ import XMonad.Layout.WindowArranger
 -- > myLayout = simpleFloat ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | A simple floating layout where every window is placed according
 -- to the window's initial attributes.

--- a/XMonad/Layout/Simplest.hs
+++ b/XMonad/Layout/Simplest.hs
@@ -33,9 +33,9 @@ import qualified XMonad.StackSet as S
 -- > myLayout = Simplest ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data Simplest a = Simplest deriving (Show, Read)
 instance LayoutClass Simplest a where

--- a/XMonad/Layout/SimplestFloat.hs
+++ b/XMonad/Layout/SimplestFloat.hs
@@ -37,9 +37,9 @@ import XMonad.Layout.LayoutModifier
 -- > myLayout = simplestFloat ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | A simple floating layout where every window is placed according
 -- to the window's initial attributes.

--- a/XMonad/Layout/SortedLayout.hs
+++ b/XMonad/Layout/SortedLayout.hs
@@ -42,9 +42,9 @@ import           XMonad.Util.WindowProperties
 -- > myLayout = sorted [ClassName "Firefox", ClassName "URxvt"] Grid
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 
 -- | Modify a layout using a list of properties to sort its windows.

--- a/XMonad/Layout/Spiral.hs
+++ b/XMonad/Layout/Spiral.hs
@@ -40,9 +40,9 @@ import XMonad.StackSet ( integrate )
 -- > myLayout =  spiral (6/7) ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 fibs :: [Integer]
 fibs = 1 : 1 : zipWith (+) fibs (tail fibs)

--- a/XMonad/Layout/Square.hs
+++ b/XMonad/Layout/Square.hs
@@ -41,7 +41,7 @@ import XMonad.StackSet ( integrate )
 -- >         [(tabbed,3),(tabbed,30),(tabbed,1),(tabbed,1)]
 
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data Square a = Square deriving ( Read, Show )
 

--- a/XMonad/Layout/StackTile.hs
+++ b/XMonad/Layout/StackTile.hs
@@ -36,9 +36,9 @@ import XMonad.Prelude
 -- > myLayout =  StackTile 1 (3/100) (1/2) ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 data StackTile a = StackTile !Int !Rational !Rational deriving (Show, Read)
 

--- a/XMonad/Layout/Stoppable.hs
+++ b/XMonad/Layout/Stoppable.hs
@@ -75,9 +75,9 @@ import System.Posix.Signals
 -- layoutHook you have to provide manageHook from
 -- "XMonad.Util.RemoteWindows" module.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 signalWindow :: Signal -> Window -> X ()
 signalWindow s w = do

--- a/XMonad/Layout/SubLayouts.hs
+++ b/XMonad/Layout/SubLayouts.hs
@@ -163,10 +163,9 @@ import qualified Data.Set as S
 --  could not be used in the keybinding instead? It avoids having to explicitly
 --  pass the conf.
 --
--- For more detailed instructions, see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
--- "XMonad.Doc.Extending#Adding_key_bindings"
+-- For more detailed instructions, see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>
+-- and "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 -- | The main layout modifier arguments:
 --

--- a/XMonad/Layout/TabBarDecoration.hs
+++ b/XMonad/Layout/TabBarDecoration.hs
@@ -39,9 +39,9 @@ import XMonad.Prompt ( XPPosition (..) )
 --
 -- > main = xmonad def { layoutHook = simpleTabBar $ layoutHook def}
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- 'tabBar' will give you the possibility of setting a custom shrinker
 -- and a custom theme.

--- a/XMonad/Layout/Tabbed.hs
+++ b/XMonad/Layout/Tabbed.hs
@@ -67,9 +67,9 @@ import XMonad.Util.Types (Direction2D(..))
 -- on the workspace.  To have it always shown, use one of the layouts or
 -- modifiers ending in @Always@.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You can also edit the default configuration options.
 --

--- a/XMonad/Layout/ThreeColumns.hs
+++ b/XMonad/Layout/ThreeColumns.hs
@@ -51,9 +51,9 @@ import Data.Ratio
 --
 -- The ThreeColMid variant places the main window between the stack columns.
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 
 -- $screenshot

--- a/XMonad/Layout/ToggleLayouts.hs
+++ b/XMonad/Layout/ToggleLayouts.hs
@@ -34,9 +34,9 @@ import XMonad.StackSet (Workspace (..))
 -- > myLayout = toggleLayouts Full (Tall 1 (3/100) (1/2)) ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- To toggle between layouts add a key binding like
 --
@@ -48,7 +48,7 @@ import XMonad.StackSet (Workspace (..))
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data ToggleLayouts lt lf a = ToggleLayouts Bool (lt a) (lf a) deriving (Read,Show)
 data ToggleLayout = ToggleLayout | Toggle String deriving (Read,Show)

--- a/XMonad/Layout/TwoPane.hs
+++ b/XMonad/Layout/TwoPane.hs
@@ -36,9 +36,9 @@ import XMonad.StackSet ( focus, up, down)
 -- > myLayout = TwoPane (3/100) (1/2)  ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data TwoPane a =
     TwoPane Rational Rational

--- a/XMonad/Layout/VoidBorders.hs
+++ b/XMonad/Layout/VoidBorders.hs
@@ -46,9 +46,9 @@ import XMonad.StackSet (integrate)
 --
 -- > layoutHook = ... ||| voidBorders Full ||| normalBorders Tall ...
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 
 data VoidBorders a = VoidBorders deriving (Read, Show)
 

--- a/XMonad/Layout/WindowArranger.hs
+++ b/XMonad/Layout/WindowArranger.hs
@@ -45,9 +45,9 @@ import Control.Arrow ((***), (>>>), (&&&), first)
 --
 -- > main = xmonad def { layoutHook = windowArrangeAll myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- You may also want to define some key binding to move or resize
 -- windows. These are good defaults:
@@ -68,7 +68,7 @@ import Control.Arrow ((***), (>>>), (&&&), first)
 -- >        , ((modm .|. controlMask .|. shiftMask, xK_Up   ), sendMessage (DecreaseUp    1))
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | A layout modifier to float the windows in a workspace
 windowArrange :: l a -> ModifiedLayout WindowArranger l a

--- a/XMonad/Layout/WindowNavigation.hs
+++ b/XMonad/Layout/WindowNavigation.hs
@@ -45,9 +45,9 @@ import XMonad.Util.XUtils
 -- > myLayout = windowNavigation (Tall 1 (3/100) (1/2)) ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the 'layoutHook' see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the 'layoutHook' see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- In keybindings:
 --
@@ -62,7 +62,7 @@ import XMonad.Util.XUtils
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 
 data MoveWindowToWindow a = MoveWindowToWindow a a deriving ( Read, Show)
@@ -75,10 +75,10 @@ instance Message Navigate
 -- | Used with 'configurableNavigation' to specify how to show reachable windows'
 -- borders. You cannot create 'WNConfig' values directly; use 'def' or one of the following
 -- three functions to create one.
--- 
+--
 -- 'def', and 'windowNavigation', uses the focused border color at 40% brightness, as if
 -- you had specified
--- 
+--
 -- > configurableNavigation (navigateBrightness 0.4)
 data WNConfig =
     WNC { brightness    :: Maybe Double -- Indicates a fraction of the focus color.

--- a/XMonad/Layout/WorkspaceDir.hs
+++ b/XMonad/Layout/WorkspaceDir.hs
@@ -51,9 +51,9 @@ import XMonad.StackSet ( tag, currentTag )
 -- > myLayout = workspaceDir "~" (Tall 1 (3/100) (1/2))  ||| Full ||| etc..
 -- > main = xmonad def { layoutHook = myLayout }
 --
--- For more detailed instructions on editing the layoutHook see:
---
--- "XMonad.Doc.Extending#Editing_the_layout_hook"
+-- For more detailed instructions on editing the layoutHook see
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial> and
+-- "XMonad.Doc.Extending#Editing_the_layout_hook".
 --
 -- WorkspaceDir provides also a prompt. To use it you need to import
 -- "XMonad.Prompt" and add something like this to your key bindings:
@@ -67,7 +67,7 @@ import XMonad.StackSet ( tag, currentTag )
 --
 -- For detailed instruction on editing the key binding see:
 --
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 newtype Chdir = Chdir String
 instance Message Chdir

--- a/XMonad/Layout/ZoomRow.hs
+++ b/XMonad/Layout/ZoomRow.hs
@@ -69,8 +69,9 @@ import Control.Arrow (second)
 -- >   -- (Un)Maximize the focused window
 -- > , ((modMask             , xK_f    ), sendMessage ToggleZoomFull)
 --
--- For more information on editing your layout hook and key bindings,
--- see "XMonad.Doc.Extending".
+-- For more information on editing your layoutHook and key bindings,
+-- see <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>
+-- and "XMonad.Doc.Extending".
 
 -- * Creation functions
 

--- a/XMonad/Prompt/AppendFile.hs
+++ b/XMonad/Prompt/AppendFile.hs
@@ -69,7 +69,7 @@ import System.IO
 -- the file too.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 newtype AppendFile = AppendFile FilePath
 

--- a/XMonad/Prompt/DirExec.hs
+++ b/XMonad/Prompt/DirExec.hs
@@ -63,7 +63,7 @@ econst = const . return
 -- terminal
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 newtype DirExec = DirExec String
 

--- a/XMonad/Prompt/Email.hs
+++ b/XMonad/Prompt/Email.hs
@@ -50,7 +50,7 @@ import XMonad.Prompt.Input
 -- characters and then hit \'tab\'.
 --
 -- For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 
 -- | Prompt the user for a recipient, subject, and body, and send an

--- a/XMonad/Prompt/FuzzyMatch.hs
+++ b/XMonad/Prompt/FuzzyMatch.hs
@@ -63,7 +63,7 @@ import qualified Data.List.NonEmpty as NE
 -- > , ((modm .|. shiftMask, xK_g), windowPrompt myXPConfig Goto allWindows)
 --
 -- For detailed instructions on editing the key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- | Returns True if the first argument is a subsequence of the second argument,
 -- that is, it can be obtained from the second sequence by deleting elements.

--- a/XMonad/Prompt/Input.hs
+++ b/XMonad/Prompt/Input.hs
@@ -70,7 +70,7 @@ import XMonad.Prompt
 -- invoked.
 --
 -- (For detailed instructions on editing your key bindings, see
--- "XMonad.Doc.Extending#Editing_key_bindings".)
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.)
 --
 -- "XMonad.Prompt.Input" is also intended to ease the process of
 -- developing other modules which require user input. For an example

--- a/XMonad/Prompt/Layout.hs
+++ b/XMonad/Prompt/Layout.hs
@@ -34,7 +34,7 @@ import XMonad.StackSet ( workspaces, layout )
 -- >   , ((modm .|. shiftMask, xK_m     ), layoutPrompt def)
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- WARNING: This prompt won't display all possible layouts, because the
 -- code to enable this was rejected from xmonad core.  It only displays

--- a/XMonad/Prompt/Man.hs
+++ b/XMonad/Prompt/Man.hs
@@ -49,7 +49,7 @@ import qualified Control.Exception as E
 -- >     , ((modm, xK_F1), manPrompt def)
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data Man = Man
 

--- a/XMonad/Prompt/Pass.hs
+++ b/XMonad/Prompt/Pass.hs
@@ -113,7 +113,7 @@ import XMonad.Util.Run (runProcessWithInput)
 --
 -- For detailed instructions on:
 --
--- - editing your key bindings, see "XMonad.Doc.Extending#Editing_key_bindings".
+-- - editing your key bindings, see <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 --
 -- - how to setup the password store, see <http://git.zx2c4.com/password-store/about/>
 --   or @man 1 pass@.

--- a/XMonad/Prompt/RunOrRaise.hs
+++ b/XMonad/Prompt/RunOrRaise.hs
@@ -45,7 +45,8 @@ econst = const . return
 >   , ((modm .|. controlMask, xK_x), runOrRaisePrompt def)
 
 For detailed instruction on editing the key binding see
-"XMonad.Doc.Extending#Editing_key_bindings". -}
+<https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
+-}
 
 data RunOrRaisePrompt = RRP
 instance XPrompt RunOrRaisePrompt where

--- a/XMonad/Prompt/Shell.hs
+++ b/XMonad/Prompt/Shell.hs
@@ -62,7 +62,8 @@ econst = const . return
 >   , ((modm .|. controlMask, xK_x), shellPrompt def)
 
 For detailed instruction on editing the key binding see
-"XMonad.Doc.Extending#Editing_key_bindings". -}
+<https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
+-}
 
 data Shell = Shell
 type Predicate = String -> String -> Bool

--- a/XMonad/Prompt/Ssh.hs
+++ b/XMonad/Prompt/Ssh.hs
@@ -46,7 +46,7 @@ econst = const . return
 -- disable the "HashKnownHosts" option in your ssh_config
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data Ssh = Ssh
 

--- a/XMonad/Prompt/Theme.hs
+++ b/XMonad/Prompt/Theme.hs
@@ -39,7 +39,7 @@ import XMonad.Util.Themes
 -- >   , ((modm .|. controlMask, xK_t), themePrompt def)
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 data ThemePrompt = ThemePrompt
 

--- a/XMonad/Prompt/Window.hs
+++ b/XMonad/Prompt/Window.hs
@@ -65,7 +65,7 @@ import XMonad.Util.NamedWindows
 -- keystrokes to the selected client.
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 -- Describe actions that can applied  on the selected window
 data WindowPrompt = Goto | Bring | BringCopy | BringToMaster | WithWindow String (Window ->  X())

--- a/XMonad/Prompt/Workspace.hs
+++ b/XMonad/Prompt/Workspace.hs
@@ -36,7 +36,7 @@ import XMonad.Util.WorkspaceCompare ( getSortByIndex )
 -- >   , ((modm .|. shiftMask, xK_m     ), workspacePrompt def (windows . W.shift))
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 newtype Wor = Wor String
 

--- a/XMonad/Prompt/XMonad.hs
+++ b/XMonad/Prompt/XMonad.hs
@@ -38,7 +38,7 @@ import XMonad.Prelude (fromMaybe)
 -- >   , ((modm .|. controlMask, xK_x), xmonadPrompt def)
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings".
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>.
 
 newtype XMonad = XMonad String
 

--- a/XMonad/Prompt/Zsh.hs
+++ b/XMonad/Prompt/Zsh.hs
@@ -38,7 +38,7 @@ import XMonad.Util.Run
 >   , ((modm .|. controlMask, xK_x), zshPrompt def "/path/to/capture.zsh")
 
 For detailed instruction on editing the key binding see
-"XMonad.Doc.Extending#Editing_key_bindings". -}
+<https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>. -}
 
 data Zsh = Zsh
 

--- a/XMonad/Util/ExclusiveScratchpads.hs
+++ b/XMonad/Util/ExclusiveScratchpads.hs
@@ -71,11 +71,12 @@ import qualified XMonad.StackSet as W
 --
 -- > scratchpads = exclusiveSps ++ regularSps
 --
--- Add the hooks to your managehook (see "XMonad.Doc.Extending#Editing_the_manage_hook"), eg.:
+-- Add the hooks to your managehook (see "XMonad.Doc.Extending#Editing_the_manage_hook" or
+-- <https://xmonad.org/TUTORIAL.html#final-touches the tutorial>); e.g.,
 --
 -- > manageHook = myManageHook <> xScratchpadsManageHook scratchpads
 --
--- And finally add some keybindings (see "XMonad.Doc.Extending#Editing_key_bindings"):
+-- And finally add some keybindings (see <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>):
 --
 -- > , ((modMask, xK_h), scratchpadAction scratchpads "htop")
 -- > , ((modMask, xK_c), scratchpadAction scratchpads "xclock")

--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -101,7 +101,7 @@ import qualified XMonad.Util.ExtensibleState as XS
 -- >  , manageHook = namedScratchpadManageHook scratchpads
 --
 -- For detailed instruction on editing the key binding see
--- "XMonad.Doc.Extending#Editing_key_bindings"
+-- <https://xmonad.org/TUTORIAL.html#customizing-xmonad the tutorial>
 --
 -- For some applications (like displaying your workspaces in a status bar) it
 -- is convenient to filter out the @NSP@ workspace when looking at all


### PR DESCRIPTION
### Commit Summary

#### 7ec2cf25 Refer to the tutorial instead of X.D.Extending more often

Essentially, whenever the tutorial actually has decent material on the
subject matter.  The replacement is roughly done as follows:

  - logHook → tutorial
  - keybindings → tutorial, as this is thoroughly covered
  - manageHook → tutorial + X.D.Extending, as the manageHook stuff the
    tutorial talks about is a little bit of an afterthought.
  - X.D.Extending (on its own) → tutorial + X.D.Extending
  - layoutHook → tutorial + X.D.Extending, as the tutorial, while
    talking about layouts, doesn't necessarily have a huge focus there.
  - mouse bindings → leave this alone, as the tutorial does not at all
    talk about them.

#### 09c47c2c X.A.FloatKeys: Add direction{Move,Resize}Window

These are simpler, more easily understood, alternatives to the existing
functions.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/712

#### 180a4aa8 X.H.InsertPosition: Add combinator

Users may not see the warning that insertPosition definitely needs to be
inserted at the leftmost position, which can cause undesired behaviour.
Having a combinator that handles this automatically seems like a sane
idea.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/709

       (Note that `docs` wasn't changed since it already inserts itself
       rightmost.)

#### 84c94d83 X.A.Navigation2D: More prominently document strategies

Also, add a note that users who use gaps or spacing may need to look
into these strategies a bit more deeply.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/627


#### f833d949 X.A.Navigation2D: Add sideNavigation as to default tiled navigation

Add sideNavigation as a fallback if needed.  This should not have any
user-facing behaviour change when not using gaps or spacing, as line
navigation is preferred.  However, users who do use spacing or gaps
should now potentially not have to change the default strategy in order
to have a usable module.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: most of this is docs, but I've manually tested e.g. the changes to FloatKeys.

  - [x] I updated the `CHANGES.md` file

    Where appropriate.