### PR TITLE
Fixes/workarounds for Steam client menus/flickering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,13 @@
     - Group workspaces by similarity. Useful when one has lots
       of workspaces and uses only a couple per unit of work.
 
+  * `XMonad.Hooks.FloatConfigureReq`
+
+    - Customize handling of floating windows' move/resize/restack requests
+      (ConfigureRequest). Useful as a workaround for some misbehaving client
+      applications (Steam, rxvt-unicode, anything that tries to restore
+      absolute position of floats).
+
 ### Bug Fixes and Minor Changes
 
   * Fix build-with-cabal.sh when XDG_CONFIG_HOME is defined.
@@ -48,6 +55,15 @@
 
     - The history file is not extraneously read and written anymore if
       the `historySize` is set to 0.
+
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - Requests for unmanaged windows no longer cause a refresh. This avoids
+      flicker and also fixes disappearing menus in the Steam client and
+      possibly a few other client applications.
+
+      (See also `XMonad.Hooks.FloatConfigureReq` and/or `XMonad.Util.Hacks`
+      for additional Steam client workarounds.)
 
 ### Other changes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,11 +7,11 @@
   * `XMonad.Hooks.StatusBars`
 
     - Move status bar functions from the `IO` to the `X` monad to
-       allow them to look up information from `X`, like the screen
-       width. Existing configurations may need to use `io` from
-       `XMonad.Core` or `liftIO` from `Control.Monad.IO.Class` in
-       order to lift any existing `IO StatusBarConfig` values into
-       `X StatusBarConfig` values.
+      allow them to look up information from `X`, like the screen
+      width. Existing configurations may need to use `io` from
+      `XMonad.Core` or `liftIO` from `Control.Monad.IO.Class` in
+      order to lift any existing `IO StatusBarConfig` values into
+      `X StatusBarConfig` values.
 
   * `XMonad.Prompt`
 
@@ -22,10 +22,10 @@
 
 ### New Modules
 
-  * `XMonad.Actions.Profiles`.
+  * `XMonad.Actions.Profiles`
 
     - Group workspaces by similarity. Useful when one has lots
-	  of workspaces and uses only a couple per unit of work.
+      of workspaces and uses only a couple per unit of work.
 
 ### Bug Fixes and Minor Changes
 

--- a/XMonad/Hooks/FloatConfigureReq.hs
+++ b/XMonad/Hooks/FloatConfigureReq.hs
@@ -25,6 +25,10 @@ module XMonad.Hooks.FloatConfigureReq (
     -- $usage
     MaybeMaybeManageHook,
     floatConfReqHook,
+
+    -- * Known workarounds
+    fixSteamFlicker,
+    fixSteamFlickerMMMH,
     ) where
 
 import qualified Data.Map.Strict as M
@@ -66,6 +70,10 @@ import qualified XMonad.StackSet as W
 -- meaningful in the context of a tiling WM):
 --
 -- > map toLower `fmap` className =? "steam" -?> mempty
