### PR TITLE
XMonad.Prompt: export getCurrentCompletions (and setCurrentCompletions)

### DIFF
--- a/XMonad/Prompt.hs
+++ b/XMonad/Prompt.hs
@@ -62,6 +62,7 @@ module XMonad.Prompt
     , defaultColor, modifyColor, setColor
     , resetColor, setBorderColor
     , modifyPrompter, setPrompter, resetPrompter
+    , selectedCompletion, setCurrentCompletions, getCurrentCompletions
     , moveWord, moveWord', killWord, killWord'
     , changeWord, deleteString
     , moveHistory, setSuccess, setDone, setModeDone


### PR DESCRIPTION
### Description

I am playing with using the key bindings to modify the input, and when trying to change the input to the next [or previous] completion in the currently available completions, I needed `getCurrentCompletions` and `selectedCompletion` to be available.  I have additionally added `setCurrentCompletions`, but if we don't want to export that, I'm happy to remove that from the PR.

I am new to Haskell, maybe I'm missing another way to do this.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: N/A

  - [ ] I updated the `CHANGES.md` file
