### PR TITLE
X.A.Search: Add multiChar, combineChar, and prefixAwareChar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,13 @@
     - Fix unintended window hiding in `nsSingleScratchpadPerWorkspace`.
       Only hide the previously active scratchpad.
 
+  * `XMonad.Actions.Search`
+
+    - Added `multiChar`, `combineChar`, and `prefixAwareChar` as
+      slightly generalised versions of `prefixAware` and `(!>)` that
+      allow specifying the character that separates a search engine's
+      prefix with the query when combining engines.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes


### PR DESCRIPTION
### Description

Added `multiChar`, `combineChar`, and `prefixAwareChar` as slightly generalised versions of `prefixAware` and `(!>)` that allow specifying the character that separates a search engine's prefix with the query when combining engines.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Tested `multiChar` manually and made sure that I didn't accidentally destroy `(!>)` et al

  - [x] I updated the `CHANGES.md` file
