### PR TITLE
update time to <1.15

### DIFF
--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -59,7 +59,7 @@ library
                    containers >= 0.5 && < 0.8,
                    directory,
                    filepath,
-                   time >= 1.8 && < 1.13,
+                   time >= 1.8 && < 1.15,
                    process,
                    random,
                    mtl >= 1 && < 3,


### PR DESCRIPTION
### Description

Update bounds of `time` to allow the new 1.14 release.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: build with `--constraint='time == 1.14'` passed locally

  - [ ] I updated the `CHANGES.md` file (n/a)
