### PR TITLE
EwmhDesktops: _NET_CLIENT_LIST_STACKING: In focus order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,14 @@
     - Deprecated the entire module, use `XMonad.Actions.WithAll`
       instead.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - `_NET_CLIENT_LIST_STACKING` puts windows in the current workspace at the
+      top in bottom-to-top order, followed by visible workspaces, followed by
+      invisible workspaces.  Within visible and invisible groups, workspaces are
+      ordered lexicographically, as before.  Currently focused window will
+      always be the topmost, meaning the last in the list.
+
 ### New Modules
 
 * `XMonad.Hooks.OnPropertyChange`:


### PR DESCRIPTION
Order workspaces based on the visibility, before collecting windows. `_NET_CLIENT_LIST_STACKING` is supposed to be in the focus order.

### Description

A fix for https://github.com/xmonad/xmonad-contrib/issues/771.  Issue contains a description of the problem.

### Checklist
  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)
  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded: manually
  - [X] I updated the `CHANGES.md` file
