### PR TITLE
X.H.Rescreen, X.A.PhysicalScreens: Add facilities to avoid (some) workspace reshuffling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,19 @@
       would be deleted when switching to a dynamic project.
     - Improved documentation on how to close a project.
 
+  * `XMonad.Hooks.Rescreen`
+
+    - Allow overriding the `rescreen` operation itself. Additionally, the
+      `XMonad.Actions.PhysicalScreens` module now provides an alternative
+      implementation of `rescreen` that avoids reshuffling the workspaces if
+      the number of screens doesn't change and only their locations do (which
+      is especially common if one uses `xrandr --setmonitor` to split an
+      ultra-wide display in two).
+
+    - Added an optional delay when waiting for events to settle. This may be
+      used to avoid flicker and unnecessary workspace reshuffling if multiple
+      `xrandr` commands are used to reconfigure the display layout.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -430,7 +430,8 @@
   * `XMonad.Config.{Arossato,Dmwit,Droundy,Monad,Prime,Saegesser,Sjanssen}`
 
     - Deprecated all of these modules.  The user-specific configuration
-      modules may still be found [on the website].
+      modules may still be found [on the
+      website](https://xmonad.org/configurations.html)
 
   * `XMonad.Util.NamedScratchpad`
 
@@ -450,8 +451,6 @@
 
     - Deprecated `urgencyConfig`; use `def` from the new `Default`
       instance of `UrgencyConfig` instead.
-
-[on the website]: https://xmonad.org/configurations.html
 
 ### New Modules
 
@@ -527,7 +526,8 @@
       `todo +d 12 02 2024` work.
 
     - Added the ability to specify alphabetic (`#A`, `#B`, and `#C`)
-      [priorities] at the end of the input note.
+      [priorities](https://orgmode.org/manual/Priorities.html) at the end of
+      the input note.
 
   * `XMonad.Prompt.Unicode`
 
@@ -621,7 +621,8 @@
 
     - Modified `mkAbsolutePath` to support a leading environment variable, so
       things like `$HOME/NOTES` work. If you want more general environment
-      variable support, comment on [this PR].
+      variable support, comment on [this
+      PR](https://github.com/xmonad/xmonad-contrib/pull/744)
 
   * `XMonad.Util.XUtils`
 
@@ -659,9 +660,6 @@
   * `XMonad.Hooks.UrgencyHook`
 
     - Added a `Default` instance for `UrgencyConfig` and `DzenUrgencyHook`.
-
-[this PR]: https://github.com/xmonad/xmonad-contrib/pull/744
-[priorities]: https://orgmode.org/manual/Priorities.html
 
 ### Other changes
 
@@ -2188,8 +2186,8 @@
 
   * `XMonad.Prompt.Pass`
 
-    This module provides 3 `XMonad.Prompt`s to ease passwords
-    manipulation (generate, read, remove) via [pass][].
+    This module provides 3 `XMonad.Prompt`s to ease passwords manipulation
+    (generate, read, remove) via [pass](http://www.passwordstore.org/).
 
   * `XMonad.Util.RemoteWindows`
 
@@ -2265,5 +2263,3 @@
 ## See Also
 
 <https://wiki.haskell.org/Xmonad/Notable_changes_since_0.8>
-
-[pass]: http://www.passwordstore.org/


### PR DESCRIPTION
### Description

The changelog says it all:

> * `XMonad.Hooks.Rescreen`
>
>   - Allow overriding the `rescreen` operation itself. Additionally, the `XMonad.Actions.PhysicalScreens` module now provides an alternative implementation of `rescreen` that avoids reshuffling the workspaces if the number of screens doesn't change and only their locations do (which is especially common if one uses `xrandr --setmonitor` to split an ultra-wide display in two).
>
>   - Added an optional delay when waiting for events to settle. This may be used to avoid flicker and unnecessary workspace reshuffling if multiple `xrandr` commands are used to reconfigure the display layout.

Well, almost all. One commit message digs a bit deeper:

> X.A.PhysicalScreens: Add rescreen alternative to avoid ws reshuffle
>
> Probably a very niche use-case: I have an ultra-wide display that I split into two using `xrandr --setmonitor`, and I want the workspaces to stay in place when the split ratio is adjusted.
>
> Furthermore, this fixes workspace reshuffling when a virtual monitor is added for screensharing a portion of the screen (https://news.ycombinator.com/item?id=41837204).
>
> Can't think of a scenario involving just physical screens where this would be useful. Those are mostly added/removed, so if anything, one might wish to preserve the workspace that is currently being showed, but that would require knowing the output name (only available via RandR, not via Xinerama). If someone physically moves their displays around and then invokes `xrandr` to update the layout, this might very well do the right thing, but I don't think anyone moves their displays around often enough to be annoyed by xmonad reshuffling the workspaces. :-)

Also worth noting that I'm don't like the implementation of `rescreenSameLength` — I feel there must be a better way, but maybe it's okay actually?

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

    Worth mentioning that a limited version of this functionality (the part that enables `clipscreen` but not changing the ultra-wide split ratio) could be added to core — skip the rescreen if the old and new cleared rectangles are exactly the same. This being a niche use-case, I think it's okay to keep core as is.

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    Used it locally. Also, it can't possibly regress anything as existing
        functionality isn't changed at all.

  - [X] I updated the `CHANGES.md` file
