### PR TITLE
Add a method to re-sort keys for visualSubmap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,11 @@
       (See also `XMonad.Hooks.FloatConfigureReq` and/or `XMonad.Util.Hacks`
       for additional Steam client workarounds.)
 
+  * `XMonad.Actions.Submap`
+
+    - Added `visualSubmapSorted` to enable sorting of the keymap
+      descriptions.
+
 ### Other changes
 
 ## 0.18.0 (February 3, 2024)


### PR DESCRIPTION
### Description

I did not see any way to display the submap bindings in a different order. I created a general function that takes a sorter for the descriptions (`visualSubmapSorted`).

The change from `zipWith` to `map . zip` showed no noticeable performance effects.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Manually tested; have observed no issues.

  - [x] I updated the `CHANGES.md` file
