### PR TITLE
Revert "build(deps): bump haskell-actions/setup from 2 to 2.11.0"

### DIFF
--- a/.github/workflows/packdeps.yml
+++ b/.github/workflows/packdeps.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v7
       - name: Setup Haskell
-        uses: haskell-actions/setup@v2.11.0
+        uses: haskell-actions/setup@v2
         with:
           # packdeps doesn't build with newer as of 2021-10
           ghc-version: '8.8'


### PR DESCRIPTION
This appears to be a Dependabot bug selecting bad versions.

This reverts commit cbd0cffe2be28260f24d0ae2b1d5f7449c142ea6.

### Description

Include a description for your changes, including the motivation
behind them.

### Checklist

  - [x] I've read [CONTRIBUTING.md](https://github.com/xmonad/xmonad/blob/master/CONTRIBUTING.md)

  - [x] I've considered how to best test these changes (property, unit,
        manually, ...) and concluded: not needed

  - [ ] I updated the `CHANGES.md` file
