### PR TITLE
fix double decode in `debugWindow`

### DIFF
--- a/XMonad/Util/DebugWindow.hs
+++ b/XMonad/Util/DebugWindow.hs
@@ -124,7 +124,7 @@ tryUTF8                          :: TextProperty -> X [String]
 tryUTF8 (TextProperty s enc _ _) =  do
   uTF8_STRING <- getAtom "UTF8_STRING"
   when (enc /= uTF8_STRING) $ error "String is not UTF8_STRING"
-  map decodeString . splitNul <$> io (peekCString s)
+  map decodeString . splitNul <$> io (peekCAString s)
 
 tryCompound                            :: TextProperty -> X [String]
 tryCompound t@(TextProperty _ enc _ _) =  do


### PR DESCRIPTION
### Description

At some point `peekCString` became locale aware. This is a double bug, since (a) `decodeString` was being applied to the result and (b) the locale might not be UTF-8, but the string being decoded always is.

The fix is to use `peekCAString` which bypasses the locale decode, then continuing to do UTF-8 decode.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested locally

  - [ ] I updated the `CHANGES.md` file: N/A
