### PR TITLE
Fix build-with-cabal.sh when XDG_CONFIG_HOME is defined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes and Minor Changes
 
+  * Fix build-with-cabal.sh when XDG_CONFIG_HOME is defined.
+
 ### Other changes
 
 ## 0.18.0 (February 3, 20

--- a/scripts/build/build-with-cabal.sh
+++ b/scripts/build/build-with-cabal.sh
@@ -15,7 +15,7 @@ output="$1"
 
 if [ "$SRC_DIR" = "" ]; then
     # look for the config directory, fall back to the old one
-    SRC_DIR="${XMONAD_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config/xmonad}}"
+    SRC_DIR="${XMONAD_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/xmonad}"
     if test -f "$SRC_DIR/build"; then
 	:
     else


### PR DESCRIPTION
### Description

The current script fails in case the project files are in `$XDG_CONFIG_HOME/xmonad/`, it tries to read them from `$XDG_CONFIG_HOME` directly.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually

  - [x] I updated the `CHANGES.md` file
