### PR TITLE
`ManageDebug`: allow stack logging to `Handle`s and add `xmessage` output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@
 
 ### Bug Fixes and Minor Changes
 
+  * `XMonad.Hooks.ManageDebug`
+
+    - `debugManageHookOn` now sends the debug output to `$XMONAD_XMESSAGE`
+      (default `xmessage`).
+
+    - `manageDebug'` has been added to stream debug output to a specified
+      `Handle`. It takes a flag passed to `manageDebugLogHook` telling it
+      whether to close the `Handle` afterward or not. (It's done this way
+      so that the visible API doesn't change beyond addition of this function.)
+
   * `XMonad.Actions.Repeatable`
 
     - Generalised the `repeatable` family of functions with new `concludable`

--- a/XMonad/Hooks/ManageDebug.hs
+++ b/XMonad/Hooks/ManageDebug.hs
@@ -22,6 +22,7 @@
 module XMonad.Hooks.ManageDebug (debugManageHook
                                 ,debugManageHookOn
                                 ,manageDebug
+                                ,manageDebug'
                                 ,maybeManageDebug
                                 ,manageDebugLogHook
                                 ,debugNextManagedWindow
@@ -31,11 +32,15 @@ import           XMonad
 import           XMonad.Hooks.DebugStack
 import           XMonad.Util.DebugWindow
 import           XMonad.Util.EZConfig
-import qualified XMonad.Util.ExtensibleState                                                 as XS
+import qualified XMonad.Util.ExtensibleState as XS
+
+import           Control.Monad       (when)
+import           System.IO
+import           System.Process
 
 -- state for manageHook debugging to trigger logHook debugging
-data MSDFinal = DoLogHook | SkipLogHook deriving Show
-data MSDTrigger = MSDActivated | MSDInactive deriving Show
+data MSDFinal = DoLogHook Handle Bool | SkipLogHook deriving Show
+data MSDTrigger = MSDActivated Handle Bool | MSDInactive deriving Show
 data ManageStackDebug = MSD MSDFinal MSDTrigger deriving Show
 instance ExtensionClass ManageStackDebug where
   initialValue = MSD SkipLogHook MSDInactive
@@ -62,18 +67,34 @@ debugManageHookOn key cf = cf {logHook    = manageDebugLogHook <> logHook    cf
 --   final 'StackSet' state.
 --
 --   Note that the initial state shows only the current workspace; the final
---   one shows all workspaces, since your 'manageHook' might use e.g. 'doShift',
+--   one shows all workspaces, since your 'manageHook' might use e.g. 'doShift'.
+--
+--   This logs to 'stderr' because there's no way to pass it a message handle,
+--   and to maintain backward compatibility. See @manageDebug'@ for an
+--   alternative that accepts a 'Handle'.
 manageDebug :: ManageHook
-manageDebug = do
+manageDebug = manageDebug' stderr False
+
+-- | @manageDebug@ to a 'Handle'. The flag specifies whether the 'Handle' should
+--   be closed after logging. @debugNextManagedWindow@ uses this to log to
+--   'xmessage', but it can be used to log to any chosen process or file.
+--
+--   Logging is incremental, so if your 'Handle' is to something that can show
+--   output before the 'logHook' prints the final 'StackSet' and optionally
+--   closes it, you can see it before it completes.
+--
+--   You should be careful to pass 'False' if you are logging to 'stdout' or
+--   'stderr', and to pass 'True' if you are logging to a process. Also remember
+--   that 'xmonad' subprocesses are auto-reaped, so don't try to wait for one.
+manageDebug' :: Handle -> Bool -> ManageHook
+manageDebug' h cp = do
   w <- ask
   liftX $ do
-    trace "== manageHook; current stack =="
-    debugStackString >>= trace
+    io $ hPutStrLn h "\n== manageHook; current stack =="
+    debugStackString >>= io . hPutStrLn h
     ws <- debugWindow w
-    trace $ "new window:\n  " ++ ws
-    -- technically we don't care about go here, since only maybeManageDebug
-    -- uses it
-    XS.modify $ \(MSD _ go') -> MSD DoLogHook go'
+    io $ hPutStrLn h $ "\nnew window:\n  " ++ ws
+    XS.modify $ \(MSD _ go) -> MSD (DoLogHook h cp) go
   idHook
 
 -- | @manageDebug@ only if the user requested it with @debugNextManagedWindow@.
@@ -81,27 +102,42 @@ maybeManageDebug :: ManageHook
 maybeManageDebug = do
   go <- liftX $ do
     MSD _ go' <- XS.get
-    -- leave it active, as we may manage multiple windows before the logHook
-    -- so we now deactivate it in the logHook
+    -- leave it active, as we may manage multiple windows before the 'logHook'
+    -- so we now deactivate it there
     return go'
   case go of
-    MSDActivated -> manageDebug
-    _            -> idHook
+    MSDActivated h cp -> manageDebug' h cp
+    _                 -> idHook
 
--- | If @manageDebug@ has set the debug-stack flag, show the stack.
+-- | If @manageDebug'@ has set the debug-stack flag, show the stack.
 manageDebugLogHook :: X ()
 manageDebugLogHook = do
                        MSD log' _ <- XS.get
                        case log' of
-                         DoLogHook -> do
-                                  trace "== manageHook; final stack =="
-                                  debugStackFullString >>= trace
-                                  -- see comment in maybeManageDebug
-                                  XS.put $ MSD SkipLogHook MSDInactive
-                         _         -> idHook
+                         DoLogHook h cp -> do
+                                            io $ hPutStrLn h "\n== manageHook; final stack =="
+                                            debugStackFullString >>= io . hPutStrLn h
+                                            when cp $ io $ hClose h
+                                            -- see comment in maybeManageDebug
+                                            XS.put $ MSD SkipLogHook MSDInactive
+                         _              -> idHook
 
 -- | Request that the next window to be managed be @manageDebug@-ed. This can
 --   be used anywhere an X action can, such as key bindings, mouse bindings
---   (presumably with 'const'), 'startupHook', etc.
+--   (presumably with 'const'), 'startupHook', etc. The output is sent to
+--   '$XMONAD_XMESSAGE' or 'xmessage'.
 debugNextManagedWindow :: X ()
-debugNextManagedWindow = XS.modify $ \(MSD log' _) -> MSD log' MSDActivated
+debugNextManagedWindow = do
+  let cpd = (shell "${XMONAD_XMESSAGE:-xmessage} \
+                      \-file - \
+                      \-default okay \
+                      \-xrm '*international:true' \
+                      \-xrm '*fontSet:-*-fixed-medium-r-normal-*-18-*-*-*-*-*-*-*,\
+                                     \-*-fixed-*-*-*-*-18-*-*-*-*-*-*-*,\
+                                     \-*-*-*-*-*-*-18-*-*-*-*-*-*-*'"){std_in = CreatePipe}
+  hs <- catchX (fmap Just $ io $ createProcess cpd) (return Nothing)
+  case hs of
+    Just (Just h, _, _, _) -> do
+                                io $ hSetBuffering h LineBuffering
+                                XS.modify $ \(MSD log' _) -> MSD log' (MSDActivated h True)
+    _                      -> return ()


### PR DESCRIPTION
### Description

`manageDebug'` can log to a `Handle` now, and `debugManageHookOn` (the usual entry point for users) uses this to log to `xmessage` (or `$XMONAD_XMESSAGE`).

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: tested manually

  - [x] I updated the `CHANGES.md` file
