### PR TITLE
EwmhDesktops: Set _NET_WM_ALLOWED_ACTIONS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,13 @@
       `arXiv`, `clojureDocs`, `cratesIo`, `rustStd`, and `zbmath` search
       engines.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - Initialize `_NET_WM_ALLOWED_ACTIONS` on all managed windows.
+
+    - Add `_NET_WM_ACTION_FULLSCREEN` to `_NET_WM_ALLOWED_ACTIONS` when
+      `ewmhFullscreen` is used to enable fullscreen support.
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)


### PR DESCRIPTION
### Description

According to [the "Extended Window Manager Hints" spec](https://specifications.freedesktop.org/wm-spec/latest/ar01s05.html#idm46217732742640
), `_NET_WM_ALLOWED_ACTIONS` is supposed to be set by the Window Manager to indicate to the clients, which operations are supported for a given window.

`EwmhDesktops` was only declaring supported operations on the root window via `_NET_SUPPORTED`, giving a superset of everything it supports.  But individual windows may have different operations.

For now, only `_NET_WM_ACTION_CLOSE` is added to `_NET_WM_ALLOWED_ACTIONS`.  Assuming that other operations, such as movement, resizing, etc. are handled by the layouts.  But it is not fully correct.  For example, it seems perfectly fine to allow floating windows to resize themselves.

`ewmhFullscreen` adds `_NET_WM_ACTION_FULLSCREEN` to `_NET_WM_ALLOWED_ACTIONS` for all managed windows, indicating that windows could request a full screen mode.

TOOD: Ideally, XMonad should remove the `_NET_WM_ALLOWED_ACTIONS` property from all windows when it is restarting or shutting down.  I could not figure out how to do it.

This change also fixes Firefox full screen, as suggested in this bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=1273746#c7

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually

  - [X] I updated the `CHANGES.md` file