### PR TITLE
X.U.XSelection: Add 'getClipboard'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Util.XSelection`
+
+    - Added `getClipboard` to query the X clipboard.
+      Also added `getSecondarySelection`.
+
   * `XMonad.Util.EZConfig`
 
     - Added `XF86WLAN` and `Menu` to the list of supported special keys.

--- a/XMonad/Util/XSelection.hs
+++ b/XMonad/Util/XSelection.hs
@@ -33,12 +33,28 @@ import Codec.Binary.UTF8.String (decode)
 
 {- $usage
    Add @import XMonad.Util.XSelection@ to the top of Config.hs
-   Then make use of getSelection or promptSelection as needed; if
-   one wanted to run Firefox with the selection as an argument (perhaps
+
+   If one wanted to run Firefox with the selection as an argument (perhaps
    the selection string is an URL you just highlighted), then one could add
    to the xmonad.hs a line like thus:
 
    > , ((modm .|. shiftMask, xK_b), promptSelection "firefox")
+
+   To add a 'paste' keybinding in your prompts, use:
+
+   > prompt_extra_bindings = [
+   >   ((mod1Mask, xK_v), getClipboard >>= insertString) -- Alt+v to paste
+   >   ]
+   > 
+   > prompt_conf = def {
+   >   promptKeymap =
+   >     foldl (\m (k, a) -> M.insert k a m) defaultXPKeymap prompt_extra_bindings,
+   >   -- other prompt config
+   > }
+
+   Next use it to construct a prompt, for example in your bindings:
+
+   > ("M-p", shellPrompt prompt_conf),
 
    Future improvements for XSelection:
 

--- a/XMonad/Util/XSelection.hs
+++ b/XMonad/Util/XSelection.hs
@@ -69,7 +69,8 @@ getSelection = io $ do
     result <- if ev_event_type ev == selectionNotify
                  then do res <- getWindowProperty8 dpy clp win
                          return $ decode . maybe [] (map fromIntegral) $ res
-                 else destroyWindow dpy win >> return ""
+                 else return ""
+    destroyWindow dpy win
     closeDisplay dpy
     return result
 

--- a/XMonad/Util/XSelection.hs
+++ b/XMonad/Util/XSelection.hs
@@ -59,7 +59,12 @@ import Codec.Binary.UTF8.String (decode)
    Future improvements for XSelection:
 
    * More elaborate functionality: Emacs' registers are nice; if you
-      don't know what they are, see <http://www.gnu.org/software/emacs/manual/html_node/emacs/Registers.html#Registers> -}
+      don't know what they are, see <http://www.gnu.org/software/emacs/manual/html_node/emacs/Registers.html#Registers>
+
+   WARNING: these functions are fundamentally implemented incorrectly and may,
+   among other possible failure modes, deadlock or crash. For details, see
+   <http://code.google.com/p/xmonad/issues/detail?id=573>.
+   (These errors are generally very rare in practice, but still exist.) -}
 
 -- Query the content of a selection in X
 getSelectionNamed :: String -> IO String
@@ -89,28 +94,16 @@ getSelectionNamed sel_name = do
 
 -- | Returns a String corresponding to the current mouse selection in X;
 --   if there is none, an empty string is returned.
---
--- WARNING: this function is fundamentally implemented incorrectly and may, among other possible failure modes,
--- deadlock or crash. For details, see <http://code.google.com/p/xmonad/issues/detail?id=573>.
--- (These errors are generally very rare in practice, but still exist.)
 getSelection :: MonadIO m => m String
 getSelection = io $ getSelectionNamed "PRIMARY"
 
 -- | Returns a String corresponding to the current clipboard in X;
 --   if there is none, an empty string is returned.
---
--- WARNING: this function is fundamentally implemented incorrectly and may, among other possible failure modes,
--- deadlock or crash. For details, see <http://code.google.com/p/xmonad/issues/detail?id=573>.
--- (These errors are generally very rare in practice, but still exist.)
 getClipboard :: MonadIO m => m String
 getClipboard = io $ getSelectionNamed "CLIPBOARD"
 
 -- | Returns a String corresponding to the secondary selection in X;
 --   if there is none, an empty string is returned.
---
--- WARNING: this function is fundamentally implemented incorrectly and may, among other possible failure modes,
--- deadlock or crash. For details, see <http://code.google.com/p/xmonad/issues/detail?id=573>.
--- (These errors are generally very rare in practice, but still exist.)
 getSecondarySelection :: MonadIO m => m String
 getSecondarySelection = io $ getSelectionNamed "SECONDARY"
 

--- a/XMonad/Util/XSelection.hs
+++ b/XMonad/Util/XSelection.hs
@@ -62,6 +62,7 @@ import Codec.Binary.UTF8.String (decode)
       don't know what they are, see <http://www.gnu.org/software/emacs/manual/html_node/emacs/Registers.html#Registers> -}
 
 -- Query the content of a selection in X
+getSelectionNamed :: String -> IO String
 getSelectionNamed sel_name = do
   dpy <- openDisplay ""
   let dflt = defaultScreen dpy


### PR DESCRIPTION
### Description

I needed a function for querying the clipboard for the purpose of customizing my prompts and I thought it might be a good addition to `XSelection`.

This function allows querying the X clipboard, which is more commonly used than the primary selection.
The code for `getSelection` and `getClipboard` would be very similar and are factored into a `getSelectionNamed` internal function.
`getSecondarySelection` is also added to make the X selection support
more complete and to avoid exposing `getSelectionNamed`.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [ ] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: XXX

  - [x] I updated the `CHANGES.md` file
