### PR TITLE
Improve MRU ergonomics by concluding repeatable actions gracefully

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Actions.Repeatable`
+
+    - Generalised the `repeatable` family of functions with new `concludable`
+      variants, providing control over how repeatable actions conclude.
+
 ## 0.18.2 (March 7, 2026)
 
 ### Breaking Changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,16 @@
     - Generalised the `repeatable` family of functions with new `concludable`
       variants, providing control over how repeatable actions conclude.
 
+  * `XMonad.Actions.MostRecentlyUsed`
+
+    - Improved ergonomics for `mostRecentlyUsed`.
+
+      * The *Escape* key can now be used to cancel the selection and return
+        whence you came.
+
+      * No longer does a modifier need to be lifted in order to conclude the
+        selection; any unexpected keypress (or release) will do.
+
 ## 0.18.2 (March 7, 2026)
 
 ### Breaking Changes

--- a/XMonad/Actions/MostRecentlyUsed.hs
+++ b/XMonad/Actions/MostRecentlyUsed.hs
@@ -1,13 +1,17 @@
-{-# LANGUAGE NamedFieldPuns, GeneralizedNewtypeDeriving #-}
+{-#
+LANGUAGE
+  BlockArguments, NamedFieldPuns, MultiWayIf,
+  GeneralizedNewtypeDeriving, FlexibleContexts
+#-}
 
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Actions.MostRecentlyUsed
 -- Description :  Tab through windows by recency of use.
--- Copyright   :  (c) 2022 L. S. Leary
+-- Copyright   :  (c) 2022,2026 L. S. Leary
 -- License     :  BSD3-style (see LICENSE)
 --
--- Maintainer  :  @LSLeary (on github)
+-- Maintainer  :  L.S.Leary.II@gmail.com
 -- Stability   :  unstable
 -- Portability :  unportable
 --
@@ -44,7 +48,7 @@ import qualified Data.Map.Strict as M
 
 -- xmonad
 import XMonad
-  ( Window, KeySym, keyPress, io
+  ( Window, KeySym, keyRelease, io, xK_Escape
   , Event (DestroyWindowEvent, UnmapEvent, ev_send_event, ev_window)
   )
 import XMonad.Core
@@ -61,7 +65,7 @@ import qualified XMonad.Util.ExtensibleState as XS
 import XMonad.Util.PureX
   (handlingRefresh, curScreenId, curTag, greedyView, view, peek, focusWindow)
 import XMonad.Util.History (History, origin, event, erase, ledger)
-import XMonad.Actions.Repeatable (repeatableSt)
+import XMonad.Actions.Repeatable (concludableSt, NotOurEvent(..), Done(..))
 import XMonad.Prelude
 
 -- }}}
@@ -117,6 +121,7 @@ newtype MRU = MRU () deriving Semigroup
 
 -- | An action to browse through the history of focused windows, taking
 --   another step back with each tap of the key.
+--   Press /Escape/ to cancel the selection and return whence you came.
 mostRecentlyUsed
   :: [KeySym] -- ^ The 'KeySym's corresponding to the modifier to which the
               --   action is bound.
@@ -127,16 +132,16 @@ mostRecentlyUsed mods key = do
   (toUndo, undo) <- undoer
   let undoably curThing withThing thing = curThing >>= \cur ->
         when (cur /= thing) $ withThing thing >> toUndo (withThing cur)
-  withMostRecentlyUsed mods key $ \win Location{workspace,screen} ->
-    handlingRefresh $ do
+  withMostRecentlyUsed mods key \win Location{workspace,screen} ->
+    handlingRefresh do
       undo
       undoably curScreenId viewScreen screen
       undoably curTag      greedyView workspace
       mi <- gets (W.findTag win . windowset)
-      for_ mi $ \i -> do
+      for_ mi \i -> do
         undoably curTag greedyView i
         mfw <- peek
-        for_ mfw $ \fw -> do
+        for_ mfw \fw -> do
           undoably (pure fw) focusWindow win
   where
     undoer :: (MonadIO m, Monoid a) => m (m a -> m (), m a)
@@ -164,20 +169,34 @@ withMostRecentlyUsed mods tab preview = do
   unless busy $ do
     XS.put wh{ busy = True }
 
-    for_ (nonEmpty $ ledger hist) $ \ne -> do
-      mfw <- gets (W.peek . windowset)
-      let iSt = case cycleS ne of
-            (w, _) :~ s | mfw == Just w -> s
-            s                           -> s
-      repeatableSt iSt mods tab $ \t s ->
-        when (t == keyPress && s == tab) (pop >>= lift . uncurry preview)
+    for_ (nonEmpty $ ledger hist) \ne -> do
+      let home    = case        ne of wl :| _   -> wl
+          options = case cycleS ne of _  :~ wls -> wls
+      concludableSt options mods tab pressHandler (eventHandler home)
 
-    XS.modify $ \ws@WinHist{} -> ws{ busy = False }
+    XS.modify \ws@WinHist{} -> ws{ busy = False }
     logWinHist
-  where
+ where
+  pressHandler t s = pure if
+    | s == tab       -> press Next
+    | s == xK_Escape -> press Cancel
+    | otherwise      -> Left NotOurEvent
+   where press = Right . ignore (t == keyRelease)
+  eventHandler home ev = case ev of
+    Ignore -> pure (Right ())
+    Next   -> do
+      (w, l) <- pop
+      lift (Right <$> preview w l)
+    Cancel -> lift (uncurry preview home) $> Left Done
+   where
     pop = do
-      h :~ t <- get
-      put t $> h
+      x :~ xs <- get
+      put xs $> x
+
+data MruEvent = Ignore | Next | Cancel
+
+ignore :: Bool -> MruEvent -> MruEvent
+ignore b e = if b then Ignore else e
 
 -- }}}
 
@@ -203,3 +222,4 @@ winHistEH ev = All True <$ case ev of
   where collect w = XS.modify $ \wh@WinHist{hist} -> wh{ hist = erase w hist }
 
 -- }}}
+

--- a/XMonad/Actions/Repeatable.hs
+++ b/XMonad/Actions/Repeatable.hs
@@ -1,11 +1,13 @@
+{-# LANGUAGE BangPatterns, BlockArguments, LambdaCase #-}
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  XMonad.Actions.Repeatable
 -- Description :  Actions you'd like to repeat.
--- Copyright   :  (c) 2022 L. S. Leary
+-- Copyright   :  (c) 2022,2026 L. S. Leary
 -- License     :  BSD3-style (see LICENSE)
 --
--- Maintainer  :  @LSLeary (on github)
+-- Maintainer  :  L.S.Leary.II@gmail.com
 -- Stability   :  unstable
 -- Portability :  unportable
 --
@@ -17,11 +19,24 @@
 --
 -----------------------------------------------------------------------------
 
-module XMonad.Actions.Repeatable
-  ( repeatable
-  , repeatableSt
-  , repeatableM
-  ) where
+module XMonad.Actions.Repeatable (
+
+  -- * Repeatable
+  repeatable,
+  repeatableSt,
+  repeatableM,
+
+  -- * Concludable
+  NotOurEvent(..),
+  Done(..),
+  concludable,
+  concludableSt,
+  concludableM,
+
+) where
+
+-- base
+import Data.Functor (($>))
 
 -- mtl
 import Control.Monad.State (StateT(..))
@@ -55,7 +70,7 @@ repeatableSt
                                            --   action.
   -> (EventType -> KeySym -> StateT s X a) -- ^ The keypress handler.
   -> X (a, s)
-repeatableSt iSt = repeatableM $ \m -> runStateT m iSt
+repeatableSt iSt = repeatableM \m -> runStateT m iSt
 
 -- | A more general variant of 'repeatable' with an arbitrary monadic handler,
 --   accumulating a monoidal return value throughout the events.
@@ -67,23 +82,100 @@ repeatableM
   -> KeySym                       -- ^ The keypress that invokes the action.
   -> (EventType -> KeySym -> m a) -- ^ The keypress handler.
   -> X b
-repeatableM run mods key pressHandler = do
-  XConf{ theRoot = root, display = d } <- ask
-  run (repeatableRaw d root mods key pressHandler)
+repeatableM run mods key handler = concludableM run mods key press event
+ where
+  press t s = pure (Right (t, s))
+  event (t, s) = Right <$> handler t s
 
-repeatableRaw
+
+data Done        = Done
+data NotOurEvent = NotOurEvent
+
+-- | A generalisation of `repeatable` which may conclude early with `NotOurEvent` or `Done`.
+concludable
+  -- | The list of 'KeySym's under the modifiers used to invoke the action.
+  :: [KeySym]
+  -- | The keypress that invokes the action.
+  -> KeySym
+  -- | Handle keypresses by translating them into custom events.
+  --   If the function produces `NotOurEvent` then we conclude and put the
+  --   X `Event` back into the queue.
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -- | The custom event handler.
+  -> (e -> X (Either Done ()))
+  -> X ()
+concludable = concludableM id
+
+-- | A more general variant of 'concludable' with a stateful handler,
+--   accumulating a monoidal return value throughout the events.
+concludableSt
+  :: Monoid a
+  -- | Initial state.
+  => s
+  -- | The list of 'KeySym's under the modifiers used to invoke the action.
+  -> [KeySym]
+  -- | The keypress that invokes the action.
+  -> KeySym
+  -- | Handle keypresses by translating them into custom events.
+  --   If the function produces `NotOurEvent` then we conclude and put the
+  --   X `Event` back into the queue.
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -- | The custom event handler.
+  -> (e -> StateT s X (Either Done a))
+  -> X (a, s)
+concludableSt iSt = concludableM \m -> runStateT m iSt
+
+-- | A more general variant of 'concludable' with an arbitrary monadic handler,
+--   accumulating a monoidal return value throughout the events.
+concludableM
+  :: (MonadIO m, Monoid a)
+  -- | How to run the monad in 'X'.
+  => (m a -> X b)
+  -- | The list of 'KeySym's under the modifiers used to invoke the action.
+  -> [KeySym]
+  -- | The keypress that invokes the action.
+  -> KeySym
+  -- | Handle keypresses by translating them into custom events.
+  --   If the function produces `NotOurEvent` then we conclude and put the
+  --   X `Event` back into the queue.
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -- | The custom event handler.
+  -> (e -> m (Either Done a))
+  -> X b
+concludableM run mods key pressHandler eventHandler = do
+  XConf{ theRoot = root, display = d } <- ask
+  run (concludableRaw d root mods key pressHandler eventHandler)
+
+concludableRaw
   :: (MonadIO m, Monoid a)
   => Display -> Window
-  -> [KeySym] -> KeySym -> (EventType -> KeySym -> m a) -> m a
-repeatableRaw d root mods key pressHandler = do
+  -> [KeySym] -> KeySym
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -> (e -> m (Either Done a))
+  -> m a
+concludableRaw d root mods key pressHandler eventHandler = do
   io (grabKeyboard d root False grabModeAsync grabModeAsync currentTime)
-  handleEvent (keyPress, key) <* io (ungrabKeyboard d currentTime)
-  where
-    getNextEvent = io $ allocaXEvent $ \p -> do
-      maskEvent d (keyPressMask .|. keyReleaseMask) p
-      KeyEvent{ ev_event_type = t, ev_keycode = c } <- getEvent p
-      s <- keycodeToKeysym d c 0
-      return (t, s)
-    handleEvent (t, s)
-      | t == keyRelease && s `elem` mods = pure mempty
-      | otherwise = (<>) <$> pressHandler t s <*> (getNextEvent >>= handleEvent)
+  mev <- io (pressHandler' (pure ()) keyPress key)
+  x   <- maybe (pure mempty) (eventHandler' mempty) mev
+  io (ungrabKeyboard d currentTime)
+  pure x
+ where
+  pressHandler' putBack t s
+    | t == keyRelease && s `elem` mods = pure Nothing
+    | otherwise                        = pressHandler t s >>= \case
+      Left NotOurEvent -> putBack $> Nothing
+      Right ev         -> pure (Just ev)
+  eventHandler' !x ev = do
+    c <- eventHandler ev
+    case c of
+      Left  Done -> pure x
+      Right y    -> do
+        mev <- getNextEvent
+        maybe (pure xy) (eventHandler' xy) mev
+       where xy = x <> y
+  getNextEvent = (io . allocaXEvent) \p -> do
+    maskEvent d (keyPressMask .|. keyReleaseMask) p
+    KeyEvent{ ev_event_type = t, ev_keycode = c } <- getEvent p
+    s <- keycodeToKeysym d c 0
+    pressHandler' (putBackEvent d p) t s
+

--- a/XMonad/Actions/Repeatable.hs
+++ b/XMonad/Actions/Repeatable.hs
@@ -70,7 +70,7 @@ repeatableSt
                                            --   action.
   -> (EventType -> KeySym -> StateT s X a) -- ^ The keypress handler.
   -> X (a, s)
-repeatableSt iSt = repeatableM \m -> runStateT m iSt
+repeatableSt iSt = repeatableM (`runStateT` iSt)
 
 -- | A more general variant of 'repeatable' with an arbitrary monadic handler,
 --   accumulating a monoidal return value throughout the events.
@@ -93,16 +93,16 @@ data NotOurEvent = NotOurEvent
 
 -- | A generalisation of `repeatable` which may conclude early with `NotOurEvent` or `Done`.
 concludable
-  -- | The list of 'KeySym's under the modifiers used to invoke the action.
   :: [KeySym]
-  -- | The keypress that invokes the action.
+  -- ^ The list of 'KeySym's under the modifiers used to invoke the action.
   -> KeySym
-  -- | Handle keypresses by translating them into custom events.
+  -- ^ The keypress that invokes the action.
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -- ^ Handle keypresses by translating them into custom events.
   --   If the function produces `NotOurEvent` then we conclude and put the
   --   X `Event` back into the queue.
-  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
-  -- | The custom event handler.
   -> (e -> X (Either Done ()))
+  -- ^ The custom event handler.
   -> X ()
 concludable = concludableM id
 
@@ -110,37 +110,37 @@ concludable = concludableM id
 --   accumulating a monoidal return value throughout the events.
 concludableSt
   :: Monoid a
-  -- | Initial state.
   => s
-  -- | The list of 'KeySym's under the modifiers used to invoke the action.
+  -- ^ Initial state.
   -> [KeySym]
-  -- | The keypress that invokes the action.
+  -- ^ The list of 'KeySym's under the modifiers used to invoke the action.
   -> KeySym
-  -- | Handle keypresses by translating them into custom events.
+  -- ^ The keypress that invokes the action.
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -- ^ Handle keypresses by translating them into custom events.
   --   If the function produces `NotOurEvent` then we conclude and put the
   --   X `Event` back into the queue.
-  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
-  -- | The custom event handler.
   -> (e -> StateT s X (Either Done a))
+  -- ^ The custom event handler.
   -> X (a, s)
-concludableSt iSt = concludableM \m -> runStateT m iSt
+concludableSt iSt = concludableM (`runStateT` iSt)
 
 -- | A more general variant of 'concludable' with an arbitrary monadic handler,
 --   accumulating a monoidal return value throughout the events.
 concludableM
   :: (MonadIO m, Monoid a)
-  -- | How to run the monad in 'X'.
   => (m a -> X b)
-  -- | The list of 'KeySym's under the modifiers used to invoke the action.
+  -- ^ How to run the monad in 'X'.
   -> [KeySym]
-  -- | The keypress that invokes the action.
+  -- ^ The list of 'KeySym's under the modifiers used to invoke the action.
   -> KeySym
-  -- | Handle keypresses by translating them into custom events.
+  -- ^ The keypress that invokes the action.
+  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
+  -- ^ Handle keypresses by translating them into custom events.
   --   If the function produces `NotOurEvent` then we conclude and put the
   --   X `Event` back into the queue.
-  -> (EventType -> KeySym -> IO (Either NotOurEvent e))
-  -- | The custom event handler.
   -> (e -> m (Either Done a))
+  -- ^ The custom event handler.
   -> X b
 concludableM run mods key pressHandler eventHandler = do
   XConf{ theRoot = root, display = d } <- ask
@@ -178,4 +178,3 @@ concludableRaw d root mods key pressHandler eventHandler = do
     KeyEvent{ ev_event_type = t, ev_keycode = c } <- getEvent p
     s <- keycodeToKeysym d c 0
     pressHandler' (putBackEvent d p) t s
-


### PR DESCRIPTION
### Description

I started using `X.A.MRU` and found the ergonomics rather lacking—having to lift the modifier to conclude the selection is a painful interruption to my flow. Fixing that required generalisation of `X.A.Repeatable`, which other users of the module may also benefit from.

#### *X.A.Repeatable: Support graceful conclusion*

>  * `XMonad.Actions.Repeatable`
>
>    - Generalised the `repeatable` family of functions with new `concludable`
>      variants, providing control over how repeatable actions conclude.

#### *X.A.MostRecentlyUsed: Improve ergonomics*

>  * `XMonad.Actions.MostRecentlyUsed`
>
>    - Improved ergonomics for `mostRecentlyUsed`.
>
>      * The *Escape* key can now be used to cancel the selection and return
>        whence you came.
>
>      * No longer does a modifier need to be lifted in order to conclude the
>        selection; any unexpected keypress (or release) will do.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded:

    * They work so far as my limited personal usage can tell, but the more eyes the better.

  - [x] I updated the `CHANGES.md` file
