### PR TITLE
X.L.Hidden: use the modifyWindowSet function

### DIFF
--- a/XMonad/Layout/Hidden.hs
+++ b/XMonad/Layout/Hidden.hs
@@ -118,7 +118,7 @@ popHiddenWindow = sendMessage . PopSpecificHiddenWindow
 --------------------------------------------------------------------------------
 hideWindowMsg :: HiddenWindows a -> Window -> X (Maybe (HiddenWindows a))
 hideWindowMsg (HiddenWindows hidden) win = do
-  modify (\s -> s { windowset = W.delete' win $ windowset s })
+  modifyWindowSet $ W.delete' win
   return . Just . HiddenWindows $ hidden ++ [win]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Use [modifyWindowSet](https://hackage.haskell.org/package/xmonad-0.18.0/docs/src/XMonad.Operations.html#modifyWindowSet) function in [hideWindowMessage](https://hackage.haskell.org/package/xmonad-contrib-0.18.0/docs/src/XMonad.Layout.Hidden.html#hideWindowMsg) function.  
It seems appropriate to use an existing function for modifying the `WindowSet` instead of doing it "by hand". 

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
