### PR TITLE
Add magnifiyxy combinator to XMonad.Layout.Magnifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,13 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Layout.Magnifier`
+
+    - Added `magnifyxy` to allow for different magnification in the
+      horizontal and vertical directions. Added `magnifierxy`,
+      `magnifierxy'`, `magnifierxyOff`, and `magnifierxyOff'` as
+      particular combinators.
+
   * `XMonad.Util.Loggers`
 
     - Added `logClassname`, `logClassnames`, `logClassnames'`,

--- a/XMonad/Layout/Magnifier.hs
+++ b/XMonad/Layout/Magnifier.hs
@@ -26,12 +26,15 @@ module XMonad.Layout.Magnifier
 
       -- * General combinators
       magnify,
+      magnifyxy,
 
       -- * Magnify Everything
       magnifier,
       magnifierOff,
       magnifiercz,
       magnifierczOff,
+      magnifierxy,
+      magnifierxyOff,
       maxMagnifierOff,
       maximizeVertical,
 
@@ -39,6 +42,8 @@ module XMonad.Layout.Magnifier
       magnifier',
       magnifiercz',
       magnifierczOff',
+      magnifierxy',
+      magnifierxyOff',
 
       -- * Messages and Types
       MagnifyMsg (..),
@@ -66,11 +71,11 @@ import XMonad.StackSet
 --
 -- By default 'magnifier' increases the focused window's size by @1.5@.
 --
--- You can also use @'magnifiercz' 1.2@ to use a custom level of
--- magnification.  You can even make the focused window smaller for a
--- pop in effect.  There's also the possibility of starting out not
--- magnifying anything at all ('magnifierOff'); see below for ways to
--- toggle this on while in use.
+-- You can also use @'magnifiercz' 1.2@ or @'magnifierxy' 1 1000@ to use
+-- a custom level of magnification. You can even make the focused window
+-- smaller for a pop in effect. There's also the possibility of starting
+-- out not magnifying anything at all ('magnifierOff'); see below for
+-- ways to toggle this on while in use.
 --
 -- The most general combinator available is 'magnify'—all of the other
 -- functions in this module are essentially just creative applications
@@ -116,8 +121,22 @@ magnify
                     --   (@True@) or off (@False@)
     -> l a          -- ^ Input layout
     -> ModifiedLayout Magnifier l a
-magnify cz mt start = ModifiedLayout $
-    Mag 1 (fromRational cz, fromRational cz) (bool Off On start) mt
+magnify cz = magnifyxy cz cz
+
+-- | Like 'magnify', but with the ability to specify different amounts
+-- of horizontal and vertical magnification.
+--
+-- >>> magnifyxy 1.3 1.6 (NoMaster 1) True
+magnifyxy
+    :: Rational      -- ^ Amount to magnify horizontally
+    -> Rational      -- ^ Amount to magnify vertically
+    -> MagnifyThis   -- ^ What to magnify
+    -> Bool          -- ^ Whether magnification should start out on
+                     --   (@True@) or off (@False@)
+    -> l a           -- ^ Input layout
+    -> ModifiedLayout Magnifier l a
+magnifyxy cx cy mt start = ModifiedLayout $
+    Mag 1 (fromRational cx, fromRational cy) (bool Off On start) mt
 
 -- | Increase the size of the window that has focus
 magnifier :: l a -> ModifiedLayout Magnifier l a
@@ -137,6 +156,24 @@ magnifier' = magnifiercz' 1.5
 magnifiercz' :: Rational -> l a -> ModifiedLayout Magnifier l a
 magnifiercz' cz = magnify cz (NoMaster 1) True
 
+-- | Increase the size of the window that has focus by a custom zoom in
+-- both directions.
+magnifierxy :: Rational -> Rational -> l a -> ModifiedLayout Magnifier l a
+magnifierxy cx cy = magnifyxy cx cy (AllWins 1) True
+
+-- | Like 'magnifierxy', but default to @Off@.
+magnifierxyOff :: Rational -> Rational -> l a -> ModifiedLayout Magnifier l a
+magnifierxyOff cx cy = magnifyxy cx cy (AllWins 1) False
+
+-- | Increase the size of the window that has focus by a custom zoom in
+-- both directions, unless it is one of the master windows.
+magnifierxy' :: Rational -> Rational -> l a -> ModifiedLayout Magnifier l a
+magnifierxy' cx cy = magnifyxy cx cy (NoMaster 1) True
+
+-- | Like 'magnifierxy'', but defaults to @Off@.
+magnifierxyOff' :: Rational -> Rational -> l a -> ModifiedLayout Magnifier l a
+magnifierxyOff' cx cy = magnifyxy cx cy (NoMaster 1) False
+
 -- | Magnifier that defaults to Off
 magnifierOff :: l a -> ModifiedLayout Magnifier l a
 magnifierOff = magnifierczOff 1.5
@@ -154,7 +191,8 @@ magnifierczOff cz = magnify cz (AllWins 1) False
 magnifierczOff' :: Rational -> l a -> ModifiedLayout Magnifier l a
 magnifierczOff' cz = magnify cz (NoMaster 1) False
 
--- | A magnifier that greatly magnifies just the vertical direction
+-- | A magnifier that greatly magnifies just the vertical direction;
+-- defaults to @Off@.
 maximizeVertical :: l a -> ModifiedLayout Magnifier l a
 maximizeVertical = ModifiedLayout (Mag 1 (1, 1000) Off (AllWins 1))
 


### PR DESCRIPTION
### Description

Include a description for your changes, including the motivation
behind them.

I've added another general combinator to XMonad.Layout.Magnifier, that allows setting up custom size both horizontally and vertically. `magnifyxy` is the new combinator, and the new implementations of magnifiers are `magnifierxy`, `magnifierxy'`, `magnifierxyOff`, and `magnifierxyOff'`.

Not sure if I am 100% on the names of the combinators.

This was mostly done to make it possible to make a `maximizeVertical` that defaults to `On`.
```hs
magnifierxy 1 1000 (Tall 1 (3/100) (1/2))
```

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: The combinators work, and the MagnifyMore+MagnifyLess keybinds still work with magnifierxy.

  - [x] I updated the `CHANGES.md` file
