### PR TITLE
Add EWMH configuration to not set _NET_DESKTOP_VIEWPORT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -144,6 +144,13 @@
     - Fixed an issue where the bottom right window would not respond to
       `MirrorShrink` and `MirrorExpand` messages.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - Added `disableEwmhManageDesktopViewport` to avoid setting the
+      `_NET_DESKTOP_VIEWPORT` property, as it can lead to issues with
+      some status bars (see this
+      [polybar issue](https://github.com/polybar/polybar/issues/2603)).
+
 ### Other changes
 
 ## 0.17.1 (September 3, 2022)


### PR DESCRIPTION
This information is picked up by polybar's xworkspaces module and used
to re-group the workspaces by monitor. I (and others) find this super
confusing, but polybar doesn't not seem open to addressing it.

https://github.com/polybar/polybar/issues/2603

Opting in to the old behavior of not managing this property is one way
to work around it instead.
