### PR TITLE
support time-1.15

### DIFF
--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -59,7 +59,7 @@ library
                    containers >= 0.5 && < 0.9,
                    directory,
                    filepath,
-                   time >= 1.8 && < 1.15,
+                   time >= 1.8 && < 1.16,
                    process,
                    random,
                    mtl >= 1 && < 3,


### PR DESCRIPTION
### Description

`time-1.15` was recently released.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested locally with `--constraint=time==1.15 --allow-newer=time`

  - [ ] I updated the `CHANGES.md` file
