### PR TITLE
X.H.EwmhDesktops: Add setEwmhHiddenWorkspaceToScreenMapping function.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,9 @@
     - Added a customization option for the action that gets executed when
       a client sends a **_NET_CURRENT_DESKTOP** request. It is now possible
       to change it using the `setEwmhSwitchDesktopHook`.
+    - Added a customization option for mapping hidden workspaces to screens
+      when setting the **_NET_DESKTOP_VIEWPORT**. This can be done using
+      the `setEwmhHiddenWorkspaceToScreenMapping`.
 
   * `XMonad.Layout.IndependentScreens`
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@
       belong to.
     - Added `doFocus'` hook as an alternative for `doFocus` when using
       IndependentScreens.
+    - Added `screenOnMonitor` for getting the active screen for a monitor.
 
   * `XMonad.Util.NamedScratchPad`
 

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -335,11 +335,10 @@ disableEwmhManageDesktopViewport = XC.modifyDef $ \c -> c{ manageDesktopViewport
 -- > import XMonad.Layout.IndependentScreens
 -- >
 -- > customMapper :: WindowSet -> (WindowSpace -> WindowScreen)
--- > customMapper winset (Workspace wsid _ _) = fromMaybe (W.current winset) screenOnMonitor
+-- > customMapper winset (Workspace wsid _ _) = fromMaybe (W.current winset) maybeMappedScreen
 -- >  where
 -- >    screenId = unmarshallS wsid
--- >    screenOnMonitor :: Maybe WindowScreen
--- >    screenOnMonitor = find ((screenId ==) . W.screen) (W.current winset : W.visible winset)
+-- >    maybeMappedScreen = screenOnMonitor screenId winset
 -- >
 -- >
 -- > main = xmonad $ ... . setEwmhHiddenWorkspaceToScreenMapping customMapper . ewmh . ... $ def{...}

--- a/XMonad/Layout/IndependentScreens.hs
+++ b/XMonad/Layout/IndependentScreens.hs
@@ -26,7 +26,7 @@ module XMonad.Layout.IndependentScreens (
     marshallPP,
     whenCurrentOn,
     countScreens,
-    workspacesOn,
+    workspacesOn, screenOnMonitor,
     workspaceOnScreen, focusWindow', doFocus', focusScreen, focusWorkspace, nthWorkspace, withWspOnScreen,
     -- * Converting between virtual and physical workspaces
     -- $converting
@@ -148,7 +148,7 @@ withWspOnScreen screenId operation ws = case workspaceOnScreen screenId ws of
     Just wsp -> operation wsp ws
     Nothing -> ws
 
--- | Get the workspace that is active on a given screen.
+-- | Get the screen that is active on a given monitor.
 screenOnMonitor :: ScreenId -> WindowSet -> Maybe WindowScreen
 screenOnMonitor screenId ws = find ((screenId ==) . W.screen) (W.current ws : W.visible ws)
 


### PR DESCRIPTION
### Description

The default assignment of hidden workspaces to the current screen is a good default, but it is not always desired.
An example for this would be a configuration that uses independent screens, because in that context workspaces
belong to certain screens which the *EWMH* module can't and won't consider when using the default behavior.

As far as I am able to tell the *EWMH* specification does not prescribe how hidden workspaces should be
assigned to screens, therefore I believe allowing customization is acceptable.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: That since the modification is nested in a function that returns `X ()` manual
        testing is the only option. I am currently using this modification in my window manager and it works as expected.

  - [x] I updated the `CHANGES.md` file
