### PR TITLE
Put a cap on window names

### DIFF
--- a/XMonad/Layout/Decoration.hs
+++ b/XMonad/Layout/Decoration.hs
@@ -400,7 +400,11 @@ updateDecos s t f = mapM_ $ updateDeco s t f
 -- structure and the needed 'Rectangle's
 updateDeco :: Shrinker s => s -> Theme -> XMonadFont -> (OrigWin,DecoWin) -> X ()
 updateDeco sh t fs ((w,_),(Just dw,Just (Rectangle _ _ wh ht))) = do
-  nw  <- getName w
+  -- xmonad-contrib #809
+  -- qutebrowser will happily shovel a 389K multiline string into @_NET_WM_NAME@
+  -- and the 'defaultShrinker' (a) doesn't handle multiline strings well (b) is
+  -- quadratic due to using 'init'
+  nw  <- fmap (take 2048 . takeWhile (/= '\n') . show) (getName w)
   ur  <- readUrgents
   dpy <- asks display
   let focusColor win ic ac uc = maybe ic (\focusw -> case () of
@@ -414,7 +418,7 @@ updateDeco sh t fs ((w,_),(Just dw,Just (Rectangle _ _ wh ht))) = do
                  (urgentColor   t, urgentBorderColor   t, urgentBorderWidth   t, urgentTextColor   t)
   let s = shrinkIt sh
   name <- shrinkWhile s (\n -> do size <- io $ textWidthXMF dpy fs n
-                                  return $ size > fromIntegral wh - fromIntegral (ht `div` 2)) (show nw)
+                                  return $ size > fromIntegral wh - fromIntegral (ht `div` 2)) nw
   let als = AlignCenter : map snd (windowTitleAddons t)
       strs = name : map fst (windowTitleAddons t)
       i_als = map snd (windowTitleIcons t)


### PR DESCRIPTION
### Description

It turns out qutebrowser will place an entire `data:` URL in `_NET_WM_NAME`, up to at least 389K characters including newlines and possibly binary characters.

Clamping window titles to the first line, and to 2K chars because `defaultShrinker` is quadratic in the title length.

Closes #809 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested in my harness

  - [ ] I updated the `CHANGES.md` file — shouldn't be necessary
