### PR TITLE
X.H.{EwmhDesktops,ManageHelpers}: Add _NET_WM_DESKTOP-handling ManageHook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -246,6 +246,10 @@
       `XMonad.Actions.ToggleFullFloat` for a float-restoring implementation of
       fullscreening.
 
+    - Added `ewmhDesktops(Maybe)ManageHook` that places windows in their
+      preferred workspaces. This is useful when restoring a browser session
+      after a restart.
+
   * `XMonad.Hooks.StatusBar`
 
     - Added `startAllStatusBars` to start the configured status bars.

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -52,6 +52,7 @@ module XMonad.Hooks.ManageHelpers (
     isMinimized,
     isDialog,
     pid,
+    desktop,
     transientTo,
     maybeToDefinite,
     MaybeManageHook,
@@ -199,6 +200,15 @@ isDialog = isInProperty "_NET_WM_WINDOW_TYPE" "_NET_WM_WINDOW_TYPE_DIALOG"
 -- See <https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm45623487788432>.
 pid :: Query (Maybe ProcessID)
 pid = ask >>= \w -> liftX $ getProp32s "_NET_WM_PID" w <&> \case
+    Just [x] -> Just (fromIntegral x)
+    _        -> Nothing
+
+-- | This function returns 'Just' the @_NET_WM_DESKTOP@ property for a
+-- particular window if set, 'Nothing' otherwise.
+--
+-- See <https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm46181547492704>.
+desktop :: Query (Maybe Int)
+desktop = ask >>= \w -> liftX $ getProp32s "_NET_WM_DESKTOP" w <&> \case
     Just [x] -> Just (fromIntegral x)
     _        -> Nothing
 


### PR DESCRIPTION
### Description

Useful for restoring browser windows to where they were before restart (which is something one should do several times a week as security updates get released).

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded:
    been running this code for a few days (limited to the browser, as otherwise many apps would jump to the workspace they were last on)

  - [X] I updated the `CHANGES.md` file
