### PR TITLE
fix: deprecated url literals

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
 # See NIX.md for an overview of module usage.
 {
   inputs = {
-    flake-utils.url = github:numtide/flake-utils;
-    git-ignore-nix.url = github:hercules-ci/gitignore.nix/master;
-    xmonad.url = github:xmonad/xmonad;
+    flake-utils.url = "github:numtide/flake-utils";
+    git-ignore-nix.url = "github:hercules-ci/gitignore.nix/master";
+    xmonad.url = "github:xmonad/xmonad";
   };
   outputs = { self, flake-utils, nixpkgs, git-ignore-nix, xmonad }:
   with xmonad.lib;


### PR DESCRIPTION
### Description

Nix url litterals are being depricated in flake inputs and fails to build on
never versions. I've just quoted them so it keeps building.

Signed-off-by: Christina Sørensen <christina@cafkafk.com>

### Checklist

  - [ ] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [ ] I updated the `CHANGES.md` file
