### PR TITLE
X.H.ManageDocks: Add `onAllDocks`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,10 @@
       allow specifying the character that separates a search engine's
       prefix with the query when combining engines.
 
+  * `XMonad.Hooks.ManageDocks`
+
+    - Added `onAllDocks` to run an action on all recognised docks.
+
 ## 0.18.1 (August 20, 2024)
 
 ### Breaking Changes

--- a/XMonad/Hooks/ManageDocks.hs
+++ b/XMonad/Hooks/ManageDocks.hs
@@ -16,7 +16,7 @@
 module XMonad.Hooks.ManageDocks (
     -- * Usage
     -- $usage
-    docks, manageDocks, checkDock, AvoidStruts(..), avoidStruts, avoidStrutsOn,
+    docks, manageDocks, checkDock, AvoidStruts(..), avoidStruts, avoidStrutsOn, onAllDocks,
     ToggleStruts(..),
     SetStruts(..),
     module XMonad.Util.Types,
@@ -133,6 +133,10 @@ updateStrut w cache = do
     when (w `M.notMember` cache) $ requestDockEvents w
     strut <- getStrut w
     pure $ M.insert w strut cache
+
+-- | Perform the given action on all docks.
+onAllDocks :: (Window -> X ()) -> X ()
+onAllDocks act = traverse_ (act . fst) . M.toList =<< getStrutCache
 
 -- | Detects if the given window is of type DOCK and if so, reveals
 --   it, but does not manage it.


### PR DESCRIPTION
### Description

Just a small helper to act on all docks in a reasonable manner (without having to `queryTree` all the time).
Also a small simplification of an internal function I saw when scrolling through the module.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Tests still pass, and `onAllDocks` was tested manually.

  - [x] I updated the `CHANGES.md` file