### PR TITLE
X.Prompt: Allow for backwards cycling of completions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -243,6 +243,10 @@
     - The `emacsLikeXPKeymap` and `vimLikeXPKeymap` keymaps now treat
       `C-m` the same as `Return`.
 
+    - Added `prevCompletionKey` to `XPConfig`, facilitating the ability
+      to cycle through the completions backwards. This is bound to
+      `S-<TAB>` by default.
+
   * `XMonad.Actions.Prefix`
 
     - Added `orIfPrefixed`, a combinator to decide upon an action based


### PR DESCRIPTION
Fixes: https://github.com/xmonad/xmonad-contrib/issues/831

+ Add a new `prevCompletionKey` to `XPConfig`, in order to cycle backwards.
  Bound to `S-<Tab>` by default.

+ Already handle null keystrings (times when only a modifier was
  pressed) in `handleMain`, such that completions aren't cleared
  prematurely.

+ Augment `nextComplIndex` (now `computeComplIndex`) with the ability to go
  in an arbitrary 1-dimensional direction. As a result, that function,
  as well as `handleCompletion` and `handleCompletionMain` now take an
  additional `Direction1D` argument.

Based on: https://github.com/solomon-b/xmonad-contrib/tree/feature/scrolling-prompt-completions

Co-authored-by: Solomon Bothwell <ssbothwell@gmail.com>

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually confirmed for this to work, but @l29ah should double check

  - [x] I updated the `CHANGES.md` file