### PR TITLE
deprecate `XMonad.Util.Ungrab`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,9 @@
     - The function `readKeySequence` now returns a non-empty list if it
       succeeded.
 
+  * Deprecate `XMonad.Util.Ungrab`; it was moved to `XMonad.Operations`
+    in core.
+
 ### New Modules
 
   * `XMonad.Layout.CenterMainFluid`

--- a/XMonad/Config/Mate.hs
+++ b/XMonad/Config/Mate.hs
@@ -1,5 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
-
+-- TODO: Remove when we depend on a version of xmonad that has unGrab.
+{-# OPTIONS_GHC -Wno-deprecations  #-}
+{-# OPTIONS_GHC -Wno-dodgy-imports #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module       : XMonad.Config.Mate
@@ -28,15 +30,14 @@ module XMonad.Config.Mate (
     desktopLayoutModifiers
     ) where
 
-import XMonad
-import XMonad.Config.Desktop
-import XMonad.Util.Run (safeSpawn)
-import XMonad.Util.Ungrab
-import XMonad.Prelude (toUpper)
-
+import System.Environment (getEnvironment)
 import qualified Data.Map as M
 
-import System.Environment (getEnvironment)
+import XMonad hiding (unGrab)
+import XMonad.Config.Desktop
+import XMonad.Prelude (toUpper)
+import XMonad.Util.Run (safeSpawn)
+import XMonad.Util.Ungrab (unGrab)
 
 -- $usage
 -- To use this module, start with the following @~\/.xmonad\/xmonad.hs@:

--- a/XMonad/Util/Ungrab.hs
+++ b/XMonad/Util/Ungrab.hs
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Util.Ungrab
+module XMonad.Util.Ungrab {-# DEPRECATED "Use XMonad.Operations.unGrab instead" #-}
     ( -- * Usage:
       -- $usage
       unGrab


### PR DESCRIPTION
### Description

Deprecate `XMonad.Util.Ungrab` as it is going to be moved to `XMonad.Operations` in https://github.com/xmonad/xmonad/pull/479

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Tested manually with a config that uses unGrab and removed the XMonad.Util.Ungrab import.

  - [X] I updated the `CHANGES.md` file
