### PR TITLE
X.L.Cross: Deprecate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 
+  * Deprecated `XMonad.Layout.Cross` due to bitrot; refer to
+    `XMonad.Layout.Circle` and `XMonad.Layout.ThreeColumns` for
+    alternatives.
+
   * Deprecated the `XMonad.Layout.StateFull` module and
     `XMonad.Layout.TrackFloating.(t|T)rackFloating` in favour of
     `XMonad.Layout.FocusTracking`.

--- a/XMonad/Layout/Cross.hs
+++ b/XMonad/Layout/Cross.hs
@@ -12,7 +12,7 @@
 --
 -- A Cross Layout with the main window in the center.
 --
-module XMonad.Layout.Cross(
+module XMonad.Layout.Cross {-# DEPRECATED "Use XMonad.Layout.Circle or XMonad.Layout.ThreeColumn.ThreeColMid instead" #-} (
                           -- * Usage
                           -- $usage
                           simpleCross


### PR DESCRIPTION
The module has badly bitrotted, and is in such a state that it's
unlikely anyone is using it currently. Better alternatives exist, so
just deprecating seems appropriate here.

Closes: https://github.com/xmonad/xmonad-contrib/issues/793

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Correctly shows me deprecation warnings

  - [x] I updated the `CHANGES.md` file