+--
+-- (this example is also available as 'fixSteamFlickerMMMH' to be added to
+-- one's @myFloatConfReqHook@ and also 'fixSteamFlicker' to be added directly
+-- to one's 'handleEventHook')
 
 -- | A variant of 'MaybeManageHook' that additionally may or may not make
 -- changes to the 'WindowSet'.
@@ -107,3 +115,12 @@ floatConfReqHook _ _ = mempty
 -- | A 'Query' to determine if a window is floating.
 isFloatQ :: Query Bool
 isFloatQ = ask >>= \w -> liftX . gets $ M.member w . W.floating . windowset
+
+-- | A pre-packaged 'floatConfReqHook' that fixes flickering of the Steam client by ignoring 'ConfigureRequestEvent's on any of its floating windows.
+--
+-- To use this, add 'fixSteamFlicker' to your 'handleEventHook'.
+fixSteamFlicker :: Event -> X All
+fixSteamFlicker = floatConfReqHook fixSteamFlickerMMMH
+
+fixSteamFlickerMMMH :: MaybeMaybeManageHook
+fixSteamFlickerMMMH = map toLower `fmap` className =? "steam" -?> mempty

--- a/XMonad/Hooks/FloatConfigureReq.hs
+++ b/XMonad/Hooks/FloatConfigureReq.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE LambdaCase #-}
+-- |
+-- Module      :  XMonad.Hooks.FloatConfigureReq
+-- Description :  Customize handling of floating windows' move\/resize\/restack requests (ConfigureRequest).
+-- Copyright   :  (c) 2024 Tomáš Janoušek <tomi@nomi.cz>
+-- License     :  BSD3
+-- Maintainer  :  Tomáš Janoušek <tomi@nomi.cz>
+--
+-- xmonad normally honours those requests by doing exactly what the client
+-- application asked, and refreshing. There are some misbehaving clients,
+-- however, that:
+--
+-- * try to move their window to the last known absolute position regardless
+--   of the current xrandr/xinerama layout
+--
+-- * move their window to 0, 0 for no particular reason (e.g. rxvt-unicode)
+--
+-- * issue lots of no-op requests causing flickering (e.g. Steam)
+--
+-- This module provides a replacement handler for 'ConfigureRequestEvent' to
+-- work around such misbehaviours.
+--
+module XMonad.Hooks.FloatConfigureReq (
+    -- * Usage
+    -- $usage
+    MaybeMaybeManageHook,
+    floatConfReqHook,
+    ) where
+
+import qualified Data.Map.Strict as M
+import XMonad
+import XMonad.Hooks.ManageHelpers
+import XMonad.Prelude
+import qualified XMonad.StackSet as W
+
+-- $usage
+-- To use this, include the following in your @xmonad.hs@:
+--
+-- > import XMonad.Hooks.FloatConfigureReq
+-- > import XMonad.Hooks.ManageHelpers
+--
+-- > myFloatConfReqHook :: MaybeMaybeManageHook
+-- > myFloatConfReqHook = composeAll
+-- >     [ … ]
+--
+-- > myEventHook :: Event -> X All
+-- > myEventHook = mconcat
+-- >     [ …
+-- >     , floatConfReqHook myFloatConfReqHook
+-- >     , … ]
+--
+-- > main = xmonad $ …
+-- >               $ def{ handleEventHook = myEventHook
+-- >                    , … }
+--
+-- Then fill the @myFloatConfReqHook@ with whatever custom rules you need.
+--
+-- As an example, the following will prevent rxvt-unicode from moving its
+-- (floating) window to 0, 0 after a font change but still ensure its size
+-- increment hints are respected:
+--
+-- > className =? "URxvt" -?> pure <$> doFloat
+--
+-- Another example that avoids flickering and xmonad slowdowns caused by the
+-- Steam client (completely ignore all its requests, none of which are
+-- meaningful in the context of a tiling WM):
+--
+-- > map toLower `fmap` className =? "steam" -?> mempty
+
+-- | A variant of 'MaybeManageHook' that additionally may or may not make
+-- changes to the 'WindowSet'.
+type MaybeMaybeManageHook = Query (Maybe (Maybe (Endo WindowSet)))
+
+-- | Customizable handler for a 'ConfigureRequestEvent'. If the event's
+-- 'ev_window' is a managed floating window, the provided
+-- 'MaybeMaybeManageHook' is consulted and its result interpreted as follows:
+--
+--  * @Nothing@ - no match, fall back to the default handler
+--
+--  * @Just Nothing@ - match but ignore, no refresh, just send ConfigureNotify
+--
+--  * @Just (Just a)@ - match, modify 'WindowSet', refresh, send ConfigureNotify
+floatConfReqHook :: MaybeMaybeManageHook -> Event -> X All
+floatConfReqHook mh ConfigureRequestEvent{ev_window = w} =
+    runQuery (join <$> (isFloatQ -?> mh)) w >>= \case
+        Nothing -> mempty
+        Just e -> do
+            whenJust e (windows . appEndo)
+            sendConfEvent
+            pure (All False)
+  where
+    sendConfEvent = withDisplay $ \dpy ->
+        withWindowAttributes dpy w $ \wa -> do
+            io . allocaXEvent $ \ev -> do
+                -- We may have made no changes to the window size/position
+                -- and thus the X server didn't emit any ConfigureNotify,
+                -- so we need to send the ConfigureNotify ourselves to make
+                -- sure there is a reply to this ConfigureRequestEvent and the
+                -- window knows we (possibly) ignored its request.
+                setEventType ev configureNotify
+                setConfigureEvent ev w w
+                    (wa_x wa) (wa_y wa) (wa_width wa)
+                    (wa_height wa) (wa_border_width wa) none (wa_override_redirect wa)
+                sendEvent dpy w False 0 ev
+floatConfReqHook _ _ = mempty
+
+-- | A 'Query' to determine if a window is floating.
+isFloatQ :: Query Bool
+isFloatQ = ask >>= \w -> liftX . gets $ M.member w . W.floating . windowset

--- a/XMonad/Util/Hacks.hs
+++ b/XMonad/Util/Hacks.hs
@@ -40,10 +40,14 @@ module XMonad.Util.Hacks (
   trayerPaddingXmobarEventHook,
   trayPaddingXmobarEventHook,
   trayPaddingEventHook,
+
+  -- * Steam flickering fix
+  fixSteamFlicker,
   ) where
 
 
 import XMonad
+import XMonad.Hooks.FloatConfigureReq (fixSteamFlicker)
 import XMonad.Hooks.StatusBar (xmonadPropLog')
 import XMonad.Prelude (All (All), fi, filterM, when)
 import System.Posix.Env (putEnv)

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -192,6 +192,7 @@ library
                         XMonad.Hooks.EwmhDesktops
                         XMonad.Hooks.FadeInactive
                         XMonad.Hooks.FadeWindows
+                        XMonad.Hooks.FloatConfigureReq
                         XMonad.Hooks.FloatNext
                         XMonad.Hooks.Focus
                         XMonad.Hooks.InsertPosition


### PR DESCRIPTION
### Description

A fix, a tool for workarounds, and a workaround:

#### [X.H.EwmhDesktops: Fix menus in Steam client](../commit/d690f7fe12fdc5955a3b67fb50b2962987e47f81)

More specifically, ignore `ClientMessageEvent`s for unmanaged windows. Steam likes to send `_NET_ACTIVE_WINDOW` requests for all its windows, including override-redirect ones, which used to result in an invocation of `windows` with a no-op Endo—equivalent to a call to `refresh`. But this refresh makes Steam close its menus immediately.

Fixes: https://github.com/ValveSoftware/steam-for-linux/issues/9376
Fixes: https://github.com/xmonad/xmonad/issues/451

#### [X.H.FloatConfigureReq: New module to customize ConfigureRequest handling](../commit/85436e6d950dbdaf0e53725ed5010e8003b97c8b)

Implements a replacement event handler for `ConfigureRequestEvent` to work around misbehaving client applications such as Steam, rxvt-unicode and others that try to restore their absolute window positions. Primarily motivated by the Steam client being almost completely unusable in xmonad lately.

(I've been running this code in my xmonad.hs for other purposes for years.)

#### [X.H.FloatConfigureReq: Add fixSteamFlicker](../commit/4149a3f9907a0348ffec97171345142884f76d40)

For ease of use, provide `fixSteamFlicker` as a pre-packaged `floatConfReqHook` that can easily be added directly to a `handleEventHook`.

Also, for discoverability, re-export it from X.U.Hacks.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded:
        been running the `X.H.FloatConfigureReq` stuff for years locally; the rest is fresh and ideally needs to be manually tested by some folks

  - [X] I updated the `CHANGES.md` file
