### PR TITLE
X.L.Renamed: Provide "named" convenience alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,7 +68,8 @@
 
   * `XMonad.Layout.Named`
 
-    - Deprecated the entire module, use `XMonad.Layout.Renamed` instead.
+    - Deprecated the entire module, use `XMonad.Layout.Renamed` (which newly
+      provides `named` for convenience) instead.
 
   * `XMonad.Actions.SinkAll`
 

--- a/XMonad/Layout/Named.hs
+++ b/XMonad/Layout/Named.hs
@@ -44,10 +44,6 @@ import XMonad.Layout.Renamed
 -- Note that this module has been deprecated and may be removed in a future
 -- release, please use "XMonad.Layout.Renamed" instead.
 
--- | (Deprecated) Rename a layout.
-named :: String -> l a -> ModifiedLayout Rename l a
-named s = renamed [Replace s]
-
 -- | (Deprecated) Remove the first word of the name.
 nameTail :: l a -> ModifiedLayout Rename l a
 nameTail = renamed [CutWordsLeft 1]

--- a/XMonad/Layout/Renamed.hs
+++ b/XMonad/Layout/Renamed.hs
@@ -19,6 +19,7 @@
 module XMonad.Layout.Renamed ( -- * Usage
                                -- $usage
                                renamed
+                             , named
                              , Rename(..) ) where
 
 import XMonad
@@ -39,6 +40,10 @@ import XMonad.Layout.LayoutModifier
 -- | Apply a list of 'Rename' values to a layout, from left to right.
 renamed :: [Rename a] -> l a -> ModifiedLayout Rename l a
 renamed = ModifiedLayout . Chain
+
+-- | Rename a layout. (Convenience alias for @renamed [Replace s]@.)
+named :: String -> l a -> ModifiedLayout Rename l a
+named s = renamed [Replace s]
 
 -- | The available renaming operations
 data Rename a = CutLeft Int -- ^ Remove a number of characters from the left


### PR DESCRIPTION
### Description

I believe this common use-case for the deprecated X.L.Named should still be provided somewhere, rather than telling everybody to let-define this themselves.

The other one – `nameTail` – only has about 6 uses in publicly available configs (https://github.com/search?q=nameTail+path%3Axmonad&type=code), so I'm not adding that one but I'm happy to be convinced to add it too.

Related: 3bf9d80c40b9 ("XMonad.Layout.Named: Deprecate")

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded:
    tested manually locally

  - [X] I updated the `CHANGES.md` file
