### PR TITLE
CI maintenance (GHA deprecations, GHC 9.4)

### DIFF
--- a/.github/workflows/haskell-ci-hackage.patch
+++ b/.github/workflows/haskell-ci-hackage.patch
@@ -45,12 +45,12 @@ set in GitHub repository secrets.
            - compiler: ghc-8.10.7
              compilerKind: ghc
              compilerVersion: 8.10.7
-@@ -240,8 +240,80 @@
+@@ -209,8 +217,80 @@
            ${CABAL} -vnormal check
        - name: haddock
          run: |
--          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
-+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH --haddock-for-hackage --builddir $GITHUB_WORKSPACE/haddock all
+-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
++          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH --haddock-for-hackage --builddir $GITHUB_WORKSPACE/haddock all
        - name: unconstrained build
          run: |
            rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -35,9 +35,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.2.2
+          - compiler: ghc-9.4.2
             compilerKind: ghc
-            compilerVersion: 9.2.2
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -245,7 +245,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH --haddock-for-hackage --builddir $GITHUB_WORKSPACE/haddock all
+          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH --haddock-for-hackage --builddir $GITHUB_WORKSPACE/haddock all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v13
+        uses: cachix/install-nix-action@v18
         with:
           install_url: https://nixos-nix-install-tests.cachix.org/serve/i6laym9jw3wg9mw6ncyrk6gjx4l34vvx/install
           install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -20,7 +20,7 @@ jobs:
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         # "nix build" builds with full optimization and includes a profiling
         # build, so just the build of xmonad-contrib itself takes 3 minutes.

--- a/.github/workflows/packdeps.yml
+++ b/.github/workflows/packdeps.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Haskell
         uses: haskell/actions/setup@v1
         with:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare apt sources
         run: |
@@ -59,13 +59,13 @@ jobs:
           date +date=1-%Y-%m >> $GITHUB_OUTPUT
 
       - name: Cache Haskell package metadata
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.stack/pantry
           key: stack-pantry-${{ runner.os }}-${{ steps.cache-date.outputs.date }}
 
       - name: Cache Haskell dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.stack/*

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -12,26 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - resolver: lts-12
-            ghc: 8.4.4
+          - resolver: lts-12  # GHC 8.4
             yaml: stack.yaml
-          - resolver: lts-12
-            ghc: 8.4.4
+          - resolver: lts-12  # GHC 8.4
             yaml: stack-master.yaml
-          - resolver: lts-14
-            ghc: 8.6.5
+          - resolver: lts-14  # GHC 8.6
             yaml: stack-master.yaml
-          - resolver: lts-16
-            ghc: 8.8.4
+          - resolver: lts-16  # GHC 8.8
             yaml: stack-master.yaml
-          - resolver: lts-18
-            ghc: 8.10.7
+          - resolver: lts-18  # GHC 8.10
             yaml: stack-master.yaml
-          - resolver: lts-19
-            ghc: 9.0.2
+          - resolver: lts-19  # GHC 9.0
             yaml: stack.yaml
-          - resolver: lts-19
-            ghc: 9.0.2
+          - resolver: lts-19  # GHC 9.0
             yaml: stack-master.yaml
 
     steps:
@@ -55,14 +48,6 @@ jobs:
             libxrandr-dev \
             libxss-dev \
             #
-
-      - name: Install GHC
-        # use system ghc (if available) in stack, don't waste GH Actions cache space
-        continue-on-error: true
-        run: |
-          set -ex
-          sudo apt install -y ghc-${{ matrix.ghc }}
-          echo /opt/ghc/${{ matrix.ghc }}/bin >> $GITHUB_PATH
 
       - name: Refresh caches once a month
         id: cache-date

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -71,7 +71,7 @@ jobs:
         # date is prefixed with an epoch number to let us manually refresh the
         # cache when needed. This is a workaround for https://github.com/actions/cache/issues/2
         run: |
-          echo "::set-output name=date::1-$(date +%Y-%m)"
+          date +date=1-%Y-%m >> $GITHUB_OUTPUT
 
       - name: Cache Haskell package metadata
         uses: actions/cache@v2

--- a/XMonad/Layout/Groups/Examples.hs
+++ b/XMonad/Layout/Groups/Examples.hs
@@ -1,5 +1,8 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-{-# LANGUAGE MultiParamTypeClasses, Rank2Types, TypeFamilies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -----------------------------------------------------------------------------
 -- |

--- a/XMonad/Util/Parser.hs
+++ b/XMonad/Util/Parser.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE TypeOperators              #-}
 --------------------------------------------------------------------
 -- |
 -- Module      : XMonad.Util.Parser

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -14,3 +14,6 @@ raw-project
   package xmonad-contrib
     flags: +pedantic
     ghc-options: -j
+
+-- avoid --haddock-all which overwrites *-docs.tar.gz with tests docs
+haddock-components: libs

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -38,7 +38,7 @@ cabal-version:      1.12
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.2
+tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.4 || == 9.4.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
### Description

* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ related changes
* drop usage of HVR's unmaintained apt repo
* test with GHC 9.4

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] **N/A** I've considered how to best test these changes (property, unit, manually, ...) and concluded: testing the tests is overkill here

  - [X] **N/A** I updated the `CHANGES.md` file
