### PR TITLE
Add XMonad.Hooks.Qubes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@
 
 ### New Modules
 
+  * `XMonad.Hooks.Qubes`
+
+    - Refresh focused and visible window borders from the
+      `_QUBES_LABEL_COLOR` property used by Qubes OS.
+
 ### Bug Fixes and Minor Changes
 
 ## 0.18.2 (March 7, 2026)

--- a/XMonad/Hooks/Qubes.hs
+++ b/XMonad/Hooks/Qubes.hs
@@ -1,0 +1,72 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Hooks.Qubes
+-- Description :  Use Qubes OS label colours for window borders.
+-- Copyright   :  (c) Roland C. Dowdeswell <elric@imrryr.org>
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  Roland C. Dowdeswell <elric@imrryr.org>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Refresh window borders from the @_QUBES_LABEL_COLOR@ property set by
+-- Qubes OS so focused and unfocused windows match their qube label.
+--
+-----------------------------------------------------------------------------
+module XMonad.Hooks.Qubes
+    ( -- * Usage
+      -- $usage
+      qubesLogHook
+    ) where
+
+import Data.Bits
+import Foreign.C.Types (CLong)
+
+import           XMonad
+import qualified XMonad.StackSet as W
+
+-- $usage
+-- You can use this module with the following in your @xmonad.hs@:
+--
+-- > import XMonad
+-- > import XMonad.Hooks.Qubes
+-- >
+-- > main = xmonad def
+-- >     { logHook = qubesLogHook
+-- >     }
+
+-- | Refresh visible window borders using their Qubes label colours.
+qubesLogHook :: X ()
+qubesLogHook = withWindowSet $ \s -> withDisplay $ \d -> do
+    let visibleWins = (W.integrate' . W.stack . W.workspace . W.current $ s)
+                   ++ concatMap (W.integrate' . W.stack . W.workspace)
+                                (W.visible s)
+        focused = W.peek s
+    mapM_ (setQubesBorder d focused) visibleWins
+
+setQubesBorder :: Display -> Maybe Window -> Window -> X ()
+setQubesBorder d focused w = do
+    s <- getCardinalProperty d w "_QUBES_LABEL_COLOR"
+    let border = qubesBorderColour s focused w
+    io $ setWindowBorder d w border
+
+qubesBorderColour :: Maybe [CLong] -> Maybe Window -> Window -> Pixel
+qubesBorderColour s focused w =
+    getColour s (if Just w == focused then focusIn else focusOut)
+
+fadeByte :: Int -> Pixel -> Pixel
+fadeByte sw c = (0x7f .&. c `shiftR` (sw + 1)) `shiftL` sw
+
+fadeColour :: EventType -> Pixel -> Pixel
+fadeColour f c
+    | f == focusIn = c
+    | otherwise = fadeByte 16 c .|. fadeByte 8 c .|. fadeByte 0 c
+
+getColour :: Maybe [CLong] -> EventType -> Pixel
+getColour (Just [s]) f = fadeColour f (fromIntegral s)
+getColour _ _ = 0x000000
+
+getCardinalProperty :: Display -> Window -> String -> X (Maybe [CLong])
+getCardinalProperty d w p = do
+    a <- getAtom p
+    io $ getWindowProperty32 d a w

--- a/xmonad-contrib.cabal
+++ b/xmonad-contrib.cabal
@@ -208,6 +208,7 @@ library
                         XMonad.Hooks.OnPropertyChange
                         XMonad.Hooks.Place
                         XMonad.Hooks.PositionStoreHooks
+                        XMonad.Hooks.Qubes
                         XMonad.Hooks.RefocusLast
                         XMonad.Hooks.Rescreen
                         XMonad.Hooks.ScreenCorners


### PR DESCRIPTION
### Description

We add hooks to set border colours on Qubes as they are set in supported window managers.

### Checklist

  - [X] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [X] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: test manually

  - [X] I updated the `CHANGES.md` file
