### PR TITLE
Drop GHC 8.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -66,11 +66,6 @@ jobs:
             compilerVersion: 8.6.5
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.4.4
-            compilerKind: ghc
-            compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20221009
+# version: 0.15.202211107
 #
-# REGENDATA ("0.15.20221009",["github","cabal.project"])
+# REGENDATA ("0.15.202211107",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -40,9 +40,9 @@ jobs:
             compilerVersion: 9.4.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.4
+          - compiler: ghc-9.2.5
             compilerKind: ghc
-            compilerVersion: 9.2.4
+            compilerVersion: 9.2.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -12,10 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - resolver: lts-12  # GHC 8.4
+          - resolver: lts-14  # GHC 8.6
             yaml: stack.yaml
-          - resolver: lts-12  # GHC 8.4
-            yaml: stack-master.yaml
           - resolver: lts-14  # GHC 8.6
             yaml: stack-master.yaml
           - resolver: lts-16  # GHC 8.8

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -23,8 +23,10 @@ jobs:
           - resolver: lts-18  # GHC 8.10
             yaml: stack-master.yaml
           - resolver: lts-19  # GHC 9.0
+            yaml: stack-master.yaml
+          - resolver: lts-20  # GHC 9.2
             yaml: stack.yaml
-          - resolver: lts-19  # GHC 9.0
+          - resolver: lts-20  # GHC 9.2
             yaml: stack-master.yaml
 
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+  * Dropped support for GHC 8.4.
+
   * `XMonad.Util.ExclusiveScratchpads`
 
     - Deprecated the module in favour of the (new) exclusive scratchpad

--- a/XMonad/Hooks/WorkspaceHistory.hs
+++ b/XMonad/Hooks/WorkspaceHistory.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingVia #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Hooks.WorkspaceHistory
@@ -63,14 +64,9 @@ import qualified XMonad.Util.ExtensibleState as XS
 newtype WorkspaceHistory = WorkspaceHistory
   { history :: [(ScreenId, WorkspaceId)] -- ^ Workspace Screens in
                                          -- reverse-chronological order.
-  } deriving (Read, Show)
-
--- @ScreenId@ is not an instance of NFData, but is a newtype on @Int@. @seq@
--- is enough for forcing it. This requires us to provide an instance.
-instance NFData WorkspaceHistory where
-  rnf (WorkspaceHistory hist) =
-    let go = liftRnf2 rwhnf rwhnf
-    in liftRnf go hist
+  }
+  deriving (Read, Show)
+  deriving NFData via [(Int, WorkspaceId)]
 
 instance ExtensionClass WorkspaceHistory where
     initialValue = WorkspaceHistory []

--- a/XMonad/Layout/Mosaic.hs
+++ b/XMonad/Layout/Mosaic.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, PatternGuards #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternGuards #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Layout.Mosaic
@@ -179,16 +183,7 @@ normalize :: Fractional a => [a] -> [a]
 normalize x = let s = sum x in map (/s) x
 
 data Tree a = Branch (Tree a) (Tree a) | Leaf a | Empty
-
-instance Foldable Tree where
-   foldMap _f Empty = mempty
-   foldMap f (Leaf x) = f x
-   foldMap f (Branch l r) = foldMap f l `mappend` foldMap f r
-
-instance Functor Tree where
-   fmap f (Leaf x) = Leaf $ f x
-   fmap f (Branch l r) = Branch (fmap f l) (fmap f r)
-   fmap _ Empty = Empty
+  deriving (Functor, Show, Foldable)
 
 instance Semigroup (Tree a) where
     Empty <> x = x

--- a/XMonad/Prompt/OrgMode.hs
+++ b/XMonad/Prompt/OrgMode.hs
@@ -67,7 +67,12 @@ import XMonad.Util.XSelection (getSelection)
 import XMonad.Util.Run
 
 import Control.DeepSeq (deepseq)
-import Data.Time (Day (ModifiedJulianDay), NominalDiffTime, UTCTime (utctDay), addUTCTime, defaultTimeLocale, formatTime, fromGregorian, getCurrentTime, iso8601DateFormat, nominalDay, toGregorian)
+import Data.Time (Day (ModifiedJulianDay), NominalDiffTime, UTCTime (utctDay), addUTCTime, fromGregorian, getCurrentTime, nominalDay, toGregorian)
+#if MIN_VERSION_time(1, 9, 0)
+import Data.Time.Format.ISO8601 (iso8601Show)
+#else
+import Data.Time.Format (defaultTimeLocale, formatTime, iso8601DateFormat)
+#endif
 import GHC.Natural (Natural)
 import System.IO (IOMode (AppendMode, ReadMode), hClose, hGetContents, openFile, withFile)
 
