### PR TITLE
Export 'Mag' and 'Toggle' from Magnifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -120,8 +120,8 @@
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Layout.Magnifier`
-    - Added `Toggle(..)` and changed `Magnifier` to `Magnifier(..)` in the exports
-      for Magnifier.hs, to allow for custom horizontal and vertical sizes for magnifiers.
+    - Exposed `Toggle(..)` and the `Mag` constructor, to allow for custom
+      horizontal and vertical sizes for magnifiers.
 
   * `XMonad.Util.Loggers`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,10 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Layout.Magnifier`
+    - Added `Toggle(..)` and changed `Magnifier` to `Magnifier(..)` in the exports
+      for Magnifier.hs, to allow for custom horizontal and vertical sizes for magnifiers.
+
   * `XMonad.Util.Loggers`
 
     - Added `logClassname`, `logClassnames`, `logClassnames'`,

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -43,7 +43,8 @@ module XMonad.Layout.Magnifier
       -- * Messages and Types
       MagnifyMsg (..),
       MagnifyThis(..),
-      Magnifier,
+      Magnifier(..),
+      Toggle(..),
     ) where
 
 import Numeric.Natural (Natural)


### PR DESCRIPTION
### Description

Include a description for your changes, including the motivation
behind them.

I've made XMonad.Layout.Magnifier export All constructors under 'Magnifier' and 'Toggle', so that it is possible to make custom magnifiers, with control over size both horizontally and vertically.

Example:
```hs
-- maximizeVertical defaulting to On instead of Off
custommaximizeVertical :: l a -> ModifiedLayout Magnifier l a
custommaximizeVertical = ModifiedLayout (Mag 1 (1, 1000) On (AllWins 1))
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: This works exactly how I want it to work

  - [x] I updated the `CHANGES.md` file