### PR TITLE
Add support for `_NET_WM_USER_TIME`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,20 @@
       * No longer does a modifier need to be lifted in order to conclude the
         selection; any unexpected keypress (or release) will do.
 
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - `_NET_WM_USER_TIME` and `_NET_WM_USER_TIME_WINDOW` were added to the list
+      of supported hints (as per `_NET_SUPPORTED`). These hints are understood
+      by the new `X.H.ManageHelpers.hasNoFocusOnMap` predicate. This enables
+      certain applications (e.g. Emacs text editor) that check whether the hint
+      is supported to use it.
+
+  * `XMonad.Hooks.ManageHelpers`
+
+    - Added `hasNoFocusOnMap` predicate to check for windows with a
+      `_NET_WM_USER_TIME` property value of zero, which requests that a new
+      window not receive focus.
+
 ## 0.18.2 (March 7, 2026)
 
 ### Breaking Changes

--- a/XMonad/Hooks/EwmhDesktops.hs
+++ b/XMonad/Hooks/EwmhDesktops.hs
@@ -773,6 +773,8 @@ setSupported = withDisplay $ \dpy -> do
                          ,"_NET_WM_DESKTOP"
                          ,"_NET_WM_STRUT"
                          ,"_NET_WM_STRUT_PARTIAL"
