### PR TITLE
X.H.EwmhDesktops: Add customization for handling the _NET_CURRENT_DESKTOP requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,12 @@
       `DestroyWindowEvent` messages instead, which are broadcast to layouts
       since xmonad v0.17.0.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - Added a customization option for the action that gets executed when
+      a client sends a **_NET_CURRENT_DESKTOP** request. It is now possible
+      to change it using the `setEwmhSwitchDesktopHook`.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,11 @@
       a client sends a **_NET_CURRENT_DESKTOP** request. It is now possible
       to change it using the `setEwmhSwitchDesktopHook`.
 
+  * `XMonad.Layout.IndependentScreens`
+
+    - Added `focusWorkspace` for focusing workspaces on the screen that they
+      belong to.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -27,7 +27,7 @@ module XMonad.Layout.IndependentScreens (
     whenCurrentOn,
     countScreens,
     workspacesOn,
-    workspaceOnScreen, focusWindow', focusScreen, nthWorkspace, withWspOnScreen,
+    workspaceOnScreen, focusWindow', focusScreen, focusWorkspace, nthWorkspace, withWspOnScreen,
     -- * Converting between virtual and physical workspaces
     -- $converting
     marshall, unmarshall, unmarshallS, unmarshallW,
@@ -40,6 +40,7 @@ import XMonad
 import XMonad.Hooks.StatusBar.PP
 import XMonad.Prelude
 import qualified XMonad.StackSet as W
+import XMonad.Actions.OnScreen (viewOnScreen)
 
 -- $usage
 -- You can use this module with the following in your @xmonad.hs@:
@@ -162,6 +163,11 @@ focusWindow' window ws
 -- | Focus a given screen.
 focusScreen :: ScreenId -> WindowSet -> WindowSet
 focusScreen screenId = withWspOnScreen screenId W.view
+
+-- | Focus the given workspace on the correct Xinerama screen.
+-- An example usage can be found at `XMonad.Hooks.EwmhDesktops.setEwmhSwitchDesktopHook`
+focusWorkspace :: WorkspaceId -> WindowSet -> WindowSet
+focusWorkspace workspaceId = viewOnScreen (unmarshallS workspaceId) workspaceId
 
 -- | Get the nth virtual workspace
 nthWorkspace :: Int -> X (Maybe VirtualWorkspace)


### PR DESCRIPTION
### Description

This adds a `setEwmhSwitchDesktopAction` function to customize how switching to the desired workspace is done when handling a _NET_CURRENT_DESKTOP request. The motivation for this was that commands using the EWMH fuctionality such as `wmctrl -s` pulled workspaces to the wrong screen in certain cases when using the `X.L.IndependentScreens` module, instead of making them active on the screen that they belong on, but the behavior seemed to be a sensible default since use of that module is not mandatory.

With the new function I changed the action to the following:
`action workspaceId = viewOnScreen (unmarshallS workspaceId) workspaceId`
This no longer pulls the workspace to the wrong screen when it is hidden, and it is on a screen that does not contain the current workspace, this is also used as the example in the documentation.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,manually, ...) and concluded:
         that manual testing is adequate since change just added a customization option without changing the default.
         I did not find a difference in the default behavior, using this version and the example is currently working as expected
         on my system.
 
  - [x] I updated the `CHANGES.md` file
