### PR TITLE
remove references to `baseConfig`

### DIFF
--- a/XMonad/Hooks/OnPropertyChange.hs
+++ b/XMonad/Hooks/OnPropertyChange.hs
@@ -65,7 +65,7 @@ import XMonad.Prelude
 --
 -- >  main = xmonad $ def
 -- >      { ...
--- >      , handleEventHook = onXPropertyChange "WM_NAME" myDynamicManageHook <> handleEventHook baseConfig
+-- >      , handleEventHook = onXPropertyChange "WM_NAME" myDynamicManageHook
 -- >      , ...
 -- >      }
 --
@@ -88,7 +88,7 @@ import XMonad.Prelude
 --
 -- >  main = xmonad $ def
 -- >      { ...
--- >      , handleEventHook = onXPropertyChange "WM_NAME" myDynHook <> handleEventHook baseConfig
+-- >      , handleEventHook = onXPropertyChange "WM_NAME" myDynHook
 -- >      , ...
 -- >      }
 -- >


### PR DESCRIPTION
### Description

that's from my private config and has no referent here
fixes: #786 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: doc change

  - [ ] I updated the `CHANGES.md` file — not needed
