### PR TITLE
XMonad.Hooks.ScreenCorners: Add support for edges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,11 @@
     - Added `visualSubmapSorted` to enable sorting of the keymap
       descriptions.
 
+  * `XMonad.Hooks.ScreenCorners`
+
+    - Added screen edge support with `SCTop`, `SCBottom`, `SCLeft` and
+      `SCRight`. Now both corners and edges are supported.
+
 ### Other changes
 
 ## 0.18.0 (February 3, 2024)


### PR DESCRIPTION
### Description

In XMonad.Hooks.ScreenCorners, previously only corner is supported, now support for top and bottom edges is added. This is similar to Hot Edge shell extension in GNOME.

I could add support for SCLeft, SCRight too, if it's desired. I thought I'd ask for a review on this first.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

        I did manual test on this added feature.
        SCTop and SCBottom works. They also with with corner specifier when the corner and edge overlap.

  - [x] I updated the `CHANGES.md` file
