### PR TITLE
add `_NET_WM_STRUT_PARTIAL` to `_NET_SUPPORTED`

### DIFF
--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -593,6 +593,7 @@ setSupported = withDisplay $ \dpy -> do
                          ,"_NET_ACTIVE_WINDOW"
                          ,"_NET_WM_DESKTOP"
                          ,"_NET_WM_STRUT"
+                         ,"_NET_WM_STRUT_PARTIAL"
                          ,"_NET_DESKTOP_VIEWPORT"
                          ]
     io $ changeProperty32 dpy r a aTOM propModeReplace (fmap fromIntegral supp)


### PR DESCRIPTION
### Description

For docks that don't support `_NET_WM_STRUT` any more,
notably `xfce4-panel`.

Closes #808

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually

  - [ ] I updated the `CHANGES.md` file: n/a
