### PR TITLE
X.Prompt: handle Return key in vim normal mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -269,6 +269,9 @@
       to cycle through the completions backwards. This is bound to
       `S-<TAB>` by default.
 
+    - The `vimLikeXPKeymap` now accepts the prompt upon pressing enter
+      in normal mode.
+
   * `XMonad.Actions.Prefix`
 
     - Added `orIfPrefixed`, a combinator to decide upon an action based

--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -1138,6 +1138,8 @@ vimLikeXPKeymap' fromColor promptF pasteFilter notWord = M.fromList $
         , (xK_c,            promptSubmap (setModeDone True) changeVimXPKeymap
                                 >> setModeDone True
           )
+        , (xK_Return,       acceptSelection)
+        , (xK_KP_Enter,     acceptSelection)
         ] ++
         map (first $ (,) shiftMask)
         [ (xK_dollar,       endOfLine >> moveCursor Prev)


### PR DESCRIPTION
### Description

Avoiding RAGE when one can't just use Return key in the normal mode like in vim.

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file