+                         ,"_NET_WM_USER_TIME"
+                         ,"_NET_WM_USER_TIME_WINDOW"
                          ,"_NET_DESKTOP_VIEWPORT"
                          ]
     io $ changeProperty32 dpy r a aTOM propModeReplace (fmap fromIntegral supp)

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -52,6 +52,7 @@ module XMonad.Hooks.ManageHelpers (
     isMinimized,
     isDialog,
     isNotification,
+    hasNoFocusOnMap,
     pid,
     desktop,
     transientTo,
@@ -82,6 +83,7 @@ import XMonad.Prelude
 import qualified XMonad.StackSet as W
 import XMonad.Util.WindowProperties (getProp32s)
 
+import Control.Monad.Trans.Maybe (MaybeT (..))
 import System.Posix (ProcessID)
 
 -- | Denotes a side of a screen. @S@ stands for South, @NE@ for Northeast
@@ -203,6 +205,32 @@ isDialog = isInProperty "_NET_WM_WINDOW_TYPE" "_NET_WM_WINDOW_TYPE_DIALOG"
 isNotification :: Query Bool
 isNotification =
   isInProperty "_NET_WM_WINDOW_TYPE" "_NET_WM_WINDOW_TYPE_NOTIFICATION"
+
+-- | A predicate to check whether a window should avoid stealing focus
+-- when it is mapped. This is the case when the @_NET_WM_USER_TIME@
+-- property for a particular window is zero. Useful with
+-- 'XMonad.Hooks.Focus.keepFocus', for example:
+--
+-- > import XMonad.Hooks.Focus
+-- > -- Honour requests from Emacs to not switch focus to new windows.
+-- > myFocus :: FocusHook
+-- > myFocus = new (className =? "Emacs" <&&> hasNoFocusOnMap) --> keepFocus
+--
+-- See <https://specifications.freedesktop.org/wm/1.5/ar01s05.html#id-1.6.16>.
+hasNoFocusOnMap :: Query Bool
+hasNoFocusOnMap = do
+    w <- ask
+    -- Per the spec, _NET_WM_USER_TIME_WINDOW should take precedence
+    -- over _NET_WM_USER_TIME. However, some X clients set a zero
+    -- value only on the base window, so check both.
+    liftX . fmap isJust . runMaybeT $ maybeZero w <|> maybeZeroW w
+  where
+    maybeZero w = do
+        [t] <- MaybeT $ getProp32s "_NET_WM_USER_TIME" w
+        guard $ t == 0
+    maybeZeroW w = do
+        [w'] <- MaybeT $ getProp32s "_NET_WM_USER_TIME_WINDOW" w
+        maybeZero $ fi w'
 
 -- | This function returns 'Just' the @_NET_WM_PID@ property for a
 -- particular window if set, 'Nothing' otherwise.

--- a/XMonad/Hooks/ManageHelpers.hs
+++ b/XMonad/Hooks/ManageHelpers.hs
@@ -83,7 +83,6 @@ import XMonad.Prelude
 import qualified XMonad.StackSet as W
 import XMonad.Util.WindowProperties (getProp32s)
 
-import Control.Monad.Trans.Maybe (MaybeT (..))
 import System.Posix (ProcessID)
 
 -- | Denotes a side of a screen. @S@ stands for South, @NE@ for Northeast
@@ -223,13 +222,11 @@ hasNoFocusOnMap = do
     -- Per the spec, _NET_WM_USER_TIME_WINDOW should take precedence
     -- over _NET_WM_USER_TIME. However, some X clients set a zero
     -- value only on the base window, so check both.
-    liftX . fmap isJust . runMaybeT $ maybeZero w <|> maybeZeroW w
+    liftX $ maybeZero w <||> maybeZeroW w
   where
-    maybeZero w = do
-        [t] <- MaybeT $ getProp32s "_NET_WM_USER_TIME" w
-        guard $ t == 0
+    maybeZero w = (Just [0] ==) <$> getProp32s "_NET_WM_USER_TIME" w
     maybeZeroW w = do
-        [w'] <- MaybeT $ getProp32s "_NET_WM_USER_TIME_WINDOW" w
+        Just [w'] <- getProp32s "_NET_WM_USER_TIME_WINDOW" w
         maybeZero $ fi w'
 
 -- | This function returns 'Just' the @_NET_WM_PID@ property for a

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -498,6 +498,7 @@ test-suite tests
                , mtl
                , random
                , process
+               , transformers
                , unix
                , utf8-string
                , deepseq

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -498,7 +498,6 @@ test-suite tests
                , mtl
                , random
                , process
-               , transformers
                , unix
                , utf8-string
                , deepseq


### PR DESCRIPTION
### Description

This PR implements:
- #973

Namely, it:
- advertises `_NET_WM_USER_TIME` and `_NET_WM_USER_TIME_WINDOW` support in `X.H.EwmhDesktops.setSupported`; and
- adds a predicate `X.H.ManageHelpers.hasNoFocusOnMap` which checks these properties.

Things I'm unsure of:

- The name and sense of the new predicate. Negatives can be confusing, but at the same time it checks for a non-default situation, thus does not require logical negation in a custom `ManageHook`, as seen in the example I included in its Haddock comment.

- ~Why I see this error when running `stack test` locally:~
  ```
  xmonad-contrib> Preprocessing test suite 'tests' for xmonad-contrib-0.18.2.9...
  xmonad-contrib> Building test suite 'tests' for xmonad-contrib-0.18.2.9...
  xmonad-contrib> [45 of 65] Compiling XMonad.Hooks.ManageHelpers
  xmonad-contrib> /home/blc/.config/xmonad/xmonad-contrib/XMonad/Hooks/ManageHelpers.hs:86:1: error: [GHC-87110]
  xmonad-contrib>     Could not load module ‘Control.Monad.Trans.Maybe’.
  xmonad-contrib>     It is a member of the hidden package ‘transformers-0.6.1.1’.
  xmonad-contrib>     Perhaps you need to add ‘transformers’ to the build-depends in your .cabal file.
  xmonad-contrib>     Use -v to see a list of the files searched for.
  xmonad-contrib>    |
  xmonad-contrib> 86 | import Control.Monad.Trans.Maybe (MaybeT (..))
  xmonad-contrib>    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  xmonad-contrib>
  ```
  ~seeing as `C.M.T.Maybe` is already used in `xmonad-contrib`, and `xmonad-contrib.cabal` already lists `transformers` under `build-depends`.~

- ~Whether to split the first commit (which updates stale freedesktop.org URLs, like xmonad/xmonad#559) into a separate PR.~

- Related to the previous two points: this is my first public contribution in Haskell, let alone XMonad, so please point out any mistakes or changes needed.

Thanks!

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: manually, with Emacs as an X client

  - [X] I updated the `CHANGES.md` file