### PR TITLE
X.H.ManageHelpers: `isNotification` predicate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 ### New Modules
  
   * `XMonad.Actions.Profiles`.
-  
+
     - Group workspaces by similarity. Usefull when one has lots 
 	  of workspaces and uses only a couple per unit of work.
 
@@ -19,9 +19,14 @@
 
     - Fixed `checkKeymap` warning that all keybindings are duplicates.
 
+  * `XMonad.Hooks.ManageHelpers`
+
+    - Added `isNotification` predicate to check for windows with
+      `_NET_WM_WINDOW_TYPE` property of `_NET_WM_WINDOW_TYPE_NOTIFICATION`.
+
 ### Other changes
 
-## 0.18.0 (February 3, 20
+## 0.18.0 (February 3, 2024)
 
 ### Breaking Changes
 

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -51,6 +51,7 @@ module XMonad.Hooks.ManageHelpers (
     isFullscreen,
     isMinimized,
     isDialog,
+    isNotification,
     pid,
     desktop,
     transientTo,
@@ -191,8 +192,17 @@ isMinimized :: Query Bool
 isMinimized = isInProperty "_NET_WM_STATE" "_NET_WM_STATE_HIDDEN"
 
 -- | A predicate to check whether a window is a dialog.
+--
+-- See <https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm46485863906176>.
 isDialog :: Query Bool
 isDialog = isInProperty "_NET_WM_WINDOW_TYPE" "_NET_WM_WINDOW_TYPE_DIALOG"
+
+-- | A predicate to check whether a window is a notification.
+--
+-- See <https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html#idm46485863906176>.
+isNotification :: Query Bool
+isNotification =
+  isInProperty "_NET_WM_WINDOW_TYPE" "_NET_WM_WINDOW_TYPE_NOTIFICATION"
 
 -- | This function returns 'Just' the @_NET_WM_PID@ property for a
 -- particular window if set, 'Nothing' otherwise.


### PR DESCRIPTION
### Description

Very similar to `isDialog`, `isNotification` checks for the `_NET_WM_WINDOW_TYPE_NOTIFICATION` value in the `_NET_WM_WINDOW_TYPE` property.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:
        It is a rather trivial predicate.  I do not see any examples of how to test those.
        `isDialog` has no tests either.
        So no tests :(

  - [X] I updated the `CHANGES.md` file