### PR TITLE
X.P: Add escape hatch for preventing X.P IO

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,13 @@
        order to lift any existing `IO StatusBarConfig` values into
        `X StatusBarConfig` values.
 
+  * `XMonad.Prompt`
+
+    - Added an additional `XPConfig` argument to `historyCompletion` and
+      `historyCompletionP`. Calls along the lines of `historyCompletionP
+      myFunc` should be changed to `historyCompletionP myConf myFunc`.
+      If not `myConf` is lying around, `def` can be used instead.
+
 ### New Modules
 
   * `XMonad.Actions.Profiles`.
@@ -36,6 +43,11 @@
   * `XMonad.Prompt.OrgMode`
 
     - Added `HH:MM-HH:MM` and `HH:MM+HH` syntax to specify time spans.
+
+  * `XMonad.Prompt`
+
+    - The history file is not extraneously read and written anymore if
+      the `historySize` is set to 0.
 
 ### Other changes
 

--- a/XMonad/Actions/Search.hs
+++ b/XMonad/Actions/Search.hs
@@ -437,14 +437,14 @@ namedEngine name (SearchEngine _ site) = searchEngineF name site
    browser. -}
 promptSearchBrowser :: XPConfig -> Browser -> SearchEngine -> X ()
 promptSearchBrowser config browser (SearchEngine name site) = do
-    hc <- historyCompletionP ("Search [" `isPrefixOf`)
+    hc <- historyCompletionP config ("Search [" `isPrefixOf`)
     mkXPrompt (Search name) config hc $ search browser site
 
 {- | Like 'promptSearchBrowser', but only suggest previous searches for the
    given 'SearchEngine' in the prompt. -}
 promptSearchBrowser' :: XPConfig -> Browser -> SearchEngine -> X ()
 promptSearchBrowser' config browser (SearchEngine name site) = do
-    hc <- historyCompletionP (searchName `isPrefixOf`)
+    hc <- historyCompletionP config (searchName `isPrefixOf`)
     mkXPrompt (Search name) config hc $ search browser site
   where
     searchName = showXPrompt (Search name)

--- a/XMonad/Actions/WorkspaceNames.hs
+++ b/XMonad/Actions/WorkspaceNames.hs
@@ -138,7 +138,7 @@ setCurrentWorkspaceName name = do
 -- | Prompt for a new name for the current workspace and set it.
 renameWorkspace :: XPConfig -> X ()
 renameWorkspace conf = do
-    completion <- historyCompletionP (prompt ==)
+    completion <- historyCompletionP conf (prompt ==)
     mkXPrompt (Wor prompt) conf completion setCurrentWorkspaceName
   where
     prompt = "Workspace name: "


### PR DESCRIPTION
### Rationale

When using `XMonad.Prompt` for multiple (8+) different use cases in my configuration, I never once needed a command history.

The default of reading and writing a file for the command history opaque to the user is strange to me, and each prompt is sharing and replacing the same `prompt-history` file... but I digress.

My feature request is to stop that behavior, where `historySize = 0` didn't cut the mustard since `prompt-history` is still reading and writing on every prompt.

## ~Proposal~

~This pull request adds `historyRead` and `historyWrite` configuration options to `XPConfig`, allowing users to write something like:~

```haskell
  ...
  , historyRead = \cacheDir -> return empty
  , historyWrite = \history cacheDir -> return ()
  ...
``` 

~This could open up functionality for using other state for a command history, but maybe that isn't desired.
My main priority with this pull request is to prevent the reading and writing of the `prompt-history` file, and as such I am marking this as a draft until discussion resolves the best path forward.~

### Proposal (current)
`historySize = 0` should branch the IO behavior, and prevent any related IO (reading or writing).

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: unknown, I am using these changes locally

  - [ ] I updated the `CHANGES.md` file
