### PR TITLE
X.L.NoBorders: Listen to DestroyWindowEvents and garbage collect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,13 @@
       used to avoid flicker and unnecessary workspace reshuffling if multiple
       `xrandr` commands are used to reconfigure the display layout.
 
+  * `XMonad.Layout.NoBorders`
+
+    - It's no longer necessary to use `borderEventHook` to garbage collect
+      `alwaysHidden`/`neverHidden` lists. The layout listens to
+      `DestroyWindowEvent` messages instead, which are broadcast to layouts
+      since xmonad v0.17.0.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Previously, it was necessary to use `borderEventHook` to make sure the `alwaysHidden`/`neverHidden` lists are garbage collected when a window is destroyed, but this was largely undocumented. Since xmonad v0.17.0, the DestroyWindowEvent is broadcast to layouts, so we can just use that instead and deprecate the event hook.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit, manually, ...) and concluded:
        I'll be running with this for a while and see if everything's okay but it's pretty trivial, it should be okay.

  - [X] I updated the `CHANGES.md` file
