### PR TITLE
X.U.NamedActions: Do not discard all keybindings in addDescrKeys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -173,7 +173,13 @@
       [polybar issue](https://github.com/polybar/polybar/issues/2603)).
 
   * `XMonad.Hooks.StatusBar`
+
     - Added `startAllStatusBars` to start the configured status bars.
+
+  * `XMonad.Util.NamedActions`
+
+    - Changed `addDescrKeys` and `addDescrKeys'` to not discard the
+      keybindings in the current config.
 
 ### Other changes
 

--- a/XMonad/Util/NamedActions.hs
+++ b/XMonad/Util/NamedActions.hs
@@ -205,7 +205,7 @@ addDescrKeys' :: (HasName b) =>
 addDescrKeys' (k,f) ks conf =
     let shk l = f $ [(k,f $ ks l)] ^++^ ks l
         keylist l = M.map getAction $ M.fromList $ ks l ^++^ [(k, shk l)]
-    in conf { keys = keylist }
+     in conf { keys = keylist <> keys conf }
 
 -- | A version of the default keys from the default configuration, but with
 -- 'NamedAction'  instead of @X ()@


### PR DESCRIPTION
Discarding keybindings may yield unintended behaviour when keybindings are added via combinators, instead of the `keys` field.  This makes the
combinators noncommutative, which is very counterintuitive.

Related: https://old.reddit.com/r/xmonad/comments/10g1v1r/deftogglestrutskey_not_working/

---

This is a PR because I don't use NamedActions and, though I've verified that this doesn't immediately break things with the simplest config, someone else should look at ti

---

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested manually; seems to do the trick.

  - [x] I updated the `CHANGES.md` file