### PR TITLE
Fix broken link in doc for XMonad.Util.SpawnOnce

### DIFF
--- a/XMonad/Util/SpawnOnce.hs
+++ b/XMonad/Util/SpawnOnce.hs
@@ -11,7 +11,7 @@
 --
 -- A module for spawning a command once, and only once.  Useful to start
 -- status bars and make session settings inside startupHook. See also
--- 'XMonad.Util.SessionStart' for a different and more flexible way to
+-- "XMonad.Util.SessionStart" for a different and more flexible way to
 -- run commands only on first startup.
 --
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Sorry for the tiny doc change, but it annoyed me. :)

tl;dr: haddock module links need `"` not `'`.

<hr/>

### Description

This fixes the broken link on the [doc page for XMonad.Util.SpawnOnce](https://hackage.haskell.org/package/xmonad-contrib-0.17.1/docs/XMonad-Util-SpawnOnce.html) to SessionStart.

Haddock interprets 'XMonad.Util.SessionStart' as a (non-existent) function in "XMonad.Util", rather than as a module, and hence it links to:

https://hackage.haskell.org/package/xmonad-contrib-0.17.1/docs/XMonad-Util.html#v:SessionStart

which doesn't exist, rather than to:

https://hackage.haskell.org/package/xmonad-contrib-0.17.1/docs/XMonad-Util-SessionStart.html

Apparently, module links need " instead of '. (See:

https://haskell-haddock.readthedocs.io/en/latest/markup.html#linking-to-modules

)

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested with `cabal haddock` and checked link for `XMonad-Util-SpawnOnce.html`.

There are quite a few other warnings about "could not find link destinations for:", but weirdly enough, if I undo the change, the broken link from SpawnOnce is _not_ reported AFAICT, and all the missing "link destinations" that I checked are simply not turned into hyperlinks.

If there's interest, I could try to find and fix all the existing hyperlinks that are broken.

  - [ ] I updated the `CHANGES.md` file

(I assume that the change is minor enough that CHANGES.md doesn't need to be changed.)