### PR TITLE
Change X.L.StateFull semantics for multi-monitor

### DIFF
--- a/XMonad/Layout/StateFull.hs
+++ b/XMonad/Layout/StateFull.hs
@@ -72,12 +72,12 @@ instance LayoutClass l Window => LayoutClass (FocusTracking l) Window where
   description (FocusTracking _ child)
     | chDesc == "Full"  = "StateFull"
     | ' ' `elem` chDesc = "FocusTracking (" ++ chDesc ++ ")"
-    | otherwise           = "FocusTracking " ++ chDesc
+    | otherwise         = "FocusTracking "  ++ chDesc
     where chDesc = description child
 
   runLayout (W.Workspace i (FocusTracking mOldFoc childL) mSt) sr = do
 
-    mRealFoc <- gets (W.peek . windowset)
+    mRealFoc <- gets (W.peek . W.view i . windowset)
     let mGivenFoc = W.focus <$> mSt
         passedMSt = if mRealFoc == mGivenFoc then mSt
                     else (mOldFoc >>= \oF -> findZ (==oF) mSt) <|> mSt


### PR DESCRIPTION
### Description

> The "last true focus" previously tracked by `X.L.StateFull.FocusTracking` was the `WindowSet` focus. With the intention of improving the multi-monitor experience, it now tracks `WindowSpace` focus instead.
> 
> That said, I was actually using two or three monitors when I originally wrote this module, so it may not be mere oversight—I have a vague feeling I used the `WindowSet` focus for a reason. If so, that reason is lost to oblivion; we'll have to rediscover it.

This change is a bit too trivial for a PR, but on account of the above, I thought I'd give others the chance to have a look at it before merging.

N.B.: Due to the variety of related messes I've collected in my local xmonad/-contrib branches and config, it's currently a PITA to test anything, so I haven't.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: ... the CI passes.

  - [ ] I updated the `CHANGES.md` file
      - Subtle behavioural changes do not merit changelog entries.
