### PR TITLE
X.Prelude: Compatibility with base-4.18.0.0

### DIFF
--- a/XMonad/Prelude.hs
+++ b/XMonad/Prelude.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-dodgy-imports #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -47,8 +48,8 @@ import Data.Bool           as Exports
 import Data.Char           as Exports
 import Data.Foldable       as Exports
 import Data.Function       as Exports
-import Data.Functor        as Exports
-import Data.List           as Exports
+import Data.Functor        as Exports hiding (unzip)
+import Data.List           as Exports hiding ((!?))
 import Data.Maybe          as Exports
 import Data.Monoid         as Exports
 import Data.Traversable    as Exports


### PR DESCRIPTION
Will ship with GHC 9.8.

Fixes: https://github.com/xmonad/xmonad-contrib/issues/826

@geekosaur: Could you send me the warnings that are generated due to `-Wx-partial`? I'd like to fix at least *some* of them.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: That's what this PR is for :)

  - [n/a] I updated the `CHANGES.md` file