### PR TITLE
Fix Xmonad.Prompt.Input usage example

### DIFF
--- a/XMonad/Prompt/Input.hs
+++ b/XMonad/Prompt/Input.hs
@@ -56,7 +56,7 @@ import XMonad.Prompt
 -- create an autocompleting version, like this:
 --
 -- > firingPrompt' = inputPromptWithCompl def "Fire"
--- >                     (mkComplFunFromList employees) ?+ fireEmployee
+-- >                     (mkComplFunFromList def employees) ?+ fireEmployee
 --
 -- Now all he has to do is add a keybinding to @firingPrompt@ (or
 -- @firingPrompt'@), such as


### PR DESCRIPTION
### Description
Something I noticed when reading the documentation, the `XPConfig` argument is missing from the usage example.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: N/A

  - [ ] I updated the `CHANGES.md` file
