### PR TITLE
Fix minimum widths for Shrink and Expand

### DIFF
--- a/XMonad/Layout/TwoPane.hs
+++ b/XMonad/Layout/TwoPane.hs
@@ -56,8 +56,8 @@ instance LayoutClass TwoPane a where
 
     handleMessage (TwoPane delta split) x =
         return $ case fromMessage x of
-                   Just Shrink -> Just (TwoPane delta (split - delta))
-                   Just Expand -> Just (TwoPane delta (split + delta))
+                   Just Shrink -> Just (TwoPane delta (max 0 (split - delta)))
+                   Just Expand -> Just (TwoPane delta (min 1 (split + delta)))
                    _           -> Nothing
 
     description _ = "TwoPane"

--- a/XMonad/Layout/TwoPanePersistent.hs
+++ b/XMonad/Layout/TwoPanePersistent.hs
@@ -58,8 +58,8 @@ instance (Show a, Eq a) => LayoutClass TwoPanePersistent a where
 
   pureMessage (TwoPanePersistent w delta split) x =
     case fromMessage x of
-      Just Shrink -> Just (TwoPanePersistent w delta (split - delta))
-      Just Expand -> Just (TwoPanePersistent w delta (split + delta))
+      Just Shrink -> Just (TwoPanePersistent w delta (max 0 (split - delta)))
+      Just Expand -> Just (TwoPanePersistent w delta (min 1 (split + delta)))
       _ -> Nothing
 
   description _ = "TwoPanePersistent"


### PR DESCRIPTION
### Description

I went to use the `TwoPane` layout while trying out `xmonad`, and immediately ran into the problem that `Shrink` and `Expand` were shrinking my windows into negative width, which broke `alacritty`.

To investigate the problem, I started reading the `Layout.hs` from `xmonad/xmonad`, and noticed that the `Tall` layout applies a `min` and `max` to the respective widths: 
- https://github.com/xmonad/xmonad/blob/master/src/XMonad/Layout.hs#L77-L78

Applying this same approach to `Shrink` and `Expand` in the `TwoPane` layouts (tested in my own `xmonad.hs`) resolves this problem for me, but I am a beginner to `xmonad` and may be misunderstanding something. :blue_heart: 



### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: writing tests is probably beyond my spare time for now 

  - [ ] I updated the `CHANGES.md` file
