### PR TITLE
X.H.SB.PP: Added `ppCurrentNoWindows`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,15 +6,6 @@
 
   * Drop support for GHC 8.6
 
-  * `XMonad.Hooks.StatusBar.PP`
-
-    - Added `ppCurrentNoWindows` to `PP`, to match `ppHiddenNoWindows`
-      and `ppVisibleNoWindows`.
-    - Added `isCurrentNoWindows` and `hasWindows` predicates.
-    - `isCurrent` now checks if the workspace contains any windows,
-      akin to `isVisible`. This may break certain configurations that
-      rely on `isCurrent`.
-
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Actions.WindowBringer`
@@ -99,6 +90,18 @@
   * `XMonad.Hooks.ManageDocks`
 
     - Added `onAllDocks` to run an action on all recognised docks.
+
+  * `XMonad.Hooks.StatusBar.PP`
+
+    - Added `ppCurrentNoWindows` to `PP`, to match `ppHiddenNoWindows`
+      and `ppVisibleNoWindows`. `ppCurrentNoWindows` falls back
+      to `ppCurrent` if unset/set to `Nothing`.
+    - Added `isCurrentNoWindows`, `isCurrentHasWindows`, and `hasWindows`
+      predicates.
+    - `isCurrent` remains as was and doesn't check for presence
+      of windows. The changes only added a simple way to check whether
+      the workspace is a current workspace that does/doesn't contain
+      windows.
 
 ## 0.18.1 (August 20, 2024)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,15 @@
 
   * Drop support for GHC 8.6
 
+  * `XMonad.Hooks.StatusBar.PP`
+
+    - Added `ppCurrentNoWindows` to `PP`, to match `ppHiddenNoWindows`
+      and `ppVisibleNoWindows`.
+    - Added `isCurrentNoWindows` and `hasWindows` predicates.
+    - `isCurrent` now checks if the workspace contains any windows,
+      akin to `isVisible`. This may break certain configurations that
+      rely on `isCurrent`.
+
 ### Bug Fixes and Minor Changes
 
   * `XMonad.Actions.WindowBringer`


### PR DESCRIPTION
### Description

We already have `ppVisibleNoWindows` and `ppHiddenNoWindows`, this change adds the missing `ppCurrentNoWindows` printer, as well as matching predicates (`isCurrentNoWindows`, `isCurrentHasWindows`, `hasWindows`). `isCurrent` remains as was and doesn't care about windows. However, the new predicates allow you to check whether a layout is the `current` one but also contains/doesn't contain windows. `ppCurrentNoWindows` falls back to `ppCurrent` if set to `Nothing` (also the default value), so existing configurations should not break in any way, but can be extended easily.

This PR shouldn't break anything as the existing public API remains unchanged, with only slight internal implementation changes and new additions to the API.

It's also not strictly necessary, you could achieve similar results by using `ppPrinters` and creating a custom predicate, but that just seems like an inconsistent and complicated way to do it, when we already have the other two printers. The change in code is rather small and could simplify configuration for some users.

In the first picture, the workspace has at least one window open.

<img width="199" height="34" alt="current" src="https://github.com/user-attachments/assets/bca4a5fd-6050-4bc7-8eb7-4da830530784" />

And here's an example of the current workspace not having any windows open.

<img width="198" height="33" alt="current-no-windows" src="https://github.com/user-attachments/assets/60dc9cef-c3e6-49e1-b5b7-cc53795867d6" />

Sample configuration, which should allow you to reproduce the example with Xmobar.

```haskell
xmobarPP' :: PP
xmobarPP' = def
    { ppCurrent          = pad . xmobarBorder "Bottom" "#6dcbfa" 3 . white
    , ppCurrentNoWindows = Just $ pad . xmobarBorder "Bottom" "#6dcbfa" 3 . gray
    , ppVisible          = pad . xmobarBorder "Bottom" "#215975" 3 . white
    , ppVisibleNoWindows = Just $ pad . xmobarBorder "Bottom" "#215975" 3 . gray
    , ppHidden           = white . pad
    , ppHiddenNoWindows  = gray . pad
    }
  where
      white        = xmobarColor "#e0e0e0" ""
      gray         = xmobarColor "#89878e" ""
```

### Checklist

  - [*] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [*] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: Test manually, swap to a workspace with no windows

  - [*] I updated the `CHANGES.md` file
