### PR TITLE
X.U.EZConfig: Fix checkKeymap warning that all keybindings are duplicate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
   * Fix build-with-cabal.sh when XDG_CONFIG_HOME is defined.
 
+  * `XMonad.Util.EZConfig`
+
+    - Fixed `checkKeymap` warning that all keybindings are duplicates.
+
 ### Other changes
 
 ## 0.18.0 (February 3, 20

--- a/XMonad/Util/EZConfig.hs
+++ b/XMonad/Util/EZConfig.hs
@@ -552,8 +552,8 @@ doKeymapCheck :: XConfig l -> [(String,a)] -> ([String], [String])
 doKeymapCheck conf km = (bad,dups)
   where ks = map ((readKeySequence conf &&& id) . fst) km
         bad = nub . map snd . filter (isNothing . fst) $ ks
-        dups = map (snd . NE.head)
-             . mapMaybe nonEmpty
+        dups = map (snd . NE.head . notEmpty)
+             . filter ((>1) . length)
              . groupBy ((==) `on` fst)
              . sortBy (comparing fst)
              . map (first fromJust)


### PR DESCRIPTION
### Description

This reverts part of 42179b8625d83b2cd3c3a35da84de6f6c0dea6d6, which effectively changed the duplicate check from `>1` to `>=1`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
