### PR TITLE
X.L.IndependentScreens: Add doFocus' ManageHook.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,8 @@
 
     - Added `focusWorkspace` for focusing workspaces on the screen that they
       belong to.
+    - Added `doFocus'` hook as an alternative for `doFocus` when using
+      IndependentScreens.
 
   * `XMonad.Util.NamedScratchPad`
 

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -238,8 +238,8 @@ setEwmhWorkspaceRename f = XC.modifyDef $ \c -> c{ workspaceRename = f }
 -- >   [ className =? "Google-chrome" <||> className =? "google-chrome" -?> doAskUrgent
 -- >   , pure True -?> doFocus ]
 --
--- See "XMonad.ManageHook", "XMonad.Hooks.ManageHelpers" and "XMonad.Hooks.Focus"
--- for functions that can be useful here.
+-- See "XMonad.ManageHook", "XMonad.Hooks.ManageHelpers", "XMonad.Hooks.Focus" and
+-- "XMonad.Layout.IndependentScreens" for functions that can be useful here.
 
 -- | Set (replace) the hook which is invoked when a client sends a
 -- @_NET_ACTIVE_WINDOW@ request to activate a window. The default is 'doFocus'

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -27,7 +27,7 @@ module XMonad.Layout.IndependentScreens (
     whenCurrentOn,
     countScreens,
     workspacesOn,
-    workspaceOnScreen, focusWindow', focusScreen, focusWorkspace, nthWorkspace, withWspOnScreen,
+    workspaceOnScreen, focusWindow', doFocus', focusScreen, focusWorkspace, nthWorkspace, withWspOnScreen,
     -- * Converting between virtual and physical workspaces
     -- $converting
     marshall, unmarshall, unmarshallS, unmarshallW,
@@ -159,6 +159,11 @@ focusWindow' window ws
   | otherwise = case W.findTag window ws of
       Just tag -> W.focusWindow window $ focusScreen (unmarshallS tag) ws
       Nothing -> ws
+
+-- | ManageHook to focus a window, switching workspace on the correct Xinerama screen if neccessary.
+-- Useful in 'XMonad.Hooks.EwmhDesktops.setActivateHook' when using this module.
+doFocus' :: ManageHook
+doFocus' = doF . focusWindow' =<< ask
 
 -- | Focus a given screen.
 focusScreen :: ScreenId -> WindowSet -> WindowSet


### PR DESCRIPTION
### Description

This PR adds a ManageHook version for `focusWindow'`. The example use case for this would be using it as an activate hook 
when using the *X.H.EwmhDesktops* module together with *X.L.IndependentScreens*.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: that manual testing is enough, and it functions as expected.
        Building with the pedantic flag did not add new errors.

  - [x] I updated the `CHANGES.md` file
