### PR TITLE
X.U.EZConfig: support "<Menu>" for xK_Menu key.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
   * `XMonad.Util.EZConfig`
 
-    - Added `XF86WLAN` to the list of supported special keys.
+    - Added `XF86WLAN` and `Menu` to the list of supported special keys.
 
   * `XMonad.Actions.DynamicProjects`
 

--- a/XMonad/Prelude.hs
+++ b/XMonad/Prelude.hs
@@ -313,6 +313,7 @@ specialKeys =
   , ("KP_7"       , xK_KP_7)
   , ("KP_8"       , xK_KP_8)
   , ("KP_9"       , xK_KP_9)
+  , ("Menu"       , xK_Menu)
   ]
 
 -- | List of multimedia keys. If Xlib does not know about some keysym


### PR DESCRIPTION
### Description

I've been using Menu key to launch terminal for years; for some reason only now I realized it is not supported by X.U.EZConfig.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've tested this manually, and it works :)

  - [x] I updated the `CHANGES.md` file
