### PR TITLE
only sink window if actually fullscreened

### DIFF
--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -545,10 +545,10 @@ fullscreenEventHook'
       chWstate f = io $ changeProperty32 dpy win wmstate aTOM propModeReplace (f wstate)
 
   when (managed && typ == wmstate && fi fullsc `elem` dats) $ do
-    when (action == add || (action == toggle && not isFull)) $ do
+    when (not isFull && (action == add || action == toggle)) $ do
       chWstate (fi fullsc:)
       windows . appEndo =<< runQuery fullscreenHook win
-    when (action == remove || (action == toggle && isFull)) $ do
+    when (isFull && (action == remove || action == toggle)) $ do
       chWstate $ delete (fi fullsc)
       windows . appEndo =<< runQuery unFullscreenHook win
 


### PR DESCRIPTION
### Description

`EwmhFullscreen` unconditionally sinks windows in response to a `_NET_WM_STATE` root window message removing `_NET_WM_STATE_FULLSCREEN`. Unfortunately, at least some versions of either the Gtk or GNOME libraries send this on startup while restoring a window's last known state, which means a `manageHook` `doFloat` will be undone.

This change ignores the remove if the window is not fullscreen.

A followup issue, #865, has been added for the follow-on problem that the floating state of a window is not restored on removal of the fullscreen state.

Closes: #820

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: a user is already using this change successfully

  - [x] I updated the `CHANGES.md` file (unnecessary)
