### PR TITLE
fix unintended window hiding

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,11 @@
     - Added `focusWorkspace` for focusing workspaces on the screen that they
       belong to.
 
+  * `XMonad.Util.NamedScratchPad`
+
+    - Fix unintended window hiding in `nsSingleScratchpadPerWorkspace`.
+      Only hide the previously active scratchpad.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes

--- a/XMonad/Util/NamedScratchpad.hs
+++ b/XMonad/Util/NamedScratchpad.hs
@@ -309,7 +309,7 @@ nsSingleScratchpadPerWorkspace :: NamedScratchpads -> X ()
 nsSingleScratchpadPerWorkspace scratches =
     nsHideOnCondition $ \ _lastFocus curFocus winSet hideScratch -> do
         allScratchesButCurrent <-
-            filterM (liftA2 (<||>) (pure . (/= curFocus)) (`isNSP` scratches))
+            filterM (liftA2 (<&&>) (pure . (/= curFocus)) (`isNSP` scratches))
                     (W.index winSet)
         whenX (isNSP curFocus scratches) $
             for_ allScratchesButCurrent hideScratch


### PR DESCRIPTION
### Description

Fix unintended window hiding in `nsSingleScratchpadPerWorkspace`

The refactoring that introduced `nsHideOnCondition` caused a misbehavior in  
`nsSingleScratchpadPerWorkspace`, leading to unintended window hiding.  
Now, when opening a new scratchpad, only the previously active scratchpad  
is hidden.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
