### PR TITLE
X.U.EZConfig: Add remapKeysP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Util.EZConfig`
+
+    - Added `remapKeysP`, which remaps keybindings from one binding to
+      another.
+
   * `XMonad.Util.NamedScratchpad`
 
     - Added `addExclusives`, `resetFocusedNSP`, `setNoexclusive`,


### PR DESCRIPTION
This was discussed on IRC, and I thought it'd be a neat addition.

The obvious caveat (also mentioned in the documentation) is that this does not work for submap keys, as these are not transparently bound.  One could provide something like

``` haskell
additionalRemapKeysP :: [(String, String)] -> [(String, X ())] -> XConfig l -> XConfig l
```

which could sort of slurp some keys from the second argument, but this seems a bit patchworky to me, so I've left it at `remapKeysP` for now.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually tested this; don't think we can easily write property test for this.

  - [x] I updated the `CHANGES.md` file