### PR TITLE
XMonad.actions.search: Add NixOS and home-manager searchEngines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,10 +207,10 @@
 
   * `XMonad.Actions.Search`
 
-    - Added `aur`, `flora`, `ncatlab`, `protondb`, `rosettacode`,
-      `sourcehut`, `steam`, `voidpgks_x86_64`, `voidpgks_x86_64_musl`,
-      `arXiv`, `clojureDocs`, `cratesIo`, `rustStd`, `noogle`, and
-      `zbmath` search engines.
+    - Added `aur`, `flora`, `ncatlab`, `protondb`, `rosettacode`, `sourcehut`,
+      `steam`, `voidpgks_x86_64`, `voidpgks_x86_64_musl`, `arXiv`,
+      `clojureDocs`, `cratesIo`, `rustStd`, `noogle`, `nixos`, `homeManager`,
+      and `zbmath` search engines.
 
   * `XMonad.Layout.ResizableThreeColumns`
 

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -55,6 +55,7 @@ module XMonad.Actions.Search (   -- * Usage
                                  maps,
                                  mathworld,
                                  ncatlab,
+                                 nixos,
                                  noogle,
                                  openstreetmap,
                                  protondb,
@@ -164,6 +165,8 @@ import           XMonad.Util.XSelection   (getSelection)
 * 'mathworld' -- Wolfram MathWorld search.
 
 * 'ncatlab' -- Higer Algebra, Homotopy and Category Theory Wiki.
+
+* 'nixos' -- Search NixOS packages and options.
 
 * 'noogle' -- 'hoogle'-like Nix API search engine.
 
@@ -336,7 +339,7 @@ searchEngineF = SearchEngine
 alpha, amazon, arXiv, aur, clojureDocs, codesearch, cratesIo, deb, debbts, debpts, dictionary, duckduckgo, ebay, flora,
   github, google, hackage, hoogle, images, imdb, lucky, maps, mathworld, ncatlab, openstreetmap, protondb, rosettacode, rustStd,
   scholar, sourcehut, stackage, steam, thesaurus, vocabulary, voidpgks_x86_64, voidpgks_x86_64_musl, wayback, wikipedia, wiktionary,
-  youtube, zbmath, noogle :: SearchEngine
+  youtube, zbmath, nixos, noogle :: SearchEngine
 alpha         = searchEngine "alpha"         "https://www.wolframalpha.com/input/?i="
 amazon        = searchEngine "amazon"        "https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords="
 arXiv         = searchEngineF "arXiv"        (\s -> "https://arxiv.org/search/?query=" <> s <> "&searchtype=all")
@@ -361,6 +364,7 @@ lucky         = searchEngine "lucky"         "https://www.google.com/search?btnI
 maps          = searchEngine "maps"          "https://maps.google.com/maps?q="
 mathworld     = searchEngine "mathworld"     "https://mathworld.wolfram.com/search/?query="
 ncatlab       = searchEngine "ncatlab"       "https://ncatlab.org/nlab/search?query="
+nixos         = searchEngine "nixos"         "https://search.nixos.org/packages?channel=unstable&from=0&size=200&sort=relevance&type=packages&query="
 noogle        = searchEngineF "noogle"       (\s -> "https://noogle.dev/?search=" <> s <> "&page=1&to=any&from=any")
 openstreetmap = searchEngine "openstreetmap" "https://www.openstreetmap.org/search?query="
 protondb      = searchEngine "protondb"      "https://www.protondb.com/search?q="

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -340,9 +340,9 @@ searchEngineF = SearchEngine
 
 -- The engines.
 alpha, amazon, arXiv, aur, clojureDocs, codesearch, cratesIo, deb, debbts, debpts, dictionary, duckduckgo, ebay, flora,
-  github, google, hackage, homeManager, hoogle, images, imdb, lucky, maps, mathworld, ncatlab, openstreetmap, protondb, rosettacode, rustStd,
-  scholar, sourcehut, stackage, steam, thesaurus, vocabulary, voidpgks_x86_64, voidpgks_x86_64_musl, wayback, wikipedia, wiktionary,
-  youtube, zbmath, nixos, noogle :: SearchEngine
+  github, google, hackage, homeManager, hoogle, images, imdb, lucky, maps, mathworld, ncatlab, nixos, noogle, openstreetmap, protondb, 
+  rosettacode, rustStd, scholar, sourcehut, stackage, steam, thesaurus, vocabulary, voidpgks_x86_64, voidpgks_x86_64_musl, wayback, 
+  wikipedia, wiktionary, youtube, zbmath :: SearchEngine
 alpha         = searchEngine "alpha"         "https://www.wolframalpha.com/input/?i="
 amazon        = searchEngine "amazon"        "https://www.amazon.com/s/ref=nb_sb_noss_2?url=search-alias%3Daps&field-keywords="
 arXiv         = searchEngineF "arXiv"        (\s -> "https://arxiv.org/search/?query=" <> s <> "&searchtype=all")

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -48,6 +48,7 @@ module XMonad.Actions.Search (   -- * Usage
                                  github,
                                  google,
                                  hackage,
+                                 homeManager,
                                  hoogle,
                                  images,
                                  imdb,
@@ -151,6 +152,8 @@ import           XMonad.Util.XSelection   (getSelection)
 * 'google' -- basic Google search.
 
 * 'hackage' -- Hackage, the Haskell package database.
+
+* 'homeManager' -- Search Nix's home-manager's options.
 
 * 'hoogle' -- Hoogle, the Haskell libraries API search engine.
 
@@ -337,7 +340,7 @@ searchEngineF = SearchEngine
 
 -- The engines.
 alpha, amazon, arXiv, aur, clojureDocs, codesearch, cratesIo, deb, debbts, debpts, dictionary, duckduckgo, ebay, flora,
-  github, google, hackage, hoogle, images, imdb, lucky, maps, mathworld, ncatlab, openstreetmap, protondb, rosettacode, rustStd,
+  github, google, hackage, homeManager, hoogle, images, imdb, lucky, maps, mathworld, ncatlab, openstreetmap, protondb, rosettacode, rustStd,
   scholar, sourcehut, stackage, steam, thesaurus, vocabulary, voidpgks_x86_64, voidpgks_x86_64_musl, wayback, wikipedia, wiktionary,
   youtube, zbmath, nixos, noogle :: SearchEngine
 alpha         = searchEngine "alpha"         "https://www.wolframalpha.com/input/?i="
@@ -357,6 +360,7 @@ flora         = searchEngine "flora"         "https://flora.pm/search?q="
 github        = searchEngine "github"        "https://github.com/search?q="
 google        = searchEngine "google"        "https://www.google.com/search?q="
 hackage       = searchEngine "hackage"       "https://hackage.haskell.org/package/"
+homeManager   = searchEngine "homeManager"   "https://mipmip.github.io/home-manager-option-search/?query="
 hoogle        = searchEngine "hoogle"        "https://hoogle.haskell.org/?hoogle="
 images        = searchEngine "images"        "https://images.google.fr/images?q="
 imdb          = searchEngine "imdb"          "https://www.imdb.com/find?s=all&q="


### PR DESCRIPTION
- feat(search): add nixos as searchEngine
- feat(search): add homeManager as searchEngine

### Description

(I've only skimmed contributing and docs, and haven't tested this, which I will ofc do before changing from draft)

Include a description for your changes, including the motivation
behind them.

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: not necessary here, e.g. some other individual search engine entries don't seem to get tested.

  - [x] I updated the `CHANGES.md` file
