### PR TITLE
Add documentation for unicode prompt

### DIFF
--- a/XMonad/Prompt/Unicode.hs
+++ b/XMonad/Prompt/Unicode.hs
@@ -61,6 +61,11 @@ and adding an appropriate keybinding, for example:
 
 >  , ((modm .|. controlMask, xK_u), unicodePrompt "/path/to/unicode-data" def)
 
+A path to a @UnicodeData.txt@ file or equivalent must be provided.  This file
+should be available through your package manager; search for @unicode-data@.
+If no package is found, one may opt to download this file directly from
+[unicode.org](http://www.unicode.org/Public/UNIDATA/UnicodeData.txt).
+
 More flexibility is given by the @mkUnicodePrompt@ function, which takes a
 command and a list of arguments to pass as its first two arguments. See
 @unicodePrompt@ for details.


### PR DESCRIPTION

### Description

This PR adds some additional context regarding the required UnicodeData.txt file needed for the `XMonad.Prompt.Unicode` module.

Closes #840 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: there are only documentation changes; no testing required

  - [ ] I updated the `CHANGES.md` file
