### PR TITLE
XMonad.Actions.GridSelect: added gs_cancelOnEmptyClick field

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,14 @@
       myFunc` should be changed to `historyCompletionP myConf myFunc`.
       If not `myConf` is lying around, `def` can be used instead.
 
+  * `XMonad.Actions.GridSelect`
+
+    - Added the `gs_cancelOnEmptyClick` field to `GSConfig`, which makes
+      mouse clicks into "empty space" cancel the current grid-select.
+      Users explicitly defining their own `GSConfig` record will have to
+      add this to their definitions. Additionally, the field defaults to
+      `True`—to retain the old behaviour, set it to `False`.
+
 ### New Modules
 
   * `XMonad.Actions.Profiles`


### PR DESCRIPTION
### Description

In the original code, when a GridSelect is shown, user has to use a keyboard to cancel it (ESC key by default). With this field added, when it is set to True, mouse click on empty space can cancel the GridSelect.

When user trigger a GridSelect action using mouse, this change makes it easier to cancel the Grid, without reaching to the keyboard.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    I have tested the code manually. The default setting preserves the original behavior. User has to opt-in to get the new feature, to reduce surprises.

    To test the new behavior,
```haskell
import XMonad.Actions.GridSelect

myGoToSelected = goToSelected def { gs_cancelOnEmptyClick = True }

-- try it with a key binding
, ("M-<Space>", myGoToSelected)
```

  - [x] I updated the `CHANGES.md` file