@@ -382,7 +387,11 @@ toOrgFmt tod day =
   mconcat ["<", isoDay, " ", take 3 $ show (dayOfWeek day), time, ">"]
  where
   time   :: String = maybe "" ((' ' :) . show) tod
+#if MIN_VERSION_time(1, 9, 0)
+  isoDay :: String = iso8601Show day
+#else
   isoDay :: String = formatTime defaultTimeLocale (iso8601DateFormat Nothing) day
+#endif
 
 -- | Pretty print a 'Date' and an optional time to reflect the actual
 -- date.

--- a/XMonad/Util/PureX.hs
+++ b/XMonad/Util/PureX.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, FlexibleContexts #-}
+{-# LANGUAGE DerivingVia, GeneralizedNewtypeDeriving, FlexibleContexts #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -110,12 +110,7 @@ import Control.Monad.Reader
 -- | The @PureX@ newtype over @ReaderT XConf (State XState) a@.
 newtype PureX a = PureX (ReaderT XConf (State XState) a)
   deriving (Functor, Applicative, Monad, MonadReader XConf, MonadState XState)
-
-instance Semigroup a => Semigroup (PureX a) where
-  (<>) = liftA2 (<>)
-
-instance Monoid a => Monoid (PureX a) where
-  mempty  = return mempty
+  deriving (Semigroup, Monoid) via Ap PureX a
 
 -- | The @XLike@ typeclass over monads reading @XConf@ values and tracking
 --   @XState@ state.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # This stack.yaml is used to build xmonad-contrib with released versions
 # of X11 and xmonad
 
-resolver: lts-19.6
+resolver: lts-20.0
 
 packages:
 - ./

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -38,7 +38,7 @@ cabal-version:      1.12
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.2
+tested-with:        GHC == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.2
 
 source-repository head
   type:     git
@@ -79,7 +79,7 @@ library
        ghc-options: -Werror -Wwarn=deprecations -Wwarn=dodgy-imports
 
     -- Keep this in sync with the oldest version in 'tested-with'
-    if impl(ghc > 8.4.4)
+    if impl(ghc > 8.6.5)
        -- don't treat unused-imports warning as errors, they may be necessary
        -- for compatibility with older versions of base (or other deps)
        ghc-options: -Wwarn=unused-imports
@@ -480,7 +480,7 @@ test-suite tests
      ghc-options: -Werror -Wwarn=deprecations -Wwarn=dodgy-imports
 
   -- Keep this in sync with the oldest version in 'tested-with'
-  if impl(ghc > 8.4.4)
+  if impl(ghc > 8.6.5)
      -- don't treat unused-imports warning as errors, they may be necessary
      -- for compatibility with older versions of base (or other deps)
      ghc-options: -Wwarn=unused-imports

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -38,7 +38,7 @@ cabal-version:      1.12
 build-type:         Simple
 bug-reports:        https://github.com/xmonad/xmonad-contrib/issues
 
-tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.4 || == 9.4.2
+tested-with:        GHC == 8.4.4 || == 8.6.5 || == 8.8.4 || == 8.10.7 || == 9.0.2 || == 9.2.5 || == 9.4.2
 
 source-repository head
   type:     git


### PR DESCRIPTION
### Description

Now that Debian has 8.6, it's time to drop 8.4.

Contrib version of https://github.com/xmonad/xmonad/pull/430

#### Commit Summary

##### 0f69215f ci: Update to GHC 9.2.5

+ A new stackage LTS is out with GHC 9.2.5, so test for this.
+ Update the haskell-ci jobs accordingly from 9.2.4.

Many instance declarations can now be derived either by DerivingVia or
GeneralizedNewtypeDeriving.

##### 30d35948 ci: Drop support for GHC 8.4

Debian stable is not on 8.6, which was always our guide as to which GHC
versions we want to support.

##### e744b643 Simplify instance declarations

##### b193fe8d stack: Bump resolver to lts-20.0

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: compiles :)

  - [x] I updated the `CHANGES.md` file