### PR TITLE
fix EWMH titles

### DIFF
--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -107,8 +107,7 @@ debugWindow w =  do
 getEWMHTitle       :: String -> Window -> X String
 getEWMHTitle sub w =  do
   a <- getAtom $ "_NET_WM_" ++ (if null sub then "" else '_':sub) ++ "_NAME"
-  (Just t) <- withDisplay $ \d -> io $ getWindowProperty32 d a w
-  return $ map (toEnum . fromEnum) t
+  getDecodedStringProp w a -- should always be UTF8_STRING but rules are made to be broken
 
 getICCCMTitle   :: Window -> X String
 getICCCMTitle w =  getDecodedStringProp w wM_NAME
@@ -116,7 +115,7 @@ getICCCMTitle w =  getDecodedStringProp w wM_NAME
 getDecodedStringProp     :: Window -> Atom -> X String
 getDecodedStringProp w a =  do
   t@(TextProperty t' _ 8 _) <- withDisplay $ \d -> io $ getTextProperty d w a
-  [s] <- catchX' (tryUTF8     t) $
+  [s] <- catchX' (tryUTF8     t) $ -- shouldn't happen but some apps do it
          catchX' (tryCompound t) $
          io ((:[]) <$> peekCString t')
   return s


### PR DESCRIPTION
I have no idea what I was thinking when I wrote that code. While at it, just reused the code for ICCCM title which already assumes the client may have broken the rules (I think we have seen a case of `WM_NAME` being `UTF8_STRING`).

### Description

Rewrite `_NET_WM_NAME` handling to correctly process it as a `UTF8_STRING` property.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: must be done manually

  - [ ] I updated the `CHANGES.md` file — not needed
