### PR TITLE
`dynamicLogString` forces its result and recovers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,12 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Hooks.StatusBar.PP`
+
+    - `dynamicLogString` now forces its result and produces an error string if
+      it throws an exception. Use `dynamicLogString'` if for some reason you
+      need the old behavior.
+
   * `XMonad.Util.EZConfig`
 
     - Added `remapKeysP`, which remaps keybindings from one binding to


### PR DESCRIPTION
### Description

Originally, `dynamicLogString` could have a bottom hidden in it and thereby crash the `logHook`. Under some circumstances (see #801) this could cause xmonad to get stuck. We now force the result, and `dynamicLogString` catches the exception and substitutes a message (currently `"_|_"`). Use `dynamicLogString'` for the old behavior.

Closes: #801 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested manually

  - [x] I updated the `CHANGES.md` file
